### PR TITLE
mutate: count the browser harnesses' own failures

### DIFF
--- a/scripts/mutate.ml
+++ b/scripts/mutate.ml
@@ -27,6 +27,11 @@
    failing at baseline is opaque, and a mutant that only changes what it prints
    scores SURVIVED. The baseline is listed on every run for that reason.
 
+   A rule that PRINTS is listed there too, which is not the same as failing: the
+   browser harnesses summarise every run, so dune names them whether they pass
+   or not. What makes their failures count is that [signature] reads the [FAIL
+   <what>] lines they write themselves.
+
    [--list] enumerates the sites and stops, [--sample N] with [--seed S] draws a
    campaign, and [--only ID] replays one site. scripts/dune spells the
    invocations out.
@@ -411,15 +416,26 @@ let test_argv ~work ~jobs =
 
 (* The failing rules and test cases, as a sorted set. Everything else dune
    prints carries a run id, a timing or a temporary path, none of which say
-   anything about the mutant. *)
+   anything about the mutant.
+
+   Three markers, because the suite reports a failure three ways. Alcotest
+   writes [FAIL]. A rule that produces output at all makes dune print its
+   location, which is a header rather than a failure, but it cancels out of the
+   set diff and pins WHICH rule the run reached. And the browser-backed
+   harnesses print their own [FAIL <what>] lines: without that marker their
+   failures add nothing to the signature, so a mutant only they catch scores
+   SURVIVED, and they are the strongest oracles in the suite. *)
 let signature log =
   let ic = open_in log in
   let acc = ref [] in
   (try
      while true do
        let l = String.trim (input_line ic) in
-       if String.starts_with ~prefix:"File \"" l || contains l "[FAIL]" then
-         acc := l :: !acc
+       if
+         String.starts_with ~prefix:"File \"" l
+         || String.starts_with ~prefix:"FAIL " l
+         || contains l "[FAIL]"
+       then acc := l :: !acc
      done
    with End_of_file -> ());
   close_in ic;


### PR DESCRIPTION
The mutation harness judges a mutant by how its set of failing rules and cases differs from the baseline's, and `signature` recognised two markers: alcotest's `[FAIL]` and dune's rule-location header. The browser-backed harnesses report a failure as a `FAIL <what>` line of their own, so their findings added nothing to the signature and a mutant only they caught scored SURVIVED.

Measured on a planted defect (`font-weight` accepting the `0` that CSS Fonts 4 sec. 2.2 ranges out): the old marker set sees 11 signature lines, the new one 14, and one of the three it was missing is the `descriptor_set` finding. The earlier reading that those rules "already fail in the worktree" was wrong: they pass there, and dune names them because they print a summary.