### PR TITLE
test: sweep the @property descriptors too

### DIFF
--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2775,6 +2775,7 @@ let read_counter_style_descriptor (r : Cursor.t) : counter_style_descriptor =
   let name = Cursor.ident ~keep_case:false r in
   let descriptor =
     match name with
+    (* COUNTER_STYLE_DESCRIPTOR_START - Used by test/spec/browser *)
     | "system" -> read_counter_style_system_descriptor r
     | "symbols" -> read_counter_symbols_descriptor r
     | "suffix" -> read_counter_symbol_descriptor (fun s -> Suffix s) r
@@ -2786,6 +2787,7 @@ let read_counter_style_descriptor (r : Cursor.t) : counter_style_descriptor =
     | "additive-symbols" ->
         read_counter_string_descriptor (fun s -> Additive_symbols s) r
     | "speak-as" -> read_counter_string_descriptor (fun s -> Speak_as s) r
+    (* COUNTER_STYLE_DESCRIPTOR_END - Used by test/spec/browser *)
     | _ -> Cursor.err_invalid r ("unknown counter-style descriptor: " ^ name)
   in
   Cursor.ws r;
@@ -3703,6 +3705,7 @@ let read_property_descriptor (r : Cursor.t) state =
   Cursor.ws r;
   let state =
     match key with
+    (* PROPERTY_DESCRIPTOR_START - Used by test/spec/browser *)
     | "syntax" -> { state with syntax = Some (Variables.read_syntax r) }
     | "inherits" -> { state with inherits = Some (Cursor.bool r) }
     | "initial-value" ->
@@ -3710,6 +3713,7 @@ let read_property_descriptor (r : Cursor.t) state =
           state with
           initial_value = Some (Cursor.consume_until_semicolon ~trim:true r);
         }
+    (* PROPERTY_DESCRIPTOR_END - Used by test/spec/browser *)
     | _ -> Cursor.err_invalid r "unknown property descriptor"
   in
   Cursor.ws r;

--- a/test/spec/browser/descriptor_set.ml
+++ b/test/spec/browser/descriptor_set.ml
@@ -61,7 +61,92 @@ let values_for = Cascade_spec_inventory.Value_gen.values_for
 
 (* ===== The population ===== *)
 
