### PR TITLE
values: keep keywords out of math operands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,13 @@ entry points both moved.
   `webkit_line_clamp`, `zoom`, `border_image_slice_item` and
   `shape_image_threshold` gain `Calc`, and `grid_line` gains `Calc_name`
   (#1072, #1086, #1124, #1125, #1126)
+- A math function takes only the operands CSS Values 4 sec. 10.8 grants, so
+  `width: calc(inherit)`, `height: calc(auto)`, `border-width: calc(medium)`,
+  `width: calc(fit-content(20rem))` and `width: min(unset, 1px)` are dropped
+  with a warning where they used to read. `calc(inherit)` was written back as a
+  live `inherit`, which changed what the element computed. Sec. 10.2 also
+  requires the arguments of `min()`, `max()` and `clamp()` to share a
+  consistent type, so `width: min(0, 1px)` is dropped as well (#1139)
 - The gap decoration, scroll-driven animation and interest properties carry a
   comma-separated list where they carried a single value, one entry per rule
   line or per timeline, so `column-rule: 1px solid red, 2px dashed blue` and

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1456,13 +1456,16 @@ let read_length_as_border_width ?(allow_negative = false) t =
 
 (* CSS Values 4 sec. 10.12: a math function is valid wherever its type is, and
    the [0,inf] range of [<line-width>] is checked on the value it resolves to,
-   not on each operand. So [calc(-1px)] reads and a literal [-1px] does not. *)
+   not on each operand. So [calc(-1px)] reads and a literal [-1px] does not.
+   Sec. 10.8 gives an operand no keyword either: [thin], [medium], [thick] and
+   the CSS-wide keywords are not [<calc-value>]s, so [keywords] is off here and
+   [calc(medium)] fails the way the browser drops it. *)
 let rec read_border_width_in_math t : border_width =
-  read_border_width_with ~allow_negative:true t
+  read_border_width_with ~keywords:false ~allow_negative:true t
 
-and read_border_width_with ~allow_negative t : border_width =
+and read_border_width_with ?(keywords = true) ~allow_negative t : border_width =
   let read_var t : border_width =
-    Var (read_var (read_border_width_with ~allow_negative) t)
+    Var (read_var (read_border_width_with ~keywords ~allow_negative) t)
   in
   let read_calc t : border_width =
     Calc (read_calc ~result_type:`Value read_border_width_in_math t)
@@ -1487,16 +1490,18 @@ and read_border_width_with ~allow_negative t : border_width =
     | _ -> Cursor.err_invalid t "invalid clamp"
   in
   Cursor.enum_or_calls "border-width"
-    [
-      ("thin", (Thin : border_width));
-      ("medium", Medium);
-      ("thick", Thick);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
+    (if keywords then
+       [
+         ("thin", (Thin : border_width));
+         ("medium", Medium);
+         ("thick", Thick);
+         ("inherit", Inherit);
+         ("initial", Initial);
+         ("unset", Unset);
+         ("revert", Revert);
+         ("revert-layer", Revert_layer);
+       ]
+     else [])
     ~calls:
       [
         ("var", read_var);

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5822,7 +5822,7 @@ let rec read_length ?(allow_negative = true) ?(with_keywords = true)
   let parsers =
     [
       read_var_length ~allow_negative ~length_only ~with_keywords;
-      read_calc_length ~length_only ~with_keywords;
+      read_calc_length ~length_only;
       read_env_length ~allow_negative ~length_only ~with_keywords;
       read_function_length ~allow_negative ~length_only ~with_keywords;
       read_length_unit ~allow_negative ~length_only;
@@ -5838,13 +5838,22 @@ and read_var_length ~allow_negative ~length_only ~with_keywords t : length =
     Var (read_var (read_length ~allow_negative ~length_only ~with_keywords) t)
   else Cursor.err t "expected var"
 
-and read_calc_length ~length_only ~with_keywords t : length =
+(* CSS Values 4 sec. 10.8: a [<calc-value>] is a number, a dimension, a
+   percentage, a [<calc-keyword>] ([e], [pi], [infinity], [-infinity], [NaN]) or
+   a parenthesised [<calc-sum>]. A CSS-wide keyword, [auto], an intrinsic size
+   and the sizing functions are none of those, and sec. 10.9 makes the
+   calculation's type failure for anything else, so a math operand reads a
+   length with the keyword grammar off. *)
+and read_math_operand_length ~allow_negative ~length_only t : length =
+  read_length ~allow_negative ~length_only ~with_keywords:false t
+
+and read_calc_length ~length_only t : length =
   if Cursor.looking_at_calc t then
     (* Same exception as [read_length_percentage]: inside [calc()] the
        non-negative constraint applies to the resolved value. *)
     Calc
       (read_calc ~result_type:`Value
-         (read_length ~length_only ~with_keywords)
+         (read_math_operand_length ~allow_negative:true ~length_only)
          t)
   else Cursor.err t "expected calc"
 
@@ -5901,12 +5910,12 @@ and length_function_readers ~allow_negative ~length_only ~with_keywords =
       ("clamp", read_clamp_length ~length_only);
       ("min", read_min_length ~length_only);
       ("max", read_max_length ~length_only);
-      ("round", read_round_length ~allow_negative ~length_only ~with_keywords);
-      ("mod", read_mod_length ~allow_negative ~length_only ~with_keywords);
-      ("rem", read_rem_length ~allow_negative ~length_only ~with_keywords);
-      ("hypot", read_hypot_length ~allow_negative ~length_only ~with_keywords);
-      ("abs", read_abs_length ~allow_negative ~length_only ~with_keywords);
-      ("sign", read_sign_length ~allow_negative ~length_only ~with_keywords);
+      ("round", read_round_length ~allow_negative ~length_only);
+      ("mod", read_mod_length ~allow_negative ~length_only);
+      ("rem", read_rem_length ~allow_negative ~length_only);
+      ("hypot", read_hypot_length ~allow_negative ~length_only);
+      ("abs", read_abs_length ~allow_negative ~length_only);
+      ("sign", read_sign_length ~allow_negative ~length_only);
       ("anchor-size", read_anchor_size_length);
       ("anchor", read_anchor_length ~allow_negative ~length_only ~with_keywords);
       ("attr", read_attr_length ~allow_negative ~length_only ~with_keywords);
@@ -5916,14 +5925,17 @@ and length_function_readers ~allow_negative ~length_only ~with_keywords =
    are implicit math expressions, so [clamp(.5rem, 2vw + .5rem, 2rem)] is valid
    without a surrounding [calc()]. Parse each argument with [read_calc_expr] and
    collapse a singleton [Val] back to the plain length so the AST stays compact
-   for the common case. *)
+   for the common case. The same section requires the arguments to "have a
+   consistent type or else the function is invalid", so every one of them is
+   checked against the length the surrounding property reads: [min(0, 1px)]
+   mixes a [<number>] with a [<length>] and browsers drop it. *)
 and read_implicit_calc_length ~length_only inner =
   let expr =
     read_calc_expr
