### PR TITLE
rule-index: drop the per-rule property table nothing reads

### DIFF
--- a/lib/rule_index.ml
+++ b/lib/rule_index.ml
@@ -7,39 +7,15 @@ open Declaration
    important-split that prepends a non-important shorthand and re-states an
    important side). *)
 type slot = Live | Absorbed | Shorthand of declaration list
-
-type t = {
-  decls : declaration array;
-  slots : slot array;
-  by_prop : (Declaration.prop_key, int list) Hashtbl.t;
-}
-
-let prop_key_of d =
-  match d with
-  | Declaration { property; _ } -> Declaration.Key property
-  | Theme_guarded _ as d -> Declaration.property_key d
+type t = { decls : declaration array; slots : slot array }
 
 let build decls =
   let decls = Array.of_list decls in
-  let n = Array.length decls in
-  let slots = Array.make n Live in
-  let by_prop : (Declaration.prop_key, int list) Hashtbl.t =
-    Hashtbl.create (max 16 n)
-  in
-  (* Walk back-to-front so the per-property positions list ends up in cascade
-     order without a final reverse. *)
-  for i = n - 1 downto 0 do
-    let k = prop_key_of decls.(i) in
-    let prev = try Hashtbl.find by_prop k with Not_found -> [] in
-    Hashtbl.replace by_prop k (i :: prev)
-  done;
-  { decls; slots; by_prop }
+  let slots = Array.make (Array.length decls) Live in
+  { decls; slots }
 
 let length t = Array.length t.decls
 let decl_at t i = t.decls.(i)
-
-let positions (type a) t (p : a Properties.property) =
-  try Hashtbl.find t.by_prop (Declaration.Key p) with Not_found -> []
 
 let is_absorbed t i =
   match t.slots.(i) with Live | Shorthand _ -> false | Absorbed -> true

--- a/lib/rule_index.mli
+++ b/lib/rule_index.mli
@@ -24,10 +24,6 @@ val length : t -> int
 val decl_at : t -> int -> Declaration.declaration
 (** [decl_at t i] returns the declaration at position [i]. *)
 
-val positions : t -> 'a Properties.property -> int list
-(** [positions t p] is the cascade-ordered list of positions at which the typed
-    property [p] appears in the rule. *)
-
 val absorb :
   t -> at:int -> absorbed:int list -> shorthand:Declaration.declaration -> bool
 (** [absorb t ~at ~absorbed ~shorthand] records that [shorthand] should appear

--- a/test/test_rule_index.ml
+++ b/test/test_rule_index.ml
@@ -29,18 +29,6 @@ let test_empty_index () =
     "to_list of empty is empty" 0
     (List.length (Rule_index.to_list t))
 
-let test_positions_in_cascade_order () =
-  let t = Rule_index.build [ red; solid_outline_width; blue ] in
-  Alcotest.(check (list int))
-    "Color positions in cascade order" [ 0; 2 ]
-    (Rule_index.positions t Properties.Color);
-  Alcotest.(check (list int))
-    "Outline_width position" [ 1 ]
-    (Rule_index.positions t Properties.Outline_width);
-  Alcotest.(check (list int))
-    "absent property returns empty" []
-    (Rule_index.positions t Properties.Background_color)
-
 let test_absorb_marks_positions () =
   let t = Rule_index.build [ red; blue ] in
   Alcotest.(check bool)
@@ -99,8 +87,6 @@ let suite =
   ( "rule_index",
     [
       Alcotest.test_case "empty" `Quick test_empty_index;
-      Alcotest.test_case "positions cascade order" `Quick
-        test_positions_in_cascade_order;
       Alcotest.test_case "absorb marks positions" `Quick
         test_absorb_marks_positions;
       Alcotest.test_case "to_list emits shorthand in place" `Quick


### PR DESCRIPTION
`Rule_index.build` indexed every rule's declarations by property into a `Hashtbl`, and the only caller of the accessor that reads it was a test of that accessor. `Rule_index` is not public, so nothing downstream can reach it either.

An `obs` profile of a 1.7 MB stylesheet ranked `Hashtbl.create` as the top allocation site at 4.2%, and this was 47% of it: 63k tables built for a median rule of two declarations. Removing it takes the site from 51.9 MB to 32.0 MB and total allocation from 1.19 GB to 1.17 GB. Wall time over 15 interleaved runs: -2.3% on the minimum, -1.8% on p25, -2.0% on the median, all three agreeing. Output over the corpus is byte-identical.