### PR TITLE
read: fold a keyword before a guard decides its reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -304,10 +304,13 @@ to lose a whole rule over one bad piece. Both are gone.
   value, so it accepts the pairs `custom_property` accepts
   (#985, #986, #987, #988, #989, #990, #991, #992)
 - Keyword, at-rule and function names match without regard to case, so
-  `grid-column: SPAN 2`, `@MEDIA`, `RGB()`, `VAR(--x)` and `:dir(LTR)` read,
-  and an escaped name reads as the name it spells: `@supports (--x\3b y: red)`
-  is read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer
-  `b` of `a` (#437, #442, #602, #603, #604, #620, #622, #767)
+  `grid-column: SPAN 2`, `@MEDIA`, `RGB()`, `VAR(--x)`, `:dir(LTR)`,
+  `touch-action: NONE`, `display: LIST-ITEM FLOW-ROOT`, `align-items: FIRST
+  BASELINE`, `grid-template-columns: REPEAT(3, 1FR)` and `color: COLOR(DISPLAY-P3
+  1 0 0)` read, while an author-defined name keeps the case it was written in.
+  An escaped name reads as the name it spells: `@supports (--x\3b y: red)` is
+  read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer `b`
+  of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141)
 - Cascade reads back everything it writes. Minified `@scope to (...)`, `rotate`
   with a negative axis, a relative colour's channels, a `-webkit-gradient`
   `color-stop()` and `center` point, `text-decoration: none solid`,

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -438,6 +438,11 @@ let peek_ident t =
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> Some s
   | _ -> None
 
+let peek_keyword t =
+  match peek_ident t with
+  | Some s -> Some (String.lowercase_ascii_preserve s)
+  | None -> None
+
 let peek_hash t =
   match peek t with
   | Some (Component.Preserved { kind = Token.Hash { value; _ }; _ }) ->

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -338,6 +338,11 @@ val peek_colon : t -> bool
 val peek_ident : t -> string option
 (** [peek_ident t] is [Some s] when the next component is [Ident s]. *)
 
+val peek_keyword : t -> string option
+(** [peek_keyword t] is the next identifier folded to ASCII lower case, for
+    matching against a keyword. CSS Values 4 sec. 4.1. Use {!peek_ident} for an
+    author-defined name, which sec. 4.2 keeps case-sensitive. *)
+
 val peek_hash : t -> string option
 (** [peek_hash t] is [Some s] when the next component is [Hash s]. *)
 

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -176,7 +176,8 @@ let valid_percentage p = Float.is_finite p && p >= 0.
    than whatever follows it. *)
 let rec read_metric_override t : metric_override =
   match Cursor.peek t with
-  | Some (Component.Preserved { kind = Token.Ident "normal"; _ }) ->
+  | Some (Component.Preserved { kind = Token.Ident name; _ })
+    when Common.String.lowercase_ascii_preserve name = "normal" ->
       Cursor.skip t;
       Normal
   | Some (Component.Preserved { kind = Token.Percentage number; _ })

--- a/lib/prop_align.ml
+++ b/lib/prop_align.ml
@@ -20,7 +20,7 @@ let read_flat_baseline ~what ~baseline ~first ~last t =
     [ ("baseline", baseline) ]
     ~default:(fun t ->
       let tok = Cursor.ident t in
-      match tok with
+      match Common.String.lowercase_ascii_preserve tok with
       | "first" ->
           Cursor.ws t;
           Cursor.expect_string "baseline" t;
@@ -330,7 +330,7 @@ let rec read_justify_items t : justify_items =
   let read_legacy t =
     Cursor.expect_string "legacy" t;
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "center" ->
         let _ = Cursor.ident t in
         Legacy_center

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -2105,7 +2105,7 @@ let read_animation_range_offset t : length_percentage option =
   if Cursor.is_done t || Cursor.peek_comma t then
     (None : length_percentage option)
   else
-    match Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t) with
+    match Cursor.peek_keyword t with
     | Some "normal" -> (None : length_percentage option)
     | Some next when List.mem next Keyframe.timeline_range_names ->
         (None : length_percentage option)
@@ -2116,7 +2116,7 @@ let read_animation_range_offset t : length_percentage option =
    [normal] names one end among others rather than the whole value. *)
 let read_animation_range_one t : animation_range_item =
   Cursor.ws t;
