### PR TITLE
counter-style: read six descriptors against their grammars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -875,6 +875,11 @@ to lose a whole rule over one bad piece. Both are gone.
   `[ left | center | right | <length-percentage> ] [ top | center | bottom |
   <length-percentage> ]` (#1122)
 
+- Six `@counter-style` descriptors are read against their grammars, so
+  `range: bogus`, `pad: 3`, `negative: 1` and `fallback: "decimal"` are dropped
+  where each was kept as an opaque string. A counter symbol may also be an
+  image now, per CSS Counter Styles 3 sec. 3.2 (#1130)
+
 - A CSS-wide keyword in an `@font-face` descriptor is dropped, so
   `font-weight: inherit` inside the rule no longer reaches output a browser
   discards. CSS Fonts 4 sec. 4.6 omits them from the descriptor grammars

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2730,10 +2730,19 @@ let read_counter_style_system_descriptor r =
       System system)
     r
 
+(* CSS Counter Styles 3 (ED) sec. 3.2: <symbol> = <string> | <image> |
+   <custom-ident>. The image arm is read for its grammar and kept as the text it
+   was written with, as the string and ident arms are. *)
 let read_counter_symbol r =
   match Cursor.string_opt r with
   | Some symbol -> symbol
-  | None -> Cursor.ident ~keep_case:true r
+  | None -> (
+      match Cursor.peek r with
+      | Some (Component.Func _)
+      | Some (Component.Preserved { kind = Token.Url _; _ }) ->
+          Pp.to_string ~minify:true Properties.pp_background_image
+            (Properties.read_background_image r)
+      | Some _ | None -> Cursor.ident ~keep_case:true r)
 
 let read_counter_symbols_descriptor r =
   read_descriptor_value Declaration.read_property_value
@@ -2757,13 +2766,83 @@ let read_counter_symbol_descriptor constructor r =
       constructor symbol)
     r
 
-let read_counter_string_descriptor constructor r =
+(* CSS Counter Styles 3 (ED) sec. 3.7: <counter-style-name> is a <custom-ident>,
+   which CSS Values 4 sec. 4.2 excludes the CSS-wide keywords and [default]
+   from, and sec. 3.7 excludes [none] as well. *)
+let read_counter_style_name c =
+  let name = Cursor.ident ~keep_case:true c in
+  let lower = String.lowercase_ascii name in
+  if
+    Properties.is_css_wide_keyword lower
+    || List.exists (String.equal lower) [ "default"; "none" ]
+  then Cursor.err_invalid c ("reserved counter style name: " ^ name)
+  else name
+
+(* Validates the value against the descriptor's grammar and keeps the text: the
+   AST carries the authored spelling, and what this adds is the refusal of a
+   value no section grants. Each reader names the section that decides it. *)
+let read_counter_validated_descriptor ~what ~check constructor r =
   read_descriptor_value
     (fun r ->
       let value = Declaration.read_property_value r in
       validate_nonempty_descriptor r "counter-style" value;
+      let c = Cursor.of_string value in
+      check c;
+      Cursor.ws c;
+      if not (Cursor.is_done c) then
+        Cursor.err_invalid r
+          (String.concat "" [ "trailing tokens in @counter-style "; what ]);
       value)
     constructor r