-      (read_length ~length_only ~with_keywords:(not length_only))
+      (read_math_operand_length ~allow_negative:true ~length_only)
       inner
   in
-  if length_only then validate_calc_type inner `Value expr;
+  validate_calc_type inner `Value expr;
   match expr with Val l -> l | expr -> Calc expr
 
 and read_clamp_length ?(length_only = false) inner =
@@ -5983,57 +5995,59 @@ and read_fit_content_length ~allow_negative ~length_only ~with_keywords inner =
   Cursor.expect_eof inner;
   Fit_content_arg arg
 
-and read_round_length ~allow_negative ~length_only ~with_keywords inner =
+and read_round_length ~allow_negative ~length_only inner =
   let strategy = read_round_strategy inner in
-  let value = read_length ~allow_negative ~length_only ~with_keywords inner in
+  let read = read_math_operand_length ~allow_negative ~length_only in
+  let value = read inner in
   Cursor.ws inner;
   Cursor.comma inner;
-  let step = read_length ~allow_negative ~length_only ~with_keywords inner in
+  let step = read inner in
   Cursor.ws inner;
   Cursor.expect_eof inner;
   Round (strategy, value, step)
 
-and read_binary_length ~allow_negative ~length_only ~with_keywords make inner =
-  let a = read_length ~allow_negative ~length_only ~with_keywords inner in
+and read_binary_length ~allow_negative ~length_only make inner =
+  let read = read_math_operand_length ~allow_negative ~length_only in
+  let a = read inner in
   Cursor.ws inner;
   Cursor.comma inner;
