### PR TITLE
test: pin the whole-byte guard on a percentage alpha

### DIFF
--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1315,6 +1315,13 @@ let test_lossless_alpha_folds_only_on_a_whole_byte () =
       (* 127.5 is not a byte, so the functional spelling stays. *)
       (".a{color:rgb(0 0 0/.5)}", ".a{color:rgb(0 0 0/.5)}");
       (".a{color:rgb(0 0 0/.3)}", ".a{color:rgb(0 0 0/.3)}");
+      (* A percentage alpha is the same question asked of a second arm, and 100%
+         of 255 is a byte where 33% of it is 84.15. The percentage itself prints
+         as the shorter <number> CSS Color 4 sec. 4.1 makes equal to it. *)
+      (".a{color:rgb(0 0 0/100%)}", ".a{color:#000}");
+      (".a{color:rgb(0 0 0/20%)}", ".a{color:#0003}");
+      (".a{color:rgb(0 0 0/33%)}", ".a{color:rgb(0 0 0/.33)}");
+      (".a{color:rgb(0 0 0/1%)}", ".a{color:rgb(0 0 0/.01)}");
     ]
 
 let test_lossless_keeps_unknown_property_order () =


### PR DESCRIPTION
`exact_alpha_value_byte` has a number arm and a percentage arm, and #1112 covered only the first. Removing the guard from the percentage arm truncates `rgb(0 0 0/33%)` (84.15 of 255) to 84 and emits `#00000054`, a different colour, under `--lossless` — whose whole promise is that it does not change one. CSS Color 4 sec. 5 writes the hex alpha as a byte, so a hex spelling exists only where the alpha is one.