+
+(* sec. 3.5: [[<integer> | infinite]{2}]# | auto. *)
+let check_counter_range c =
+  let bound c =
+    match Cursor.peek_ident c with
+    | Some "infinite" -> ignore (Cursor.ident c)
+    | Some _ | None -> ignore (Cursor.int c)
+  in
+  let pair c =
+    bound c;
+    Cursor.ws c;
+    bound c
+  in
+  match Cursor.peek_ident c with
+  | Some "auto" -> ignore (Cursor.ident c)
+  | Some _ | None -> ignore (Cursor.list ~at_least:1 ~sep:Cursor.comma pair c)
+
+(* sec. 3.6: <integer [0,inf]> && <symbol>, so the two come in either order. *)
+let check_counter_pad c =
+  let non_negative c =
+    let n = Cursor.int c in
+    if n < 0 then Cursor.err_invalid c "@counter-style pad takes no negative"
+  in
+  match Cursor.option non_negative c with
+  | Some () ->
+      Cursor.ws c;
+      ignore (read_counter_symbol c)
+  | None ->
+      ignore (read_counter_symbol c);
+      Cursor.ws c;
+      non_negative c
+
+(* sec. 3.4: <symbol> <symbol>?. *)
+let check_counter_negative c =
+  ignore (read_counter_symbol c);
+  Cursor.ws c;
+  if not (Cursor.is_done c) then ignore (read_counter_symbol c)
+
+(* sec. 3.3: [<integer [0,inf]> && <symbol>]#. *)
+let check_counter_additive_symbols c =
+  ignore (Cursor.list ~at_least:1 ~sep:Cursor.comma check_counter_pad c)
+
+(* sec. 3.8: auto | bullets | numbers | words | spell-out |
+   <counter-style-name>. *)
+let check_counter_speak_as c =
+  match Cursor.peek_ident c with
+  | Some ("auto" | "bullets" | "numbers" | "words" | "spell-out") ->
+      ignore (Cursor.ident c)
+  | Some _ | None -> ignore (read_counter_style_name c)
 
 (* CSS Counter Styles 3 sec. 3: "unknown descriptors are invalid and ignored".
    One descriptor of the body, the caller looping over the rest, so a descriptor
@@ -2780,13 +2859,35 @@ let read_counter_style_descriptor (r : Cursor.t) : counter_style_descriptor =
     | "symbols" -> read_counter_symbols_descriptor r
     | "suffix" -> read_counter_symbol_descriptor (fun s -> Suffix s) r
     | "prefix" -> read_counter_symbol_descriptor (fun s -> Prefix s) r
-    | "fallback" -> read_counter_string_descriptor (fun s -> Fallback s) r
-    | "range" -> read_counter_string_descriptor (fun s -> Range s) r
-    | "pad" -> read_counter_string_descriptor (fun s -> Pad s) r
-    | "negative" -> read_counter_string_descriptor (fun s -> Negative s) r
+    | "fallback" ->
+        read_counter_validated_descriptor ~what:"fallback"
+          ~check:(fun c -> ignore (read_counter_style_name c))
+          (fun s -> Fallback s)
+          r
+    | "range" ->
+        read_counter_validated_descriptor ~what:"range"
+          ~check:check_counter_range
+          (fun s -> Range s)
+          r
+    | "pad" ->
+        read_counter_validated_descriptor ~what:"pad" ~check:check_counter_pad
+          (fun s -> Pad s)
+          r
+    | "negative" ->
+        read_counter_validated_descriptor ~what:"negative"
+          ~check:check_counter_negative
+          (fun s -> Negative s)
+          r
     | "additive-symbols" ->
-        read_counter_string_descriptor (fun s -> Additive_symbols s) r
-    | "speak-as" -> read_counter_string_descriptor (fun s -> Speak_as s) r
+        read_counter_validated_descriptor ~what:"additive-symbols"
+          ~check:check_counter_additive_symbols
+          (fun s -> Additive_symbols s)
+          r
+    | "speak-as" ->
+        read_counter_validated_descriptor ~what:"speak-as"
+          ~check:check_counter_speak_as
+          (fun s -> Speak_as s)
+          r
     (* COUNTER_STYLE_DESCRIPTOR_END - Used by test/spec/browser *)
     | _ -> Cursor.err_invalid r ("unknown counter-style descriptor: " ^ name)
   in

--- a/lib/support.ml
+++ b/lib/support.ml
@@ -576,6 +576,108 @@ let measured =
       measured = "Chrome 153";
     };
     {
+      key = "css.at-rules.counter-style.symbols.image";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Counter Styles 3 (ED) sec. 3.2 gives <symbol> the arms <string> | \
+         \\\n\
+        \         <image> | <custom-ident>, so a counter symbol may be an \
+         image. Chrome \\\n\
+        \         implements the string and ident arms and refuses every image";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.counter-style.negative.image";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Counter Styles 3 (ED) sec. 3.2 gives <symbol> the arms <string> | \
+         \\\n\
+        \         <image> | <custom-ident>, so a counter symbol may be an \
+         image. Chrome \\\n\
+        \         implements the string and ident arms and refuses every image";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.counter-style.prefix.image";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Counter Styles 3 (ED) sec. 3.2 gives <symbol> the arms <string> | \
+         \\\n\
+        \         <image> | <custom-ident>, so a counter symbol may be an \
+         image. Chrome \\\n\
+        \         implements the string and ident arms and refuses every image";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.counter-style.suffix.image";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Counter Styles 3 (ED) sec. 3.2 gives <symbol> the arms <string> | \
+         \\\n\
+        \         <image> | <custom-ident>, so a counter symbol may be an \
+         image. Chrome \\\n\
+        \         implements the string and ident arms and refuses every image";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.counter-style.additive-symbols.image";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Counter Styles 3 (ED) sec. 3.2 gives <symbol> the arms <string> | \
+         \\\n\
+        \         <image> | <custom-ident>, so a counter symbol may be an \
+         image. Chrome \\\n\
+        \         implements the string and ident arms and refuses every image";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.counter-style.pad.image";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Counter Styles 3 (ED) sec. 3.2 gives <symbol> the arms <string> | \
+         \\\n\
+        \         <image> | <custom-ident>, so a counter symbol may be an \
+         image. Chrome \\\n\
+        \         implements the string and ident arms and refuses every image";
+      measured = "Chrome 153";
+    };
+    {
       key = "css.properties.font-family.default";
       support =
         {

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -185,7 +185,11 @@ let keys_for ?(prefix = "css.properties") ~property ~value () =
     match call_name value with
     | None -> []
     | Some name ->
-        prop (String.concat "" [ underscored name; "_function" ])
+        (* An arm a grammar spells as a value TYPE is named after the type, not
+           the function that wrote it: [url(a.png)] and [linear-gradient(...)]
+           are both the <image> arm. *)
+        prop "image"
+        @ prop (String.concat "" [ underscored name; "_function" ])
         @ [
             String.concat "" [ "css.types."; name ];
             String.concat "" [ "css.types.image."; name ];

--- a/test/spec/browser/descriptor_set.ml
+++ b/test/spec/browser/descriptor_set.ml
@@ -88,7 +88,7 @@ let font_face_sheet ~descriptor ~value =
 
 (* CSS Counter Styles 3 sec. 2 makes system and symbols the pair a style needs
    to resolve, and sec. 3.1's default system is symbolic. *)
-let _counter_style_sheet ~descriptor ~value =
+let counter_style_sheet ~descriptor ~value =
   let base =
     match descriptor with
     | "system" | "symbols" -> ""
@@ -137,6 +137,11 @@ let at_rules =
       name = "font-face";
       modelled = List.sort_uniq String.compare Font_face_descriptors.all;
       sheet = font_face_sheet;
+    };
+    {
+      name = "counter-style";
+      modelled = List.sort_uniq String.compare Counter_style_descriptors.all;
+      sheet = counter_style_sheet;
     };
     {
       name = "property";

--- a/test/spec/inventory/descriptor_grammar.ml
+++ b/test/spec/inventory/descriptor_grammar.ml
@@ -143,7 +143,10 @@ let rows =
       "sec. 3.8 auto | bullets | numbers | words | spell-out | \
        <counter-style-name>"
       [ "auto"; "bullets"; "numbers"; "words"; "spell-out"; "decimal" ]
-      [ "bogus"; "1" ];
+      (* An undefined name is still a <counter-style-name>: sec. 3.7 makes it a
+         <custom-ident>, and whether a style by that name exists is resolved
+         when the counter is rendered rather than when the rule is read. *)
+      [ "1"; "\"decimal\""; "none" ];
     (* CSS Properties and Values API 1 (ED). *)
     row "property" "syntax" "sec. 3.1 <string>"
       [ "\"<color>\""; "\"*\""; "\"<length>\""; "\"<length># \"" ]


### PR DESCRIPTION
`range: bogus`, `pad: 3`, `negative: 1`, `fallback: \"decimal\"` and `additive-symbols: -1 \"a\"` were all kept: `fallback`, `range`, `pad`, `negative`, `additive-symbols` and `speak-as` were read as any non-empty string. Each now reads against the section that defines it (CSS Counter Styles 3 sec. 3.3 to 3.8), and a symbol may be an `<image>` as sec. 3.2 grants, which the reader took neither.

Found by turning `descriptor_set` on `@counter-style`: the sweep reported 218 values on the first run and reports none now. It is enabled here, so the harness covers all three at-rules whose descriptor set is fixed.