-  let b = read_length ~allow_negative ~length_only ~with_keywords inner in
+  let b = read inner in
   Cursor.ws inner;
   Cursor.expect_eof inner;
   make a b
 
-and read_mod_length ~allow_negative ~length_only ~with_keywords inner =
-  read_binary_length ~allow_negative ~length_only ~with_keywords
+and read_mod_length ~allow_negative ~length_only inner =
+  read_binary_length ~allow_negative ~length_only
     (fun (a : length) (b : length) -> (Mod (a, b) : length))
     inner
 
-and read_rem_length ~allow_negative ~length_only ~with_keywords inner =
-  read_binary_length ~allow_negative ~length_only ~with_keywords
+and read_rem_length ~allow_negative ~length_only inner =
+  read_binary_length ~allow_negative ~length_only
     (fun (a : length) (b : length) -> (Rem_fn (a, b) : length))
     inner
 
-and read_hypot_length ~allow_negative ~length_only ~with_keywords inner =
+and read_hypot_length ~allow_negative ~length_only inner =
   let values =
     Cursor.list ~sep:Cursor.comma
-      (read_length ~allow_negative ~length_only ~with_keywords)
+      (read_math_operand_length ~allow_negative ~length_only)
       inner
   in
   Cursor.expect_eof inner;
   Hypot values
 
-and read_unary_length ~allow_negative ~length_only ~with_keywords make inner =
-  let value = read_length ~allow_negative ~length_only ~with_keywords inner in
+and read_unary_length ~allow_negative ~length_only make inner =
+  let value = read_math_operand_length ~allow_negative ~length_only inner in
   Cursor.ws inner;
   Cursor.expect_eof inner;
   make value
 
-and read_abs_length ~allow_negative ~length_only ~with_keywords inner =
-  read_unary_length ~allow_negative ~length_only ~with_keywords
+and read_abs_length ~allow_negative ~length_only inner =
+  read_unary_length ~allow_negative ~length_only
     (fun (value : length) -> (Abs value : length))
     inner
 
-and read_sign_length ~allow_negative ~length_only ~with_keywords inner =
-  read_unary_length ~allow_negative ~length_only ~with_keywords
+and read_sign_length ~allow_negative ~length_only inner =
+  read_unary_length ~allow_negative ~length_only
     (fun (value : length) -> (Sign value : length))
     inner
 
@@ -7497,7 +7511,7 @@ let rec read_length_percentage ?(allow_negative = true) ?(with_keywords = true)
     [
       read_length_percentage_var ~allow_negative ~with_keywords;
       read_length_percentage_env ~allow_negative ~with_keywords;
-      read_length_percentage_calc ~with_keywords;
+      read_length_percentage_calc;
       read_invalid_length_percentage_function;
       read_length_percentage_pct ~allow_negative;
       read_length_percentage_length ~allow_negative ~with_keywords ~sizing;
@@ -7516,14 +7530,17 @@ and read_length_percentage_env ~allow_negative ~with_keywords t :
     Env (read_env (read_length_percentage ~allow_negative ~with_keywords) t)
   else Cursor.err t "expected env"
 
-and read_length_percentage_calc ~with_keywords t : length_percentage =
+and read_length_percentage_calc t : length_percentage =
   if Cursor.looking_at_calc t then
     (* CSS Values 4 10 (calc): inside [calc()] negative operands are always
        allowed even when the surrounding property is non-negative; the
        non-negative constraint applies to the resolved value, not to inner
-       operands. *)
+       operands. Sec. 10.8 gives an operand no keyword, so the leaf reads with
+       the keyword grammar off. *)
     Calc