-let modelled = List.sort_uniq String.compare Font_face_descriptors.all
+(* One at-rule the harness sweeps: the descriptors cascade models for it, read
+   out of the library's own dispatch, and how a rule carrying one is written.
+   @page is absent because its body is ordinary declarations, so the accept-set
+   differential already answers for all but its three page-only descriptors. *)
+type at_rule = {
+  name : string;
+  modelled : string list;
+  sheet : descriptor:string -> value:string -> string;
+}
+
+(* CSS Fonts 4 sec. 4.2 and 4.3 make font-family and src required: a @font-face
+   missing either is invalid as a whole, so every sheet carries both and the
+   descriptor under test takes over its own slot. *)
+let font_face_sheet ~descriptor ~value =
+  let family, src, extra =
+    match descriptor with
+    | "font-family" -> (value, "url(brand.woff2)", None)
+    | "src" -> ("Brand", value, None)
+    | _ -> ("Brand", "url(brand.woff2)", Some (descriptor, value))
+  in
+  String.concat ""
+    ([ "@font-face{font-family:"; family; ";src:"; src ]
+    @ (match extra with None -> [] | Some (name, v) -> [ ";"; name; ":"; v ])
+    @ [ "}" ])
+
+(* CSS Counter Styles 3 sec. 2 makes system and symbols the pair a style needs
+   to resolve, and sec. 3.1's default system is symbolic. *)
+let _counter_style_sheet ~descriptor ~value =
+  let base =
+    match descriptor with
+    | "system" | "symbols" -> ""
+    | _ -> "system:cyclic;symbols:\"a\";"
+  in
+  let rest =
+    match descriptor with
+    | "system" -> String.concat "" [ "system:"; value; ";symbols:\"a\"" ]
+    | "symbols" -> String.concat "" [ "system:cyclic;symbols:"; value ]
+    | _ -> String.concat "" [ descriptor; ":"; value ]
+  in
+  String.concat "" [ "@counter-style cascade-probe{"; base; rest; "}" ]
+
+(* CSS Properties and Values API 1 sec. 2 makes syntax and inherits required,
+   and an initial-value required for every syntax but the universal one, which
+   has to PARSE as that syntax: a rule pairing [<length>] with [red] is invalid
+   for the pairing rather than for either descriptor. The universal syntax takes
+   anything, so it is what a rule testing something else carries. *)
+let initial_value_for = function
+  | "\"<color>\"" -> Some "red"
+  | "\"<length>\"" -> Some "0px"
+  | "\"<length>#\"" | "\"<length># \"" -> Some "0px"
+  | "\"*\"" -> None
+  | _ -> None
+
+let property_sheet ~descriptor ~value =
+  let syntax, inherits, initial =
+    match descriptor with
+    | "syntax" -> (value, "true", initial_value_for value)
+    | "inherits" -> ("\"*\"", value, None)
+    | _ -> ("\"*\"", "true", Some value)
+  in
+  String.concat ""
+    ([ "@property --cascade-probe{syntax:"; syntax; ";inherits:"; inherits ]
+    @ (match initial with None -> [] | Some v -> [ ";initial-value:"; v ])
+    @ [ "}" ])
+
+(* @counter-style is not swept yet, and the reason is a defect rather than an
+   omission: six of its descriptors are read as an opaque string, so [range:
+   bogus] and [pad: "0"] reach the output. Enabling it here reports 218 values
+   on the first run, which is a reader to fix rather than a harness to land red,
+   and the rows in Descriptor_grammar are written and waiting. *)
+let at_rules =
+  [
+    {
+      name = "font-face";
+      modelled = List.sort_uniq String.compare Font_face_descriptors.all;
+      sheet = font_face_sheet;
+    };
+    {
+      name = "property";
+      modelled = List.sort_uniq String.compare Property_descriptors.all;
+      sheet = property_sheet;
+    };
+  ]
+
+let modelled =
+  List.concat_map (fun r -> List.map (fun d -> (r.name, d)) r.modelled) at_rules
 
 (* A rename in the library, or a generator that stopped generating, would
    otherwise turn this run into a green one that asks nothing. *)
@@ -69,28 +154,11 @@ let minimum_descriptors = 10
 let minimum_values = 200
 let minimum_arbitrated = 100
 
-(* CSS Fonts 4 sec. 4.2 and 4.3 make font-family and src required: a @font-face
-   missing either is invalid as a whole, so every sheet carries both and the
-   descriptor under test takes over its own slot. *)
-let base_family = "Brand"
-let base_src = "url(brand.woff2)"
-
-let sheet ~descriptor ~value =
-  let family, src, extra =
-    match descriptor with
-    | "font-family" -> (value, base_src, None)
-    | "src" -> (base_family, value, None)
-    | _ -> (base_family, base_src, Some (descriptor, value))
-  in
-  String.concat ""
-    ([ "@font-face{font-family:"; family; ";src:"; src ]
-    @ (match extra with None -> [] | Some (name, v) -> [ ";"; name; ":"; v ])
-    @ [ "}" ])
-
 type kind = Positive | Negative | Generated
 
 type job = {
   id : string;
+  at_rule : string;
   descriptor : string;
   value : string;
   kind : kind;
@@ -116,37 +184,48 @@ let jobs ~seed ~only =
     incr n;
     string_of_int !n
   in
-  let job descriptor kind value =
-    { id = fresh (); descriptor; value; kind; sheet = sheet ~descriptor ~value }
-  in
   List.concat_map
-    (fun descriptor ->
-      if (not (String.equal only "")) && not (String.equal only descriptor) then
-        []
-      else
-        let manifest =
-          match Grammar.row_for descriptor with
-          | None -> []
-          | Some row ->
-              List.map (job descriptor Positive) row.positives
-              @ List.map (job descriptor Negative) row.negatives
-        in
-        (* The generator draws from the manifest too, so a value the row already
-           decides would otherwise arrive twice and be judged by both rules at
-           once. *)
-        let decided value =
-          match Grammar.row_for descriptor with
-          | None -> false
-          | Some row ->
-              List.exists (String.equal value) row.positives
-              || List.exists (String.equal value) row.negatives
-        in
-        manifest
-        @ List.map (job descriptor Generated)
-            (List.filter
-               (fun v -> drawable v && not (decided v))
-               (values_for ~seed descriptor)))
-    modelled
+    (fun rule ->
+      let job descriptor kind value =
+        {
+          id = fresh ();
+          at_rule = rule.name;
+          descriptor;
+          value;
+          kind;
+          sheet = rule.sheet ~descriptor ~value;
+        }
+      in
+      List.concat_map
+        (fun descriptor ->
+          if (not (String.equal only "")) && not (String.equal only descriptor)
+          then []
+          else
+            let row = Grammar.row_for ~at_rule:rule.name descriptor in
+            let manifest =
+              match row with
+              | None -> []
+              | Some (row : Grammar.row) ->
+                  List.map (job descriptor Positive) row.positives
+                  @ List.map (job descriptor Negative) row.negatives
+            in
+            (* The generator draws from the manifest too, so a value the row
+               already decides would otherwise arrive twice and be judged by
+               both rules at once. *)
+            let decided value =
+              match row with
+              | None -> false
+              | Some (row : Grammar.row) ->
+                  List.exists (String.equal value) row.positives
+                  || List.exists (String.equal value) row.negatives
+            in
+            manifest
+            @ List.map (job descriptor Generated)
+                (List.filter
+                   (fun v -> drawable v && not (decided v))
+                   (values_for ~seed descriptor)))
+        rule.modelled)
+    at_rules
 
 (* ===== The reader ===== *)
 
@@ -271,7 +350,8 @@ let fail line =
   incr failures;
   Fmt.pr "FAIL %s@." line
 
-let describe job = String.concat "" [ job.descriptor; ": "; job.value ]
+let describe job =
+  String.concat "" [ "@"; job.at_rule; " "; job.descriptor; ": "; job.value ]
 
 (* ===== Skipping ===== *)
 
@@ -328,32 +408,32 @@ let arg name default =
   in
   loop (Array.to_list Sys.argv)
 
-let support_key descriptor =
-  String.concat "" [ "css.at-rules.font-face."; descriptor ]
+let support_key ~at_rule descriptor =
+  String.concat "" [ "css.at-rules."; at_rule; "."; descriptor ]
 
 (* A descriptor this browser takes no positive of cannot arbitrate a single
    value of it. Whether that is the browser being behind is a fact about
    browsers, so it is looked up rather than asserted here. *)
-let report_unshipped ~version descriptor =
-  let key = support_key descriptor in
+let report_unshipped ~version ~at_rule descriptor =
+  let key = support_key ~at_rule descriptor in
+  let named = String.concat "" [ "@"; at_rule; " "; descriptor ] in
   match Support.engine_implements Support.Chrome version key with
   | Some true ->
       fail
         (String.concat ""
            [
-             descriptor;
+             named;
              ": the browser took none of the manifest's positives, and ";
              key;
              " says this build shipped it";
            ])
   | Some false ->
-      Fmt.pr "  behind: %s (%s says this build has not shipped it)@." descriptor
-        key
+      Fmt.pr "  behind: %s (%s says this build has not shipped it)@." named key
   | None ->
       fail
         (String.concat ""
            [
-             descriptor;
+             named;
              ": the browser took none of the manifest's positives and ";
              key;
              " is not in the support dataset, so nothing says whether the \
@@ -438,7 +518,9 @@ let () =
   (* A descriptor no current specification defines has no grammar to judge a
      generated value against, so the browser's answer about one says nothing: it
      is the leftovers of a removed section either way. *)
-  let ungoverned descriptor = Option.is_none (Grammar.row_for descriptor) in
+  let ungoverned job =
+    Option.is_none (Grammar.row_for ~at_rule:job.at_rule job.descriptor)
+  in
   let pending = ref [] in
   List.iter
     (fun job ->
@@ -461,7 +543,8 @@ let () =
                  ]))
           else begin
             (match job.kind with
-            | Positive when parsed -> bump positives_taken job.descriptor
+            | Positive when parsed ->
+                bump positives_taken (job.at_rule, job.descriptor)
             | Positive | Negative | Generated -> ());
             let reads = cascade_accepts job in
             match (job.kind, reads, parsed) with
@@ -500,16 +583,20 @@ let () =
             | Generated, true, false
               when Option.is_some
                      (Chrome_gaps.explains_rejection
-                        ~prefix:"css.at-rules.font-face" ~chrome:version
-                        ~property:job.descriptor ~value:job.value ()) ->
+                        ~prefix:
+                          (String.concat "" [ "css.at-rules."; job.at_rule ])
+                        ~chrome:version ~property:job.descriptor
+                        ~value:job.value ()) ->
                 incr behind
             | Generated, false, true
               when Option.is_some
                      (Chrome_gaps.explains_acceptance
-                        ~prefix:"css.at-rules.font-face" ~chrome:version
-                        ~property:job.descriptor ~value:job.value ()) ->
+                        ~prefix:
+                          (String.concat "" [ "css.at-rules."; job.at_rule ])
+                        ~chrome:version ~property:job.descriptor
+                        ~value:job.value ()) ->
                 incr lenient