-  match Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t) with
+  match Cursor.peek_keyword t with
   | Some "normal" ->
       let _ = Cursor.ident t in
       (Normal : animation_range_item)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1946,7 +1946,7 @@ let read_background_position_axis ~label ~start_edge ~end_edge =
       ]
       ~var:(fun t -> Var (Values.read_var read t))
       ~default:(fun t : background_position_axis ->
-        match Cursor.peek_ident t with
+        match Cursor.peek_keyword t with
         | Some "center" ->
             ignore (Cursor.ident_opt t);
             Center
@@ -2389,7 +2389,7 @@ let read_border_image_slice_step t values has_fill =
   Cursor.ws t;
   if Cursor.is_done t || Cursor.peek_delim t = Some '/' then `Stop
   else
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "fill" ->
         if has_fill then
           Cursor.err_invalid t "duplicate border-image fill keyword";
@@ -2412,7 +2412,7 @@ let read_border_image_slice_offsets t : border_image_slice_offsets =
 (* CSS Cascade 5 sec. 7.3 gives the longhand the CSS-wide keywords; the
    shorthand takes offsets alone. *)
 let rec read_border_image_slice t : border_image_slice =
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some ("initial" | "inherit" | "unset" | "revert" | "revert-layer" | "var")
     ->
       Cursor.enum_or_var "border-image-slice"

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -94,7 +94,7 @@ let read_display_two_value t : display =
      reject so the caller can fall back to the legacy single-value form. *)
   let outside = Cursor.enum "display-outside" display_outside_idents t in
   Cursor.ws t;
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some s when List.mem_assoc s display_inside_idents ->
       let inside = Cursor.enum "display-inside" display_inside_idents t in
       Multi (outside, inside)
@@ -106,7 +106,7 @@ let read_display_list_item t : display =
   let list_item = ref false in
   let consume_slot () =
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "list-item" when not !list_item ->
         ignore (Cursor.ident t : string);
         list_item := true;
@@ -961,14 +961,14 @@ let rec read_aspect_ratio (t : Cursor.t) : aspect_ratio =
   let read_number_or_ratio t : aspect_ratio =
     let w, h = read_ratio t in
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "auto" ->
         Cursor.skip t;
         aspect_ratio_of_numbers ~auto:true w h
     | _ -> aspect_ratio_of_numbers ~auto:false w h
   in
   let read_auto t : aspect_ratio =
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "auto" -> (
         Cursor.skip t;
         (* [auto] may stand alone or be followed by a [<ratio>]. Only treat a

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -341,7 +341,7 @@ let read_flex_wrap_balance_pair t : flex_wrap =
   let direction = ref Option.None and balance = ref false in
   let rec loop seen =
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "balance" when not !balance ->
         let _ = Cursor.ident t in
         balance := true;

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -483,7 +483,7 @@ let read_feature_value_names t =
 
 let read_font_variant_alternates_item t : font_variant_alternates_item =
   Cursor.ws t;
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "historical-forms" ->
       let _ = Cursor.ident t in
       Historical_forms
@@ -1899,8 +1899,8 @@ let read_font_shorthand r : font_shorthand =
   let rec consume_prefix () =
     Cursor.ws r;
     if Cursor.is_done r then ()
-    else if font_shorthand_prefix_ident (Cursor.peek_ident r) then (
-      assign (font_prefix_slot_of (Cursor.ident r));
+    else if font_shorthand_prefix_ident (Cursor.peek_keyword r) then (
+      assign (font_prefix_slot_of (Cursor.ident ~keep_case:false r));
       consume_prefix ())
     else if try_numeric_font_weight r weight then consume_prefix ()
   in
@@ -2561,7 +2561,7 @@ let rec read_font_size_adjust t : font_size_adjust =
   let read_metric_value t =
     let metric = read_font_size_adjust_metric t in
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "from-font" ->
         let _ = Cursor.ident t in
         Metric_from_font metric

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -920,7 +920,7 @@ module Grid_template = struct
   let read_fr t : grid_template =
     (* [1fr] lexes as a single [Dimension] with unit "fr". *)
     match Cursor.dimension_opt t with
-    | Some (n, "fr") -> Fr n
+    | Some (n, unit_) when String.lowercase_ascii_preserve unit_ = "fr" -> Fr n
     | _ -> Cursor.err_expected t "<fr>"
 
   type math_kind = Number | Dimension | Flex | Unknown | Invalid
@@ -1480,7 +1480,7 @@ let read_grid_auto_tracks t : grid_template =
 let read_grid_auto_flow_clause side t =
   let rec loop seen_auto_flow seen_dense =
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "auto-flow" when not seen_auto_flow ->
         let _ = Cursor.ident t in
         loop true seen_dense
@@ -1504,7 +1504,7 @@ let read_grid_auto_flow_tracks t : grid_template option =
   | Some _ -> Cursor.option read_grid_template_tracks t
 
 let grid_starts_auto_flow t =
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some ("auto-flow" | "dense") -> true
   | _ -> false
 

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1154,7 +1154,7 @@ let read_image_resolution_dimension t (parts : [ `From_image | `Snap ] list)
 
 let read_image_resolution_step t parts resolution =
   Cursor.ws t;
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "from-image" -> read_image_resolution_from_image t parts resolution
   | Some "snap" -> read_image_resolution_snap t parts resolution
   | _ when image_resolution_has_dimension t ->
@@ -1397,25 +1397,25 @@ module Position_value = struct
 
   (* Read 3-value syntax: keyword offset keyword *)
   let read_3_value t : position_value =
-    let edge1 = Cursor.ident t in
+    let edge1 = Cursor.ident ~keep_case:false t in
     Cursor.ws t;
     let offset = read_length_percentage ~with_keywords:false t in
     Cursor.ws t;
-    let axis = Cursor.ident t in
+    let axis = Cursor.ident ~keep_case:false t in
     if valid_edge_axis edge1 axis then Edge_offset_axis (edge1, offset, axis)
     else Cursor.err_invalid t "invalid three-value position"
 
   let read_axis_edge_offset t : position_value =
-    let axis = Cursor.ident t in
+    let axis = Cursor.ident ~keep_case:false t in
     Cursor.ws t;
-    let edge = Cursor.ident t in
+    let edge = Cursor.ident ~keep_case:false t in
     Cursor.ws t;
     let offset = read_length_percentage ~with_keywords:false t in
     if valid_edge_axis edge axis then Axis_edge_offset (axis, edge, offset)
     else Cursor.err_invalid t "invalid position axis edge offset"
 
   let read_horizontal_keyword_length t : position_value =
-    let keyword = Cursor.ident t in
+    let keyword = Cursor.ident ~keep_case:false t in
     Cursor.ws t;
     let y = read_length ~with_keywords:false t in
     match keyword with
@@ -1432,7 +1432,7 @@ module Position_value = struct
   let read_length_keyword t : position_value =
     let offset = read_length ~with_keywords:false t in
     Cursor.ws t;
-    match Cursor.ident t with
+    match Cursor.ident ~keep_case:false t with
     | "center" -> Single offset
     | "top" -> XY (offset, (Pct 0. : length))
     | "bottom" -> XY (offset, (Pct 100. : length))
@@ -1440,11 +1440,11 @@ module Position_value = struct
 
   (* Read 4-value syntax: keyword offset keyword offset *)
   let read_4_value t : position_value =
-    let edge1 = Cursor.ident t in
+    let edge1 = Cursor.ident ~keep_case:false t in
     Cursor.ws t;
     let offset1 = read_length_percentage ~with_keywords:false t in
     Cursor.ws t;
-    let edge2 = Cursor.ident t in
+    let edge2 = Cursor.ident ~keep_case:false t in
     Cursor.ws t;
     let offset2 = read_length_percentage ~with_keywords:false t in
     if
@@ -1568,7 +1568,7 @@ let read_conic_gradient_config t : conic_gradient_config =
   let position : position_value option ref = ref Option.None in
   let interpolation : color_interpolation option ref = ref Option.None in
   let read_from t =
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "from" ->
         let _ = Cursor.ident t in
         Cursor.ws t;
@@ -1576,7 +1576,7 @@ let read_conic_gradient_config t : conic_gradient_config =
     | _ -> Cursor.err_expected t "from"
   in
   let read_at t =
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "at" ->
         let _ = Cursor.ident t in
         Cursor.ws t;
@@ -1656,7 +1656,7 @@ let rec read_gradient_position t : gradient_position =
     when String.lowercase_ascii_preserve name = "var" ->
       (Var (Values.read_var read_gradient_position t) : gradient_position)
   | _ -> (
-      match Cursor.peek_ident t with
+      match Cursor.peek_keyword t with
       | Some "from" -> Conic_position (read_conic_gradient_config t)
       | Some
           ( "circle" | "ellipse" | "closest-side" | "closest-corner"

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -554,14 +554,14 @@ let read_contain_intrinsic_size_item t : contain_intrinsic_size_item =
   in
   let none_or_size t ~auto : contain_intrinsic_size_item =
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some "none" ->
         let _ = Cursor.ident t in
         if auto then Auto_none else None
     | _ -> if auto then Auto (size t) else Length (size t)
   in
   Cursor.ws t;
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "auto" ->
       let _ = Cursor.ident t in
       none_or_size t ~auto:true
@@ -620,7 +620,7 @@ let rec read_contain_intrinsic_longhand (t : Cursor.t) :
    keyword before the slash is a name: [container: inline-size] names a
    container, it does not type one. *)
 let read_container_shorthand_name t : container_name =
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "none" ->
       let _ = Cursor.ident t in
       (None : container_name)
@@ -741,7 +741,7 @@ let rec read_scroll_snap_align (t : Cursor.t) : scroll_snap_align =
 
 let read_position_try_fallback t =
   Cursor.ws t;
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some (("flip-block" | "flip-inline" | "flip-start") as keyword) -> (
       let _ = Cursor.ident t in
       match keyword with
@@ -970,7 +970,7 @@ let rec read_position_try t : position_try =
          order keyword is optional and never collides with a fallback, and the
          fallbacks are not, so an order on its own is no value. *)
       let order : position_try_order =
-        match Cursor.peek_ident t with
+        match Cursor.peek_keyword t with
         | Some
             ( "normal" | "most-width" | "most-height" | "most-block-size"
             | "most-inline-size" ) ->
@@ -1183,7 +1183,7 @@ let read_margin_trim_axes t : margin_trim option =
   let axes = [ "block"; "inline" ] in
   let rec loop acc =
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some s
       when List.mem s axes && not (List.mem (margin_trim_axis_of_ident t s) acc)
       ->
@@ -1211,7 +1211,7 @@ let read_margin_trim_edges t =
   let edges = [ "block-start"; "inline-start"; "block-end"; "inline-end" ] in
   let rec loop acc =
     Cursor.ws t;
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some s
       when List.mem s edges
            && not (List.mem (margin_trim_edge_of_ident t s) acc) ->

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -887,7 +887,7 @@ let rec read_clip t : clip =
 
 let read_clip_path_round t : border_radius option =
   Cursor.ws t;
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "round" ->
       let _ = Cursor.ident t in
       Cursor.ws t;
@@ -896,7 +896,7 @@ let read_clip_path_round t : border_radius option =
 
 let read_clip_path_inset_side t : length_percentage option =
   Cursor.ws t;
-  match (Cursor.is_done t, Cursor.peek_ident t) with
+  match (Cursor.is_done t, Cursor.peek_keyword t) with
   | true, _ | _, Some "round" -> None
   | false, _ -> Some (read_length_percentage t)
 
@@ -913,7 +913,7 @@ let read_clip_path_inset t =
       Clip_path_inset { top; right; bottom; left; rounded })
 
 let read_clip_path_extent inner : clip_path_extent =
-  match Cursor.peek_ident inner with
+  match Cursor.peek_keyword inner with
   | Some "closest-side" ->
       Cursor.skip inner;
       Closest_side
@@ -929,7 +929,7 @@ let read_clip_path_fill_rule t =
 
 let read_clip_path_position_clause inner =
   Cursor.ws inner;
-  match Cursor.peek_ident inner with
+  match Cursor.peek_keyword inner with
   | Some "at" ->
       Cursor.skip inner;
       Cursor.ws inner;
@@ -949,7 +949,8 @@ let read_clip_path_circle t : clip_path =
       Cursor.call "circle" t @@ fun inner ->
       Cursor.ws inner;
       let radius : clip_path_extent option =
-        if Cursor.is_done inner || Cursor.peek_ident inner = Some "at" then None
+        if Cursor.is_done inner || Cursor.peek_keyword inner = Some "at" then
+          None
         else Some (read_clip_path_extent inner)
       in
       let position = read_clip_path_position_clause inner in
@@ -962,14 +963,15 @@ let read_clip_path_ellipse t : clip_path =
       Cursor.call "ellipse" t @@ fun inner ->
       Cursor.ws inner;
       let rx : clip_path_extent option =
-        if Cursor.is_done inner || Cursor.peek_ident inner = Some "at" then None
+        if Cursor.is_done inner || Cursor.peek_keyword inner = Some "at" then
+          None
         else Some (read_clip_path_extent inner)
       in
       Cursor.ws inner;
       let ry : clip_path_extent option =
         if
           Option.is_none rx || Cursor.is_done inner
-          || Cursor.peek_ident inner = Some "at"
+          || Cursor.peek_keyword inner = Some "at"
         then None
         else Some (read_clip_path_extent inner)
       in
@@ -979,7 +981,7 @@ let read_clip_path_ellipse t : clip_path =
       Clip_path_ellipse { rx; ry; position })
 
 let read_polygon_fill_rule inner : clip_path_fill_rule option =
-  match Cursor.peek_ident inner with
+  match Cursor.peek_keyword inner with
   | Some "nonzero" ->
       Cursor.skip inner;
       Cursor.ws inner;
@@ -1063,7 +1065,7 @@ let read_clip_path_shape t =
       Clip_path_shape (Cursor.consume_remaining_as_string ~trim:true inner))
 
 let read_clip_geometry_box_opt t : clip_geometry_box option =
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "margin-box" ->
       Cursor.skip t;
       Some Margin_box

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -311,14 +311,14 @@ let vector_effect_space_of = function
 let read_vector_effect_keyword t : vector_effect_keyword =
   let loc = Cursor.position t in
   let name = Cursor.ident t in
-  match vector_effect_keyword_of name with
+  match vector_effect_keyword_of (String.lowercase_ascii_preserve name) with
   | Some k -> k
   | Option.None -> err_invalid_value ~loc t "vector-effect" name
 
 let read_vector_effect_space t : vector_effect_space =
   let loc = Cursor.position t in
   let name = Cursor.ident t in
-  match vector_effect_space_of name with
+  match vector_effect_space_of (String.lowercase_ascii_preserve name) with
   | Some s -> s
   | Option.None -> err_invalid_value ~loc t "vector-effect" name
 
@@ -338,7 +338,7 @@ let rec read_vector_effect t : vector_effect =
     ~default:(fun t ->
       let rec go acc =
         Cursor.ws t;
-        match Option.map vector_effect_keyword_of (Cursor.peek_ident t) with
+        match Option.map vector_effect_keyword_of (Cursor.peek_keyword t) with
         | Some (Some k) ->
             let _ = Cursor.ident t in
             go (k :: acc)
@@ -347,7 +347,7 @@ let rec read_vector_effect t : vector_effect =
       let effects = go [ read_vector_effect_keyword t ] in
       Cursor.ws t;
       let space =
-        match Option.map vector_effect_space_of (Cursor.peek_ident t) with
+        match Option.map vector_effect_space_of (Cursor.peek_keyword t) with
         | Some (Some _) -> Some (read_vector_effect_space t)
         | _ -> Option.None
       in
@@ -363,7 +363,7 @@ let paint_order_keyword_of = function
 let read_paint_order_keyword t : paint_order_keyword =
   let loc = Cursor.position t in
   let name = Cursor.ident t in
-  match paint_order_keyword_of name with
+  match paint_order_keyword_of (String.lowercase_ascii_preserve name) with
   | Some k -> k
   | None -> err_invalid_value ~loc t "paint-order" name
 
@@ -385,7 +385,7 @@ let rec read_paint_order t : paint_order =
         if List.length acc = 3 then List.rev acc
         else begin
           Cursor.ws t;
-          match Option.map paint_order_keyword_of (Cursor.peek_ident t) with
+          match Option.map paint_order_keyword_of (Cursor.peek_keyword t) with
           | Some (Some k) when not (List.mem k acc) ->
               let _ = Cursor.ident t in
               go (k :: acc)

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -299,7 +299,7 @@ let rec read_text_indent_value t : text_indent_value =
       let each_line = ref false in
       while not (Cursor.is_done t) do
         Cursor.ws t;
-        match Cursor.peek_ident t with
+        match Cursor.peek_keyword t with
         | Some "hanging" when not !hanging ->
             Cursor.skip t;
             hanging := true
@@ -689,7 +689,7 @@ let rec read_text_transform t : text_transform =
       while !consumed do
         consumed := false;
         Cursor.ws t;
-        match Cursor.peek_ident t with
+        match Cursor.peek_keyword t with
         | Some "uppercase" when Option.is_none !case ->
             Cursor.skip t;
             case := Option.Some Uppercase;
@@ -1671,7 +1671,7 @@ let read_text_box_edge_keyword t : text_box_edge_keyword =
    is a value of the property rather than a CSS-wide keyword and reaches the
    [text-box] shorthand along with the rest. *)
 let read_text_box_edge_value t : text_box_edge =
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "auto" ->
       let _ = Cursor.ident t in
       (Auto : text_box_edge)
@@ -1931,7 +1931,7 @@ let rec read_hyphenate_limit_chars t : hyphenate_limit_chars =
 
 let rec read_white_space t : white_space =
   Cursor.ws t;
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "preserve" ->
       ignore (Cursor.ident t : string);
       Cursor.ws t;
@@ -2021,7 +2021,7 @@ let read_webkit_text_stroke t : webkit_text_stroke =
     slot := Some value
   in
   let read_one t =
-    match Cursor.peek_ident t with
+    match Cursor.peek_keyword t with
     | Some ("thin" | "medium" | "thick") -> fill width (read_border_width t)
     | _ -> (
         let snap = Cursor.save t in

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1012,7 +1012,7 @@ let read_rotate_axis_angle t : rotate_value =
   Axis (first, second, third, angle)
 
 let read_rotate_angle_axis_tail angle t =
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "x" ->
       Cursor.skip t;
       (X angle : rotate_value)
@@ -1308,14 +1308,14 @@ let read_offset_path_path t =
   | None -> Cursor.err_expected inner "path string"
 
 let read_offset_path_ray_contain inner =
-  match Cursor.peek_ident inner with
+  match Cursor.peek_keyword inner with
   | Some "contain" ->
       let _ = Cursor.ident inner in
       true
   | _ -> false
 
 let read_offset_path_ray_position inner =
-  match Cursor.peek_ident inner with
+  match Cursor.peek_keyword inner with
   | Some "at" ->
       let _ = Cursor.ident inner in
       Cursor.ws inner;
@@ -1395,7 +1395,7 @@ let read_ray t : ray =
   let size = Cursor.option read_ray_size inner in
   Cursor.ws inner;
   let contain =
-    match Cursor.peek_ident inner with
+    match Cursor.peek_keyword inner with
     | Some "contain" ->
         let _ = Cursor.ident inner in
         true
@@ -1403,7 +1403,7 @@ let read_ray t : ray =
   in
   Cursor.ws inner;
   let position =
-    match Cursor.peek_ident inner with
+    match Cursor.peek_keyword inner with
     | Some "at" ->
         let _ = Cursor.ident inner in
         Cursor.ws inner;

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -887,7 +887,7 @@ let touch_action_is_var t =
   | _ -> false
 
 let touch_action_starts_keyword t =
-  match Cursor.peek_ident t with
+  match Cursor.peek_keyword t with
   | Some
       ( "auto" | "none" | "manipulation" | "inherit" | "initial" | "unset"
       | "revert" | "revert-layer" ) ->
@@ -1051,7 +1051,7 @@ let rec read_scrollbar_gutter (t : Cursor.t) : scrollbar_gutter =
      ~default:(fun t ->
        Cursor.expect_string "stable" t;
        Cursor.ws t;
-       match Cursor.peek_ident t with
+       match Cursor.peek_keyword t with
        | Some "both-edges" ->
            let _ = Cursor.ident t in
            Stable_both_edges
@@ -1176,8 +1176,11 @@ let rec read_appearance t : appearance =
     ~var:(fun t -> (Var (Values.read_var read_appearance t) : appearance))
     t
 
+(* Only the [<custom-ident>] alternative of the grammar below keeps its case;
+   every other ident in it is a keyword. *)
 let color_scheme_of_idents t names : color_scheme =
-  match names with
+  let keywords = List.map String.lowercase_ascii_preserve names in
+  match keywords with
   | [ "normal" ] -> Normal
   | [ "light" ] -> Light
   | [ "dark" ] -> Dark
@@ -1200,13 +1203,13 @@ let color_scheme_of_idents t names : color_scheme =
          dark | <custom-ident>]+ && only?]. [normal] is mutually exclusive with
          the list form; [only] is a modifier that must accompany a non-empty
          list; CSS-wide keywords can only stand alone. *)
-      let has_normal = List.mem "normal" names in
+      let has_normal = List.mem "normal" keywords in
       let has_css_wide =
         List.exists
           (fun n ->
-            List.mem (String.lowercase_ascii n)
+            List.mem n
               [ "inherit"; "initial"; "unset"; "revert"; "revert-layer" ])
-          names
+          keywords
       in
       if has_normal then
         Cursor.err_invalid t
@@ -1214,12 +1217,12 @@ let color_scheme_of_idents t names : color_scheme =
       if has_css_wide then
         Cursor.err_invalid t
           "color-scheme: CSS-wide keyword cannot be mixed with other keywords";
-      let is_only n = String.equal (String.lowercase_ascii n) "only" in
-      let non_only_names = List.filter (fun n -> not (is_only n)) names in
+      let is_only n = String.equal n "only" in
+      let non_only_names = List.filter (fun n -> not (is_only n)) keywords in
       if non_only_names = [] then
         Cursor.err_invalid t
           "color-scheme: [only] must be combined with a color scheme";
-      if List.length (List.filter is_only names) > 1 then
+      if List.length (List.filter is_only keywords) > 1 then
         Cursor.err_invalid t "color-scheme: [only] cannot be repeated";
       Custom names
 

--- a/lib/prop_writing.ml
+++ b/lib/prop_writing.ml
@@ -325,7 +325,7 @@ let rec read_text_combine_upright t : text_combine_upright =
     ]
     ~var:(fun t -> Var (read_var read_text_combine_upright t))
     ~default:(fun t ->
-      match Cursor.peek_ident t with
+      match Cursor.peek_keyword t with
       | Some "digits" ->
           let _ = Cursor.ident t in
           Cursor.ws t;

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2510,7 +2510,7 @@ let read_list_style_shorthand r : list_style_shorthand =
     if Cursor.is_done r then ()
     else
       let saved = Cursor.save r in
-      let kw = Cursor.peek_ident r in
+      let kw = Cursor.peek_keyword r in
       if kw = Some "none" then begin
         let _ = Cursor.ident r in
         saw_none := true;

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1975,8 +1975,8 @@ let read_import_layer (r : Cursor.t) =
   with
   | Some _ as some -> some
   | None -> (
-      match Cursor.peek_ident r with
-      | Some s when String.lowercase_ascii s = "layer" ->
+      match Cursor.peek_keyword r with
+      | Some "layer" ->
           let _ = Cursor.ident r in
           Some []
       | _ -> None)
@@ -2798,7 +2798,7 @@ let read_counter_validated_descriptor ~what ~check constructor r =
 (* sec. 3.5: [[<integer> | infinite]{2}]# | auto. *)
 let check_counter_range c =
   let bound c =
-    match Cursor.peek_ident c with
+    match Cursor.peek_keyword c with
     | Some "infinite" -> ignore (Cursor.ident c)
     | Some _ | None -> ignore (Cursor.int c)
   in
@@ -2807,7 +2807,7 @@ let check_counter_range c =
     Cursor.ws c;
     bound c
   in
-  match Cursor.peek_ident c with
+  match Cursor.peek_keyword c with
   | Some "auto" -> ignore (Cursor.ident c)
   | Some _ | None -> ignore (Cursor.list ~at_least:1 ~sep:Cursor.comma pair c)
 
@@ -2839,7 +2839,7 @@ let check_counter_additive_symbols c =
 (* sec. 3.8: auto | bullets | numbers | words | spell-out |
    <counter-style-name>. *)
 let check_counter_speak_as c =
-  match Cursor.peek_ident c with
+  match Cursor.peek_keyword c with
   | Some ("auto" | "bullets" | "numbers" | "words" | "spell-out") ->
       ignore (Cursor.ident c)
   | Some _ | None -> ignore (read_counter_style_name c)
@@ -3641,12 +3641,6 @@ let conditional_atom r ~at_rule (fn : Component.func Component.node) =
       Cursor.err_condition r ~at_rule ("unknown condition function: " ^ name)
 
 let conditional_components ~at_rule cursor =
-  let peek_ident () =
-    match Cursor.peek cursor with
-    | Some (Component.Preserved { kind = Token.Ident name; _ }) ->
-        Some (String.lowercase_ascii name)
-    | _ -> None
-  in
   let read_atom () =
     Cursor.ws cursor;
     match Cursor.peek cursor with
@@ -3659,7 +3653,7 @@ let conditional_components ~at_rule cursor =
   let mixed op = Cursor.err_condition cursor ~at_rule ("cannot mix " ^ op) in
   let rec chain op acc =
     Cursor.ws cursor;
-    match peek_ident () with
+    match Cursor.peek_keyword cursor with
     | Some "and" ->
         (match op with Some `Or -> mixed "or and and" | _ -> ());
         Cursor.skip cursor;

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -405,15 +405,9 @@ let function_call t (fn : Component.func Component.node) =
            ( String.lowercase_ascii name,
              Cursor.string_of_components_verbatim ~trim:true args ))
 
