### PR TITLE
cursor: read a <custom-ident> in one place

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -206,6 +206,13 @@ to lose a whole rule over one bad piece. Both are gone.
   `Cascade.Properties.read_border_image_source`
   (#640, #982, #1000, #1001, #1002, #1003, #1004, #1005, #1006, #1007, #1009,
   #1010, #1015, #1077, #1078)
+- A `<custom-ident>` refuses the names CSS Values 4 sec. 4.2 reserves, in every
+  ASCII case permutation, so `animation-name: default`, `counter-reset: DEFAULT`,
+  `view-transition-name: default` and a `default` counter-style symbol are
+  dropped with a warning. The string spelling is untouched, so
+  `animation-name: "default"` still reads. Six productions each carried their
+  own exclusion list, five of which had forgotten `default`; they now share
+  `Cascade.Cursor.custom_ident` (#1143)
 - A property whose grammar names a `<length>` takes neither a percentage nor an
   intrinsic-sizing keyword, and a `<time>` or `<angle>` needs its unit. Cascade
   read them wherever it read a length, so `border-width: 50%`, `top:

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -569,6 +569,21 @@ let ident ?(keep_case = true) t =
   | Some s -> if keep_case then s else String.lowercase_ascii_preserve s
   | None -> err_expected t "identifier"
 
+(* CSS Values 4 sec. 4.2 again: no <custom-ident> is a CSS-wide keyword, and
+   [default] is reserved from every one of them too. The exclusions hold in all
+   ASCII case permutations, which is why the author's spelling is matched
+   folded. *)
+let custom_ident_reserved =
+  [ "default"; "initial"; "inherit"; "unset"; "revert"; "revert-layer" ]
+
+let custom_ident ?(reserved = []) label t =
+  let loc = position t in
+  let name = ident ~keep_case:true t in
+  let folded = String.lowercase_ascii_preserve name in
+  if List.mem folded custom_ident_reserved || List.mem folded reserved then
+    err_invalid ~loc t (String.concat "" [ "reserved "; label; ": "; name ])
+  else name
+
 let number ?(allow_negative = true) t =
   match number_opt t with
   | Some n ->

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -250,6 +250,14 @@ val ident : ?keep_case:bool -> t -> string
     4 sec. 4.2). [~keep_case:false] lowercases it, which is what a keyword is
     (sec. 4.1). *)
 
+val custom_ident : ?reserved:string list -> string -> t -> string
+(** [custom_ident label t] consumes a [<custom-ident>] in the author's spelling
+    and raises on one sec. 4.2 excludes: a CSS-wide keyword or the reserved
+    [default]. [reserved] names what the production excludes on top of those,
+    such as [none] for a [<counter-style-name>]. Every exclusion is matched in
+    all ASCII case permutations, and [label] names the production in the error.
+*)
+
 val number : ?allow_negative:bool -> t -> float
 (** [number t] consumes the next numeric token. *)
 

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -715,10 +715,8 @@ let rec read_view_transition_name (t : Cursor.t) : view_transition_name =
     ]
   in
   let read_name t =
-    let name = Cursor.ident ~keep_case:true t in
-    if String.lowercase_ascii name = "auto" then
-      Cursor.err_invalid t "invalid view-transition-name: auto";
-    (Name name : view_transition_name)
+    (Name (Cursor.custom_ident ~reserved:[ "auto" ] "view-transition-name" t)
+      : view_transition_name)
   in
   (Cursor.enum_or_var "view-transition-name" keywords
      ~var:(fun t ->
@@ -727,14 +725,8 @@ let rec read_view_transition_name (t : Cursor.t) : view_transition_name =
      ~default:read_name t
     : view_transition_name)
 
-let view_transition_class_reserved =
-  [ "none"; "initial"; "inherit"; "unset"; "revert"; "revert-layer" ]
-
 let read_view_transition_class_ident t =
-  let ident = Cursor.ident ~keep_case:true t in
-  if List.mem (String.lowercase_ascii ident) view_transition_class_reserved then
-    Cursor.err_invalid t ("reserved view-transition-class ident: " ^ ident)
-  else ident
+  Cursor.custom_ident ~reserved:[ "none" ] "view-transition-class ident" t
 
 let rec read_view_transition_class t : view_transition_class =
   let keywords : (string * view_transition_class) list =
@@ -1400,7 +1392,7 @@ let rec read_animation_name t : animation_name =
       ~default:(fun t ->
         match Cursor.string_opt t with
         | Some s -> (animation_quoted_or_name s : animation_name)
-        | None -> Name (Cursor.ident t))
+        | None -> Name (Cursor.custom_ident "keyframes name" t))
       t
   in
   Cursor.enum_or_var "animation-name"
@@ -1680,7 +1672,7 @@ module Animation = struct
       | None -> Cursor.err t "expected animation-name string"
     in
     let read_name t =
-      let v = Cursor.ident t in
+      let v = Cursor.custom_ident "keyframes name" t in
       if Option.is_some (animation_shorthand_kind (String.lowercase_ascii v))
       then
         (* This identifier is for another property, not animation-name *)

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -461,27 +461,12 @@ let rec read_container_type (t : Cursor.t) : container_type =
     t
 
 (* CSS Conditional 5 sec. 3.2 excludes [none], [and], [not] and [or] from a
-   container name, and CSS Values 4 sec. 3.2 excludes [default] and the CSS-wide
-   keywords from every [<custom-ident>]. *)
-let container_name_reserved =
-  [
-    "none";
-    "and";
-    "not";
-    "or";
-    "default";
-    "initial";
-    "inherit";
-    "unset";
-    "revert";
-    "revert-layer";
-  ]
-
+   container name, on top of what CSS Values 4 sec. 4.2 excludes from every
+   [<custom-ident>]. *)
 let read_container_custom_ident t =
-  let ident = Cursor.ident ~keep_case:true t in
-  if List.mem (String.lowercase_ascii ident) container_name_reserved then
-    Cursor.err_invalid t ("reserved container-name ident: " ^ ident)
-  else ident
+  Cursor.custom_ident
+    ~reserved:[ "none"; "and"; "not"; "or" ]
+    "container-name ident" t
 
 let rec read_container_name (t : Cursor.t) : container_name =
   let keywords : (string * container_name) list =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2436,10 +2436,8 @@ let rec read_list_style_type t : list_style_type =
            (fun t -> Cursor.call "symbols" t read_symbols_body);
            (fun t -> (String (Cursor.string t) : list_style_type));
            (fun t ->
-             let name = Cursor.ident t in
-             if String.lowercase_ascii name = "default" then
-               Cursor.err_invalid t "reserved counter-style name";
-             (Name name : list_style_type));
+             (Name (Cursor.custom_ident "counter style name" t)
+               : list_style_type));
          ])
     t
 
@@ -2671,14 +2669,10 @@ and read_content t : content =
       then Cursor.err_invalid t "none/normal cannot be combined in content";
       Content_list items
 
-let counter_name_reserved =
-  [ "none"; "inherit"; "initial"; "unset"; "revert"; "revert-layer" ]
-
+(* CSS Lists 3 sec. 2.1 spells a counter name [<custom-ident>] and excludes
+   [none] from it. *)
 let read_counter_name t =
-  let name = Cursor.ident t in
-  if List.mem name counter_name_reserved then
-    Cursor.err_invalid t ("reserved counter name: " ^ name);
-  name
+  Cursor.custom_ident ~reserved:[ "none" ] "counter name" t
 
 let read_counter_item t =
   let name = read_counter_name t in

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2742,7 +2742,7 @@ let read_counter_symbol r =
       | Some (Component.Preserved { kind = Token.Url _; _ }) ->
           Pp.to_string ~minify:true Properties.pp_background_image
             (Properties.read_background_image r)
-      | Some _ | None -> Cursor.ident ~keep_case:true r)
+      | Some _ | None -> Cursor.custom_ident "counter style symbol" r)
 
 let read_counter_symbols_descriptor r =
   read_descriptor_value Declaration.read_property_value
@@ -2766,17 +2766,12 @@ let read_counter_symbol_descriptor constructor r =
       constructor symbol)
     r
 
-(* CSS Counter Styles 3 (ED) sec. 3.7: <counter-style-name> is a <custom-ident>,
-   which CSS Values 4 sec. 4.2 excludes the CSS-wide keywords and [default]
-   from, and sec. 3.7 excludes [none] as well. *)
+(* CSS Counter Styles 3 (ED) sec. 3.7: <counter-style-name> is a <custom-ident>
+   excluding [none], on top of what CSS Values 4 sec. 4.2 excludes from every
+   one of them. Blink 151 refuses [revert-rule] here too, though it takes it as
+   a [list-style-type] name. *)
 let read_counter_style_name c =
-  let name = Cursor.ident ~keep_case:true c in
-  let lower = String.lowercase_ascii name in
-  if
-    Properties.is_css_wide_keyword lower
-    || List.exists (String.equal lower) [ "default"; "none" ]
-  then Cursor.err_invalid c ("reserved counter style name: " ^ name)
-  else name
+  Cursor.custom_ident ~reserved:[ "none"; "revert-rule" ] "counter style name" c
 
 (* Validates the value against the descriptor's grammar and keeps the text: the
    AST carries the authored spelling, and what this adds is the refusal of a
@@ -2942,7 +2937,9 @@ let read_counter_style (r : Cursor.t) : statement =
   Cursor.with_context r "@counter-style" @@ fun () ->
   Cursor.expect_at_keyword "counter-style" r;
   Cursor.ws r;
-  let name = Cursor.ident ~keep_case:true r in
+  (* Sec. 2: the prelude is the same <counter-style-name> the fallback and
+     speak-as descriptors take. *)
+  let name = read_counter_style_name r in
   Cursor.ws r;
   let descriptors =
     read_counter_style_descriptors r

--- a/test/spec/inventory/at_rule_grammar.ml
+++ b/test/spec/inventory/at_rule_grammar.ml
@@ -70,6 +70,11 @@ let positive =
     row "keyframes" "invalid-selector-list-block-dropped" "@keyframes bad{}"
       "@keyframes bad { 50%, { opacity: 1 } from, 120% { opacity: 1 } 50px { \
        opacity: 1 } }";
+    (* CSS Counter Styles 3 sec. 2: the prelude is a <counter-style-name>, so
+       CSS Values 4 sec. 4.2 keeps the reserved [default] out of it. *)
+    row "counter-style" "named-prelude"
+      "@counter-style thumbs{system:cyclic;symbols:\"x\"}"
+      "@counter-style thumbs { system: cyclic; symbols: \"x\" }";
     row "font-palette-values" "duplicate-descriptor"
       "@font-palette-values \
        --brand{font-family:Brand;base-palette:2;override-colors:0 red}"
@@ -154,6 +159,8 @@ let negative =
     invalid "page" "bad-margin-descriptor-value"
       "@page { @top-center { display: 1px } }";
     invalid "keyframes" "missing-block" "@keyframes missing-block";
+    invalid "counter-style" "reserved-prelude"
+      "@counter-style default { system: cyclic; symbols: \"x\" }";
     invalid "font-palette-values" "bad-name"
       "@font-palette-values brand { font-family: Brand; base-palette: 1 }";
     invalid "font-palette-values" "nested-rule"

--- a/test/spec/inventory/descriptor_grammar.ml
+++ b/test/spec/inventory/descriptor_grammar.ml
@@ -102,7 +102,8 @@ let rows =
     row "font-face" "line-gap-override" "sec. 4.9 normal | <percentage [0,inf]>"
       [ "normal"; "0%"; "10%" ] [ "-1%"; "10"; "auto" ];
     (* CSS Counter Styles 3 (ED). <symbol> = <string> | <image> | <custom-ident>
-       (sec. 3.2). *)
+       (sec. 3.2), and CSS Values 4 sec. 4.2 reserves [default] from the ident
+       arm of every one of them, leaving it the string. *)
     row "counter-style" "system"
       "sec. 3.1 cyclic | numeric | alphabetic | symbolic | additive | [fixed \
        <integer>?] | [extends <counter-style-name>]"
@@ -118,25 +119,26 @@ let rows =
       ]
       [ "bogus"; "fixed extends"; "extends" ];
     row "counter-style" "symbols" "sec. 3.2 <symbol>+"
-      [ "\"a\""; "\"a\" \"b\""; "a"; "url(a.png)" ]
-      [ "1"; "\"a\", \"b\"" ];
+      [ "\"a\""; "\"a\" \"b\""; "a"; "url(a.png)"; "\"default\"" ]
+      [ "1"; "\"a\", \"b\""; "default" ];
     row "counter-style" "additive-symbols"
       "sec. 3.3 [<integer [0,inf]> && <symbol>]#"
       [ "3 \"a\""; "\"a\" 3"; "3 \"a\", 1 \"b\"" ]
-      [ "-1 \"a\""; "\"a\""; "3" ];
+      [ "-1 \"a\""; "\"a\""; "3"; "3 default" ];
     row "counter-style" "negative" "sec. 3.4 <symbol> <symbol>?"
       [ "\"-\""; "\"(\" \")\""; "a" ]
-      [ "1"; "\"a\" \"b\" \"c\"" ];
-    row "counter-style" "prefix" "sec. 3.4 <symbol>" [ "\"(\""; "a" ]
-      [ "1"; "\"a\" \"b\"" ];
+      [ "1"; "\"a\" \"b\" \"c\""; "default"; "a default" ];
+    row "counter-style" "prefix" "sec. 3.4 <symbol>"
+      [ "\"(\""; "a"; "\"default\"" ]
+      [ "1"; "\"a\" \"b\""; "default" ];
     row "counter-style" "suffix" "sec. 3.4 <symbol>" [ "\".\""; "a" ]
-      [ "1"; "\"a\" \"b\"" ];
+      [ "1"; "\"a\" \"b\""; "default" ];
     row "counter-style" "range" "sec. 3.5 [[<integer> | infinite]{2}]# | auto"
       [ "auto"; "1 5"; "infinite 5"; "1 infinite"; "1 5, 8 10" ]
       [ "1"; "5 1 3"; "bogus" ];
     row "counter-style" "pad" "sec. 3.6 <integer [0,inf]> && <symbol>"
       [ "3 \"0\""; "\"0\" 3"; "0 \"0\"" ]
-      [ "-1 \"0\""; "3"; "\"0\"" ];
+      [ "-1 \"0\""; "3"; "\"0\""; "3 default" ];
     row "counter-style" "fallback" "sec. 3.7 <counter-style-name>"
       [ "decimal"; "my-style" ] [ "\"decimal\""; "1" ];
     row "counter-style" "speak-as"

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -380,8 +380,10 @@ let matrix =
     };
     {
       (* CSS Animations 1 sec. 3: <keyframes-name> = <custom-ident> | <string>,
-         and the exclusion covers none and the CSS-wide keywords only, so
-         [infinite] names a keyframe set after an iteration count. *)
+         and the only name the section excludes on top of what <custom-ident>
+         already does is none, so [infinite] names a keyframe set after an
+         iteration count. CSS Values 4 sec. 4.2 keeps the reserved [default] out
+         of the ident arm, leaving it the string. *)
       property = "animation";
       positives =
         [
@@ -391,7 +393,7 @@ let matrix =
           "infinite infinite";
           "--x x";
         ];
-      negatives = [ "1s 2s 3s"; "2 3" ];
+      negatives = [ "1s 2s 3s"; "2 3"; "default 1s"; "1s default" ];
     };
     {
       property = "grid-auto-flow";
@@ -429,14 +431,25 @@ let matrix =
       negatives = [ "square disc"; "inside outside outside" ];
     };
     {
+      (* CSS Lists 3 sec. 2.1 spells a counter name [<custom-ident>], so CSS
+         Values 4 sec. 4.2 keeps the reserved [default] out of it in every ASCII
+         case permutation. *)
       property = "counter-reset";
       positives = [ "none"; "section"; "section 2"; "section 2 page -1" ];
-      negatives = [ "none section"; "section 1.5"; "section none" ];
+      negatives =
+        [
+          "none section";
+          "section 1.5";
+          "section none";
+          "default";
+          "DEFAULT";
+          "section default";
+        ];
     };
     {
       property = "counter-increment";
       positives = [ "none"; "section"; "section 2"; "section 2 page -1" ];
-      negatives = [ "none section"; "section 1.5"; "section none" ];
+      negatives = [ "none section"; "section 1.5"; "section none"; "default" ];
     };
     {
       property = "content";
@@ -871,7 +884,7 @@ let matrix =
       {
         property = "list-style-type";
         positives = [ "disc"; "square"; "decimal"; "\"-\"" ];
-        negatives = [ "disc square"; "url(marker.png)" ];
+        negatives = [ "disc square"; "url(marker.png)"; "default" ];
       };
       {
         property = "list-style-position";
@@ -1670,12 +1683,12 @@ let matrix =
       {
         property = "view-transition-name";
         positives = [ "none"; "card"; "match-element" ];
-        negatives = [ "card card"; "auto" ];
+        negatives = [ "card card"; "auto"; "default"; "DEFAULT" ];
       };
       {
         property = "view-transition-class";
         positives = [ "none"; "card"; "card primary" ];
-        negatives = [ "none card"; "card, primary" ];
+        negatives = [ "none card"; "card, primary"; "default"; "card default" ];
       };
       {
         property = "image-orientation";
@@ -1903,7 +1916,8 @@ let matrix =
       {
         property = "animation-name";
         positives = [ "none"; "fade"; "fade, slide" ];
-        negatives = [ "initial fade"; "," ];
+        negatives =
+          [ "initial fade"; ","; "default"; "DEFAULT"; "fade, default" ];
       };
       {
         property = "animation-iteration-count";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3047,9 +3047,13 @@ let list_style_custom_names () =
   (* CSS Lists 3 sections 3.4 and 3.6 allow custom counter-style names,
      including names that collide with an already-filled position slot. The
      referenced counter style need not be defined in this stylesheet. *)
+  (* CSS Values 4 sec. 4.2 reserves [default] from the <custom-ident> arm in
+     every ASCII case permutation, leaving the string spelling. *)
   List.iter
     (fun name -> check_declaration ~roundtrip:true ("list-style-type:" ^ name))
-    [ "footsteps"; "FootSteps"; "inside"; "OUTSIDE"; "--markers" ];
+    [
+      "footsteps"; "FootSteps"; "inside"; "OUTSIDE"; "--markers"; "\"default\"";
+    ];
   List.iter
     (fun (value, expected) ->
       check_declaration ~roundtrip:true ~expected:("list-style:" ^ expected)
@@ -3066,6 +3070,7 @@ let list_style_custom_names () =
     (none_cursor read_declaration)
     [
       "list-style-type:default";
+      "list-style-type:DEFAULT";
       "list-style-type:FootSteps Other";
       "list-style:inside outside outside";
       "list-style:inside FootSteps Other";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1470,6 +1470,34 @@ let font_family_descriptor_grammar () =
   strict_reject "CSS-wide @font-palette-values family"
     "@font-palette-values --brand { font-family: inherit }"
 
+(* CSS Counter Styles 3 (ED) sec. 3.2 spells [<symbol>] as [<string> | <image> |
+   <custom-ident>], and CSS Values 4 sec. 4.2 reserves [default] from every
+   [<custom-ident>], so a symbol descriptor takes the string and refuses the
+   bare ident. Blink 151 drops each of the rejections below. *)
+let counter_style_symbol_reserved_default () =
+  let body rest =
+    "@counter-style c { system: cyclic; symbols: \"a\"; " ^ rest ^ " }"
+  in
+  strict_accept "quoted default as a counter-style prefix"
+    (body "prefix: \"default\"");
+  strict_accept "unreserved ident as a counter-style prefix" (body "prefix: a");
+  strict_accept "quoted default as a counter-style symbol"
+    "@counter-style c { system: cyclic; symbols: \"default\" }";
+  strict_reject "reserved default as a counter-style prefix"
+    (body "prefix: default");
+  strict_reject "reserved default as a counter-style suffix"
+    (body "suffix: default");
+  strict_reject "reserved default as a counter-style negative"
+    (body "negative: default");
+  strict_reject "reserved default as the second counter-style negative"
+    (body "negative: a default");
+  strict_reject "reserved default as a counter-style pad symbol"
+    (body "pad: 3 default");
+  strict_reject "reserved default as a counter-style symbol"
+    "@counter-style c { system: cyclic; symbols: default }";
+  strict_reject "reserved default in counter-style additive-symbols"
+    "@counter-style c { system: additive; additive-symbols: 3 default }"
+
 let lenient_recover name css expected min_warnings =
   let { Css.stylesheet; warnings; _ } =
     match Css.of_string ~strict:false css with
@@ -2549,6 +2577,9 @@ let stylesheet_tests =
       `Quick,
       spec_font_face_descriptor_matrix );
     ("font-family descriptor grammar", `Quick, font_family_descriptor_grammar);
+    ( "counter-style symbol reserves default",
+      `Quick,
+      counter_style_symbol_reserved_default );
     ("spec keyframes selector matrix", `Quick, spec_keyframes_selector_matrix);
     ("spec keyframes shadow colour var", `Quick, spec_keyframes_shadow_color_var);
     ("page", `Quick, page_case);


### PR DESCRIPTION
CSS Values 4 sec. 4.2 reserves `default` alongside the CSS-wide keywords, and `animation-name: default` was written back where every browser rejects it. There was no shared `<custom-ident>` reader: six productions each rolled their own exclusion list, five had forgotten `default`, and three matched their own list case-sensitively. This PR adds `Cursor.custom_ident`, which holds the reserved names once and takes what each production adds.