-            | Generated, _, _ when ungoverned job.descriptor -> ()
+            | Generated, _, _ when ungoverned job -> ()
             | Generated, _, _ -> pending := (job, reads) :: !pending
           end)
     jobs;
@@ -517,44 +604,44 @@ let () =
      under it, so it is reported once and its values are not reported again. *)
   let unshipped = Hashtbl.create 8 in
   List.iter
-    (fun descriptor ->
-      match Grammar.row_for descriptor with
+    (fun (at_rule, descriptor) ->
+      let key = support_key ~at_rule descriptor in
+      let named = String.concat "" [ "@"; at_rule; " "; descriptor ] in
+      match Grammar.row_for ~at_rule descriptor with
       | None -> (
           (* A descriptor with no current grammar is not an oversight when the
              support dataset carries it: web-features records what browsers
              ship, and a removed-but-shipped descriptor is exactly that. One
              that neither a section nor the dataset knows is cascade's
              invention. *)
-          match
-            Support.implemented Support.evergreen (support_key descriptor)
-          with
+          match Support.implemented Support.evergreen key with
           | Some _ ->
               Fmt.pr
                 "  no row: %s (no current section grants it, and %s records it \
                  as shipped)@."
-                descriptor (support_key descriptor)
+                named key
           | None ->
               fail
                 (String.concat ""
                    [
-                     descriptor;
+                     named;
                      ": cascade models this descriptor, no Descriptor_grammar \
                       row grants it, and ";
-                     support_key descriptor;
+                     key;
                      " is not in the support dataset either";
                    ]))
       | Some _ ->
           if
             Option.value ~default:0
-              (Hashtbl.find_opt positives_taken descriptor)
+              (Hashtbl.find_opt positives_taken (at_rule, descriptor))
             = 0
           then (
-            Hashtbl.replace unshipped descriptor ();
-            report_unshipped ~version descriptor))
-    (List.filter selected modelled);
+            Hashtbl.replace unshipped (at_rule, descriptor) ();
+            report_unshipped ~version ~at_rule descriptor))
+    (List.filter (fun (_, d) -> selected d) modelled);
   List.iter
     (fun (job, reads) ->
-      if not (Hashtbl.mem unshipped job.descriptor) then
+      if not (Hashtbl.mem unshipped (job.at_rule, job.descriptor)) then
         fail
           (String.concat ""
              [
@@ -569,10 +656,11 @@ let () =
     (List.rev !pending);
   let major, minor = version in
   Fmt.pr
-    "descriptor_set: %d value(s) over %d descriptor(s), Chrome %d.%d, %.1fs@."
+    "descriptor_set: %d value(s) over %d descriptor(s) of %d at-rule(s), \
+     Chrome %d.%d, %.1fs@."
     (List.length jobs)
-    (List.length (List.filter selected modelled))
-    major minor elapsed;
+    (List.length (List.filter (fun (_, d) -> selected d) modelled))
+    (List.length at_rules) major minor elapsed;
   Fmt.pr
     "  arbitrated: %d, browser behind: %d, browser lenient: %d, splits: %d, \
      failures: %d@."

--- a/test/spec/browser/dune
+++ b/test/spec/browser/dune
@@ -67,6 +67,41 @@
     FONT_FACE_DESCRIPTOR_END
     10))))
 