-      (read_calc ~result_type:`Value (read_length_percentage ~with_keywords) t)
+      (read_calc ~result_type:`Value
+         (read_length_percentage ~with_keywords:false)
+         t)
   else Cursor.err t "expected calc"
 
 (** Read number_percentage value. Inside a [<number-percentage>] [calc()], a raw

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3515,6 +3515,35 @@ let invalid () =
   neg "-webkit-text-stroke-width: 20%";
   neg "border-width: calc(50%)";
 
+  (* CSS Values 4 sec. 10.8 gives [<calc-value>] a number, a dimension, a
+     percentage, a [<calc-keyword>] or a parenthesised [<calc-sum>], and sec.
+     10.9 makes the calculation's type failure for anything else. A CSS-wide
+     keyword, a sizing keyword or a sizing function is none of those, so a math
+     operand takes none of them. Chrome 153 drops each of these declarations;
+     unwrapping one to its bare keyword would make a live [width: inherit] out
+     of a value the browser ignores. *)
+  neg "width: calc(inherit)";
+  neg "height: calc(auto)";
+  neg "width: calc(initial)";
+  neg "width: calc(unset)";
+  neg "width: calc(revert)";
+  neg "width: calc(1px + initial)";
+  neg "width: calc(calc(auto))";
+  neg "width: calc(fit-content(20rem))";
+  neg "width: min(unset,1px)";
+  neg "width: min(1px,auto)";
+  neg "border-width: calc(medium)";
+  neg "border-width: calc(thin)";
+  neg "border-width: calc(thick)";
+  neg "outline-width: calc(thin)";
+  neg "outline-width: min(thin,1px)";
+
+  (* CSS Values 4 sec. 10.2: the arguments of [min()] / [max()] / [clamp()]
+     "must have a consistent type or else the function is invalid", and sec.
+     10.9 gives a unitless zero inside a math function the [<number>] type. *)
+  neg "width: min(0,1px)";
+  neg "width: clamp(0px,0,100px)";
+
   (* CSS Sizing 3 sec. 5 gives the intrinsic sizes to the sizing properties, so
      a property reading a plain length does not take them. Chrome 146 refuses
      each of these. *)

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -249,6 +249,37 @@ let test_length () =
   neg_cursor read_length "calc((1px 2px))";
   neg_cursor read_length "min((1px 2px))";
 
+  (* CSS Values 4 sec. 10.8: [<calc-value>] is a number, a dimension, a
+     percentage, a [<calc-keyword>] or a parenthesised [<calc-sum>], and sec.
+     10.7 limits [<calc-keyword>] to [e], [pi], [infinity], [-infinity] and
+     [NaN]. A CSS-wide keyword (sec. 4.1.1 gives it the whole declaration value
+     alone) and a sizing keyword or function are none of those, so a math
+     operand takes none of them. *)
+  neg_cursor read_length "calc(auto)";
+  neg_cursor read_length "calc(inherit)";
+  neg_cursor read_length "calc(initial)";
+  neg_cursor read_length "calc(unset)";
+  neg_cursor read_length "calc(revert)";
+  neg_cursor read_length "calc(revert-layer)";
+  neg_cursor read_length "calc(calc(auto))";
+  neg_cursor read_length "calc(1px + initial)";
+  neg_cursor read_length "calc(fit-content(20rem))";
+  neg_cursor read_length "min(unset,1px)";
+  neg_cursor read_length "min(1px,auto)";
+  neg_cursor read_length "clamp(1px,inherit,3px)";
+  neg_cursor read_length "abs(auto)";
+  neg_cursor read_length "round(auto,1px)";
+  neg_cursor read_length "hypot(auto)";
+  neg_cursor read_length "mod(auto,1px)";
+  neg_cursor read_length "rem(auto,1px)";
+
+  (* CSS Values 4 sec. 10.2: the arguments of [min()] / [max()] / [clamp()]
+     "must have a consistent type or else the function is invalid", and sec.
+     10.9 makes a unitless zero a [<number>], not a length. *)
+  neg_cursor read_length "min(0,1px)";
+  neg_cursor read_length "max(0,1px)";
+  neg_cursor read_length "clamp(0px,0,100px)";
+
   neg_cursor read_length "invalid";
   neg_cursor read_length "abc";
   neg_cursor read_length "10";


### PR DESCRIPTION
Cascade wrote `width: calc(inherit)` back as a live `width: inherit`, where every browser drops the declaration, so minified output could change what an element computed. The math operand reader was the property's own value reader, so every keyword that reader accepts stood as a `<calc-value>`.