### PR TITLE
property: refuse a substituted @property initial-value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -257,10 +257,12 @@ to lose a whole rule over one bad piece. Both are gone.
   `range: bogus`, `pad: 3`, `negative: 1` and `fallback: "decimal"` are dropped
   where each was kept as an opaque string, and a counter symbol may be an image
   (#1130)
-- An `@property` syntax rejects a component with two multipliers, a multiplied
-  `<transform-list>` and a `*` combined with anything, so the registration
-  drops rather than typing values by a grammar it cannot honour. Two syntaxes
-  that used to hang the parser are read (#398, #707, #710, #713)
+- An `@property` registration drops rather than typing values by a grammar it
+  cannot honour. Its syntax rejects a component with two multipliers, a
+  multiplied `<transform-list>` and a `*` combined with anything, and its
+  `initial-value` rejects a `var()`, `attr()` or `env()` at any depth, which
+  has nothing to substitute from at registration time. Two syntaxes that used
+  to hang the parser are read (#398, #707, #710, #713, #1142)
 - A bad piece is dropped on its own and the rule around it survives. A nested
   rule, a descriptor, a stray `;`, a margin at-rule, an `@counter-style` with
   no descriptor, an `@media` condition, an `@font-face` descriptor name, an

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3613,9 +3613,24 @@ let css_wide_keyword s =
   | "initial" | "inherit" | "unset" | "revert" | "revert-layer" -> true
   | _ -> false
 
+(* An [initial-value] is registered before any element is styled, so one
+   carrying an arbitrary substitution function has nothing to substitute from
+   and cannot become the value the registration stores. Chrome 153 drops the
+   whole rule at every syntax, the universal one included. That is the revision
+   of Properties and Values API 1 this reader follows throughout, the one that
+   also makes syntax, inherits and a non-universal initial-value required;
+   today's ED sec. 3.3 ignores the descriptor alone instead. Not computational
+   independence, which is sec. 4.1 and binds registerProperty: Chrome keeps
+   [3em] here at the universal syntax. *)
 let read_property_initial_value r syntax str =
   if css_wide_keyword str then
     Cursor.err_invalid r "@property: initial-value cannot be CSS-wide keyword";
+  (match Variables.substitution_fn_in_value_string str with
+  | Some fn ->
+      Cursor.err_invalid r
+        (String.concat ""
+           [ "@property: initial-value cannot contain "; fn; "()" ])
+  | None -> ());
   let value_reader = Cursor.of_string str in
   let value = Variables.read_value value_reader syntax in
   Cursor.ws value_reader;

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -58,14 +58,38 @@ let rec var_refs_in_components acc (components : Component.t list) =
       | Component.Preserved _ -> acc)
     acc components
 
-let var_refs_in_value_string value =
+let components_of_value_string value =
   let p = Parser.of_string value in
   let rec collect acc =
     match Parser.next p with
     | Component.Preserved { Token.kind = Token.Eof; _ } -> List.rev acc
     | c -> collect (c :: acc)
   in
-  var_refs_in_components [] (collect [])
+  collect []
+
+let var_refs_in_value_string value =
+  var_refs_in_components [] (components_of_value_string value)
+
+(* CSS Values 5 calls var(), attr() and env() arbitrary substitution functions:
+   what each stands for is known only while an element is being styled. Walks
+   into arguments and blocks, so one nested in another's fallback still counts,
+   and a [var(] inside a string or url stays an atomic [Preserved] token rather
+   than a [Func], as it does for the reference walk above. *)
+let rec substitution_fn_in_components (components : Component.t list) =
+  List.find_map
+    (fun (c : Component.t) ->
+      match c with
+      | Component.Func { node = { name; arguments; _ }; _ } -> (
+          match String.lowercase_ascii name with
+          | ("var" | "attr" | "env") as fn -> Option.Some fn
+          | _ -> substitution_fn_in_components arguments)
+      | Component.Block { node = { value; _ }; _ } ->
+          substitution_fn_in_components value
+      | Component.Preserved _ -> Option.None)
+    components
+
+let substitution_fn_in_value_string value =
+  substitution_fn_in_components (components_of_value_string value)
 
 (** Pretty-print a syntax descriptor to CSS syntax string *)
 let rec pp_syntax_inner : type a. a syntax Pp.t =

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -25,6 +25,13 @@ val var_refs_in_value_string : string -> string list
     walks them, so a [var(] inside a string or [url()] is recognised as data,
     not a reference - unlike a textual scan. *)
 
+val substitution_fn_in_value_string : string -> string option
+(** [substitution_fn_in_value_string value] is the name of the first arbitrary
+    substitution function ([var()], [attr()] or [env()]) anywhere in [value],
+    including nested in another one's fallback. It parses [value] to components
+    and walks them, so a [var(] inside a string or [url()] is data rather than a
+    call. *)
+
 val pp_syntax : 'a syntax Pp.t
 (** [pp_syntax] pretty-prints a syntax descriptor to a CSS syntax string. *)
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -487,6 +487,63 @@ let test_property_missing_descriptors () =
   check_stylesheet ~expected:"@property --x{syntax:\"*\";inherits:false}"
     "@property --x { syntax: \"*\"; inherits: false }"
 
+(* An [initial-value] carrying var(), attr() or env() has nothing to substitute
+   from at registration time, so Chrome 153 drops the
+   whole rule at every syntax, the universal one included. The values below the
+   substitution cases are the other side of the same filter: they stay readable,
+   including the ones cascade knowingly keeps that Chrome drops for
+   computational independence ([3em] at a non-universal syntax). *)
+(* Not a roundtrip test *)
+let test_property_initial_value_substitution () =
+  let expect_error what syntax value =
+    expect_property_error what
+      (String.concat ""
+         [
+           "@property --x { syntax: \"";
+           syntax;
+           "\"; inherits: false; initial-value: ";
+           value;
+           " }";
+         ])
+  in
+  let substitutions =
+    [
+      "var(--y)";
+      "var(--y, 1px)";
+      "attr(data-x)";
+      "attr(data-x type(<length>))";
+      "env(safe-area-inset-top)";
+      "env(--x, 1px)";
+      "calc(var(--y) + 1px)";
+    ]
+  in
+  List.iter
+    (fun value ->
+      expect_error "substitution at <length>" "<length>" value;
+      expect_error "substitution at universal" "*" value)
+    substitutions;
+  (* A substitution function nested in the fallback of another one still counts,
+     and a [var(] written inside a string is data rather than a reference. *)
+  expect_error "nested substitution" "*" "var(--y, env(safe-area-inset-top))";
+  check_stylesheet
+    ~expected:
+      "@property --x{syntax:\"*\";inherits:false;initial-value:\"var(--y)\"}"
+    "@property --x { syntax: \"*\"; inherits: false; initial-value: \
+     \"var(--y)\" }";
+  check_stylesheet
+    ~expected:
+      "@property --x{syntax:\"<length>\";inherits:false;initial-value:5px}"
+    "@property --x { syntax: \"<length>\"; inherits: false; initial-value: 5px \
+     }";
+  check_stylesheet
+    ~expected:
+      "@property --x{syntax:\"<length>\";inherits:false;initial-value:3em}"
+    "@property --x { syntax: \"<length>\"; inherits: false; initial-value: 3em \
+     }";
+  check_stylesheet
+    ~expected:"@property --x{syntax:\"*\";inherits:false;initial-value:red}"
+    "@property --x { syntax: \"*\"; inherits: false; initial-value: red }"
+
 (* Not a roundtrip test *)
 let test_property_invalid_inherits () =
   expect_property_error "invalid inherits value"
@@ -2468,6 +2525,9 @@ let stylesheet_tests =
     (* Additional property tests *)
     ("property permutations", `Quick, test_property_permutations);
     ("property missing descriptors", `Quick, test_property_missing_descriptors);
+    ( "property initial-value substitution",
+      `Quick,
+      test_property_initial_value_substitution );
     ("property invalid inherits", `Quick, test_property_invalid_inherits);
     ("property unknown descriptor", `Quick, test_property_unknown_descriptor);
     ( "property duplicate descriptors",


### PR DESCRIPTION
An `@property` `initial-value` holding a `var()`, `attr()` or `env()` was kept, where Chrome 153 drops the rule. Such a value has nothing to substitute from at registration time, so it cannot serve as an initial value; the check walks the parsed component stream, so a string spelling `"var(--y)"` and a `url(var.svg)` stay data.