+; The same dispatch-table reading for the other two at-rules whose descriptor
+; set is fixed. @page is not among them: its body is ordinary declarations, so
+; the accept-set differential already answers for all but its three page-only
+; descriptors.
+
+(rule
+ (target counter_style_descriptors.ml)
+ (deps
+  (:stylesheet ../../../lib/stylesheet.ml)
+  gen_reader_properties.exe)
+ (action
+  (with-stdout-to
+   counter_style_descriptors.ml
+   (run
+    ./gen_reader_properties.exe
+    %{stylesheet}
+    COUNTER_STYLE_DESCRIPTOR_START
+    COUNTER_STYLE_DESCRIPTOR_END
+    9))))
+
+(rule
+ (target property_descriptors.ml)
+ (deps
+  (:stylesheet ../../../lib/stylesheet.ml)
+  gen_reader_properties.exe)
+ (action
+  (with-stdout-to
+   property_descriptors.ml
+   (run
+    ./gen_reader_properties.exe
+    %{stylesheet}
+    PROPERTY_DESCRIPTOR_START
+    PROPERTY_DESCRIPTOR_END
+    3))))
+
 (executables
  (names property_vectors accept_set descriptor_set)
  (modules
@@ -76,6 +111,8 @@
   chrome_gaps
   reader_properties
   font_face_descriptors
+  counter_style_descriptors
+  property_descriptors
   browser
   json)
  (libraries cascade cascade_spec_inventory fmt unix))