-let peek_ident t =
-  match Cursor.peek t with
-  | Some (Component.Preserved { kind = Token.Ident name; _ }) ->
-      Some (String.lowercase_ascii name)
-  | _ -> None
-
 let rec condition t =
   Cursor.ws t;
-  match peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "not" ->
       Cursor.skip t;
       Not (in_parens ~allow_unwrapped_decl:false t)
@@ -423,7 +417,7 @@ let rec condition t =
 
 and chain t op acc =
   Cursor.ws t;
-  match peek_ident t with
+  match Cursor.peek_keyword t with
   | Some "and" ->
       (match op with
       | Some `Or ->

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5229,7 +5229,7 @@ let read_math_constant_or_number t =
    [up], [down], [to-zero]); when omitted the default is [nearest]. *)
 let read_round_strategy inner =
   let snap = Cursor.save inner in
-  match Cursor.peek_ident inner with
+  match Cursor.peek_keyword inner with
   | Some (("nearest" | "up" | "down" | "to-zero") as kw) ->
       Cursor.skip inner;
       Cursor.ws inner;
@@ -6266,7 +6266,7 @@ let read_rgb_comma_separated t : color =
 (** Read color space identifier *)
 let read_color_space t : color_space =
   let space_ident = Cursor.ident t in
-  match space_ident with
+  match Common.String.lowercase_ascii_preserve space_ident with
   | "srgb" -> Srgb
   | "srgb-linear" -> Srgb_linear
   | "display-p3" -> Display_p3

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -2213,6 +2213,67 @@ let spec_keyword_case_insensitive () =
     ~lower:
       ".a{background:-webkit-gradient(linear,left top,left \
        bottom,from(red),color-stop(50%,green),to(blue))}";
+  (* A guard predicate that decides which reader a value goes to reads its ident
+     raw, so sec. 4.1 has to reach the guard and not only the reader behind it.
+     Each of these is a distinct guard. *)
+  pins "touch-action none" ~upper:".a{touch-action:NONE}"
+    ~lower:".a{touch-action:none}" ~expect:".a{touch-action:none}";
+  pins "touch-action manipulation" ~upper:".a{touch-action:MANIPULATION}"
+    ~lower:".a{touch-action:manipulation}"
+    ~expect:".a{touch-action:manipulation}";
+  pins "touch-action CSS-wide keyword" ~upper:".a{touch-action:INHERIT}"
+    ~lower:".a{touch-action:inherit}" ~expect:".a{touch-action:inherit}";
+  pins "text-transform uppercase" ~upper:".a{text-transform:UPPERCASE}"
+    ~lower:".a{text-transform:uppercase}" ~expect:".a{text-transform:uppercase}";
+  agrees "white-space shorthand" ~upper:".a{white-space:PRESERVE NOWRAP}"
+    ~lower:".a{white-space:preserve nowrap}";
+  pins "paint-order stroke" ~upper:".a{paint-order:STROKE}"
+    ~lower:".a{paint-order:stroke}" ~expect:".a{paint-order:stroke}";
+  pins "vector-effect" ~upper:".a{vector-effect:NON-SCALING-STROKE}"
+    ~lower:".a{vector-effect:non-scaling-stroke}"
+    ~expect:".a{vector-effect:non-scaling-stroke}";
+  agrees "display two-keyword form" ~upper:".a{display:LIST-ITEM FLOW-ROOT}"
+    ~lower:".a{display:list-item flow-root}";
+  agrees "align-items baseline qualifier"
+    ~upper:".a{align-items:FIRST BASELINE}"
+    ~lower:".a{align-items:first baseline}";
+  agrees "perspective-origin position keywords"
+    ~upper:".a{perspective-origin:LEFT 10PX TOP 20PX}"
+    ~lower:".a{perspective-origin:left 10px top 20px}";
+  pins "contain-intrinsic-size auto"
+    ~upper:".a{contain-intrinsic-size:AUTO 300PX}"
+    ~lower:".a{contain-intrinsic-size:auto 300px}"
+    ~expect:".a{contain-intrinsic-size:auto 300px}";
+  agrees "aspect-ratio auto" ~upper:".a{aspect-ratio:AUTO 1/1}"
+    ~lower:".a{aspect-ratio:auto 1/1}";
+  pins "text-indent each-line" ~upper:".a{text-indent:2EM EACH-LINE}"
+    ~lower:".a{text-indent:2em each-line}"
+    ~expect:".a{text-indent:2em each-line}";
+  pins "grid repeat()" ~upper:".a{grid-template-columns:REPEAT(3, 1FR)}"
+    ~lower:".a{grid-template-columns:repeat(3, 1fr)}"
+    ~expect:".a{grid-template-columns:repeat(3,1fr)}";
+  pins "grid minmax()" ~upper:".a{grid-auto-rows:MINMAX(0, 1FR)}"
+    ~lower:".a{grid-auto-rows:minmax(0, 1fr)}"
+    ~expect:".a{grid-auto-rows:minmax(0,1fr)}";
+  agrees "color() colour space" ~upper:".a{color:COLOR(DISPLAY-P3 1 0 0)}"
+    ~lower:".a{color:color(display-p3 1 0 0)}";
+  agrees "font shorthand"
+    ~upper:".a{font:ITALIC SMALL-CAPS BOLD 16PX/1.5 SERIF}"
+    ~lower:".a{font:italic small-caps bold 16px/1.5 serif}";
+  pins "scrollbar-gutter modifier"
+    ~upper:".a{scrollbar-gutter:STABLE BOTH-EDGES}"
+    ~lower:".a{scrollbar-gutter:stable both-edges}"
+    ~expect:".a{scrollbar-gutter:stable both-edges}";
+  pins "color-scheme CSS-wide keyword" ~upper:".a{color-scheme:Initial}"
+    ~lower:".a{color-scheme:initial}" ~expect:".a{color-scheme:initial}";
+  pins "border-image-slice CSS-wide keyword"
+    ~upper:".a{border-image-slice:UnSet}" ~lower:".a{border-image-slice:unset}"
+    ~expect:".a{border-image-slice:unset}";
+  agrees "@font-face metric overrides"
+    ~upper:
+      "@font-face{font-family:F;src:url(a.woff);ascent-override:NORMAL;descent-override:NORMAL}"
+    ~lower:
+      "@font-face{font-family:F;src:url(a.woff);ascent-override:normal;descent-override:normal}";
   (* An empty [var()] is invalid regardless of case (CSS Custom Properties 1
      sec. 3); the diagnosis must agree, not just the rejection. *)
   let empty_var_diagnostic input =


### PR DESCRIPTION
CSS Values 4 sec. 4.1 reads a keyword ASCII case-insensitively, and `Cursor.enum` does, but guards standing in front of it compared a raw identifier against lower-case literals, so `touch-action: NONE` never reached the reader whose table would have matched it and was dropped. This PR adds `Cursor.peek_keyword` and converts the guards that read a keyword, leaving the ones that read an author-defined name, which sec. 4.2 keeps case-sensitive.