--- a/test/spec/inventory/descriptor_grammar.ml
+++ b/test/spec/inventory/descriptor_grammar.ml
@@ -1,12 +1,13 @@
 type row = {
+  at_rule : string;
   descriptor : string;
   positives : string list;
   negatives : string list;
   why : string;
 }
 
-let row descriptor why positives negatives =
-  { descriptor; positives; negatives; why }
+let row at_rule descriptor why positives negatives =
+  { at_rule; descriptor; positives; negatives; why }
 
 (* Sections are CSS Fonts 4 (ED) unless the row says otherwise. Values a browser
    and the specification disagree about are deliberately absent: this is the
@@ -14,7 +15,8 @@ let row descriptor why positives negatives =
    dataset rather than a vector written to match it. *)
 let rows =
   [
-    row "font-family" "sec. 4.2 <font-family-name> = <string> | <custom-ident>+"
+    row "font-face" "font-family"
+      "sec. 4.2 <font-family-name> = <string> | <custom-ident>+"
       [ "Brand"; "\"Brand Sans\""; "Brand Sans"; "'Brand'"; "B2" ]
       [
         "serif";
@@ -26,7 +28,7 @@ let rows =
         "Red/Black";
         "\"Brand";
       ];
-    row "src" "sec. 4.3.1 <font-src-list>"
+    row "font-face" "src" "sec. 4.3.1 <font-src-list>"
       [
         "url(brand.woff2)";
         "url(brand.woff2) format(\"woff2\")";
@@ -37,7 +39,7 @@ let rows =
         "url(brand.woff2) format(\"woff2\") tech(variations)";
       ]
       [ "nonsense"; "format(\"woff2\")"; "url(brand.woff2) format()" ];
-    row "font-style"
+    row "font-face" "font-style"
       "sec. 4.4 auto | normal | italic | left | right | oblique [<angle \
        [-90deg,90deg]>{1,2}]?"
       [
@@ -49,22 +51,24 @@ let rows =
         "oblique 0deg 10deg";
       ]
       [ "normal italic"; "italic oblique"; "bold"; "oblique 10px" ];
-    row "font-weight"
+    row "font-face" "font-weight"
       "sec. 4.4 auto | <font-weight-absolute>{1,2}, over normal | bold | \
        <number [1,1000]>"
       [ "auto"; "normal"; "bold"; "400"; "1"; "1000"; "100 900"; "bold 400" ]
       [ "lighter"; "bolder"; "400 lighter"; "normal bold italic" ];
-    row "font-stretch"
+    row "font-face" "font-stretch"
       "sec. 4.4 auto | <'font-width'>{1,2}, under the sec. 2.3.1 legacy name"
       [ "auto"; "normal"; "condensed"; "75%"; "75% 125%"; "normal condensed" ]
       [ "condensed 75% 100%"; "75px"; "wider" ];
-    row "font-display" "sec. 4.7 auto | block | swap | fallback | optional"
+    row "font-face" "font-display"
+      "sec. 4.7 auto | block | swap | fallback | optional"
       [ "auto"; "block"; "swap"; "fallback"; "optional" ]
       [ "maybe"; "swap block"; "0" ];
-    row "unicode-range" "sec. 4.5 <unicode-range-token>#"
+    row "font-face" "unicode-range" "sec. 4.5 <unicode-range-token>#"
       [ "U+0-7F"; "U+25-FF"; "U+1F600-1F64F"; "U+???"; "U+0-7F, U+100" ]
       [ "red"; "0-7F"; "U+0-7F U+100" ];
-    row "font-feature-settings" "sec. 4.6 normal | <feature-tag-value>#"
+    row "font-face" "font-feature-settings"
+      "sec. 4.6 normal | <feature-tag-value>#"
       [
         "normal";
         "\"kern\"";
@@ -74,7 +78,8 @@ let rows =
         "\"kern\" 1, \"liga\" 0";
       ]
       [ "kern"; "\"kern\" bogus"; "\"kern\" 1 2" ];
-    row "font-variation-settings" "sec. 4.6 normal | [<string> <number>]#"
+    row "font-face" "font-variation-settings"
+      "sec. 4.6 normal | [<string> <number>]#"
       [ "normal"; "\"wght\" 650"; "\"wght\" 650, \"wdth\" 100" ]
       [
         "wght 650";
@@ -86,18 +91,73 @@ let rows =
         "\"text\"";
         "\"liga\" off";
       ];
-    row "size-adjust" "CSS Fonts 5 (ED) sec. 4.10 <percentage [0,inf]>"
+    row "font-face" "size-adjust"
+      "CSS Fonts 5 (ED) sec. 4.10 <percentage [0,inf]>"
       [ "0%"; "92%"; "100%"; "300%" ]
       [ "-1%"; "100"; "normal" ];
-    row "ascent-override" "sec. 4.9 normal | <percentage [0,inf]>"
+    row "font-face" "ascent-override" "sec. 4.9 normal | <percentage [0,inf]>"
       [ "normal"; "0%"; "90%" ] [ "-1%"; "90"; "auto" ];
-    row "descent-override" "sec. 4.9 normal | <percentage [0,inf]>"
+    row "font-face" "descent-override" "sec. 4.9 normal | <percentage [0,inf]>"
       [ "normal"; "0%"; "25%" ] [ "-1%"; "25"; "auto" ];
-    row "line-gap-override" "sec. 4.9 normal | <percentage [0,inf]>"
+    row "font-face" "line-gap-override" "sec. 4.9 normal | <percentage [0,inf]>"
       [ "normal"; "0%"; "10%" ] [ "-1%"; "10"; "auto" ];
+    (* CSS Counter Styles 3 (ED). <symbol> = <string> | <image> | <custom-ident>
+       (sec. 3.2). *)
+    row "counter-style" "system"
+      "sec. 3.1 cyclic | numeric | alphabetic | symbolic | additive | [fixed \
+       <integer>?] | [extends <counter-style-name>]"
+      [
+        "cyclic";
+        "numeric";
+        "alphabetic";
+        "symbolic";
+        "additive";
+        "fixed";
+        "fixed 3";
+        "extends decimal";
+      ]
+      [ "bogus"; "fixed extends"; "extends" ];
+    row "counter-style" "symbols" "sec. 3.2 <symbol>+"
+      [ "\"a\""; "\"a\" \"b\""; "a"; "url(a.png)" ]
+      [ "1"; "\"a\", \"b\"" ];
+    row "counter-style" "additive-symbols"
+      "sec. 3.3 [<integer [0,inf]> && <symbol>]#"
+      [ "3 \"a\""; "\"a\" 3"; "3 \"a\", 1 \"b\"" ]
+      [ "-1 \"a\""; "\"a\""; "3" ];
+    row "counter-style" "negative" "sec. 3.4 <symbol> <symbol>?"
+      [ "\"-\""; "\"(\" \")\""; "a" ]
+      [ "1"; "\"a\" \"b\" \"c\"" ];
+    row "counter-style" "prefix" "sec. 3.4 <symbol>" [ "\"(\""; "a" ]
+      [ "1"; "\"a\" \"b\"" ];
+    row "counter-style" "suffix" "sec. 3.4 <symbol>" [ "\".\""; "a" ]
+      [ "1"; "\"a\" \"b\"" ];
+    row "counter-style" "range" "sec. 3.5 [[<integer> | infinite]{2}]# | auto"
+      [ "auto"; "1 5"; "infinite 5"; "1 infinite"; "1 5, 8 10" ]
+      [ "1"; "5 1 3"; "bogus" ];
+    row "counter-style" "pad" "sec. 3.6 <integer [0,inf]> && <symbol>"
+      [ "3 \"0\""; "\"0\" 3"; "0 \"0\"" ]
+      [ "-1 \"0\""; "3"; "\"0\"" ];
+    row "counter-style" "fallback" "sec. 3.7 <counter-style-name>"
+      [ "decimal"; "my-style" ] [ "\"decimal\""; "1" ];
+    row "counter-style" "speak-as"
+      "sec. 3.8 auto | bullets | numbers | words | spell-out | \
+       <counter-style-name>"
+      [ "auto"; "bullets"; "numbers"; "words"; "spell-out"; "decimal" ]
+      [ "bogus"; "1" ];
+    (* CSS Properties and Values API 1 (ED). *)
+    row "property" "syntax" "sec. 3.1 <string>"
+      [ "\"<color>\""; "\"*\""; "\"<length>\""; "\"<length># \"" ]
+      [ "<color>"; "1" ];
+    row "property" "inherits" "sec. 3.2 true | false" [ "true"; "false" ]
+      [ "yes"; "1" ];
+    row "property" "initial-value" "sec. 3.3 <declaration-value>?"
+      [ "red"; "0"; "10px" ] [];
   ]
 
 let descriptors = List.map (fun r -> r.descriptor) rows
 
-let row_for descriptor =
-  List.find_opt (fun r -> String.equal r.descriptor descriptor) rows
+let row_for ~at_rule descriptor =
+  List.find_opt
+    (fun r ->
+      String.equal r.at_rule at_rule && String.equal r.descriptor descriptor)
+    rows

--- a/test/spec/inventory/descriptor_grammar.mli
+++ b/test/spec/inventory/descriptor_grammar.mli
@@ -1,4 +1,4 @@
-(** Spec-derived vectors for the [@font-face] descriptors.
+(** Spec-derived vectors for the at-rule descriptors.
 
     A descriptor is not a property, so {!Property_grammar} cannot carry these:
     [src] and [unicode-range] have no property of the same name, and the ones
@@ -11,6 +11,7 @@
     is no [font-style] alone and a good one after [oblique]. *)
 
 type row = {
+  at_rule : string;  (** the at-rule the descriptor belongs to, without [@] *)
   descriptor : string;  (** the descriptor name, as written in the rule *)
   positives : string list;
   negatives : string list;
@@ -30,5 +31,7 @@ val rows : row list
 val descriptors : string list
 (** [descriptors] is the descriptor names {!rows} covers. *)
 
-val row_for : string -> row option
-(** [row_for descriptor] is the row named [descriptor]. *)
+val row_for : at_rule:string -> string -> row option
+(** [row_for ~at_rule descriptor] is the row for that descriptor of that
+    at-rule. The name alone is not enough: [font-family] is a descriptor of
+    [\@font-face] and of [\@font-palette-values], with different grammars. *)


### PR DESCRIPTION
`descriptor_set` took one at-rule; it now takes a list, reading each one's descriptor set out of the library's own dispatch table the way the property population is read. 997 values over 17 descriptors of 2 at-rules, all arbitrated, no disagreement between the two parser entry points.

`@page` is not among them: its body is ordinary declarations, so the accept-set differential already answers for all but its three page-only descriptors. `@counter-style` is written, with rows citing CSS Counter Styles 3 sec. 3.1 to 3.8, and held back behind a comment naming why: six of its descriptors are read as an opaque string, so `range: bogus` and `pad: \"0\"` reach the output, and enabling the sweep reports 218 values. That is a reader to fix, not a harness to land red.