### PR TITLE
values: keep keywords out of the remaining math operands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,7 +37,10 @@ entry points both moved.
   with a warning where they used to read. `calc(inherit)` was written back as a
   live `inherit`, which changed what the element computed. Sec. 10.2 also
   requires the arguments of `min()`, `max()` and `clamp()` to share a
-  consistent type, so `width: min(0, 1px)` is dropped as well (#1139)
+  consistent type, so `width: min(0, 1px)` is dropped as well. The same holds
+  at `font-size`, `line-height`, `flex-basis`, the opacity family and the
+  `<line-width>` slots, where `border-width: min(0, 1px)` used to fold to `0`
+  (#1139, #1144)
 - The gap decoration, scroll-driven animation and interest properties carry a
   comma-separated list where they carried a single value, one entry per rule
   line or per timeline, so `column-rule: 1px solid red, 2px dashed blue` and

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1463,6 +1463,15 @@ let read_length_as_border_width ?(allow_negative = false) t =
 let rec read_border_width_in_math t : border_width =
   read_border_width_with ~keywords:false ~allow_negative:true t
 
+(* CSS Values 4 sec. 10.2 requires the arguments of [min()], [max()] and
+   [clamp()] to "have a consistent type or else the function is invalid", and
+   sec. 10.9 gives a unitless zero inside a math function the [<number>] type.
+   Without the check [min(0,1px)] folded to [0] rather than dropping. *)
+and read_math_arg t =
+  let expr = read_calc_expr read_border_width_in_math t in
+  validate_calc_type t `Value expr;
+  expr
+
 and read_border_width_with ?(keywords = true) ~allow_negative t : border_width =
   let read_var t : border_width =
     Var (read_var (read_border_width_with ~keywords ~allow_negative) t)
@@ -1470,7 +1479,6 @@ and read_border_width_with ?(keywords = true) ~allow_negative t : border_width =
   let read_calc t : border_width =
     Calc (read_calc ~result_type:`Value read_border_width_in_math t)
   in
-  let read_math_arg t = read_calc_expr read_border_width_in_math t in
   let read_min t : border_width =
     Min
       (Cursor.call "min" t

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -450,14 +450,11 @@ let rec read_opacity_dim_only t : opacity =
          [read_calc] falls through to its own [Num] path. *)
       (fun t -> (Opacity_number (Cursor.pct t /. 100.) : opacity));
       (fun t ->
+        (* CSS Values 4 sec. 10.8 gives an operand no keyword, so the CSS-wide
+           keywords are left out and [calc(inherit)] fails the way the browser
+           drops it rather than unwrapping to a live [inherit]. *)
         Cursor.enum_or_calls "opacity"
-          [
-            ("inherit", (Inherit : opacity));
-            ("initial", Initial);
-            ("unset", Unset);
-            ("revert", Revert);
-            ("revert-layer", Revert_layer);
-          ]
+          ([] : (string * opacity) list)
           ~calls:[ ("var", fun t -> Var (read_var read_opacity_dim_only t)) ]
           ~default:(fun t ->
             Cursor.err_expected t "opacity (var/calc inside calc)")
@@ -530,14 +527,9 @@ let rec read_threshold_dim_only t : shape_image_threshold =
     [
       (fun t -> (Number (Cursor.pct t /. 100.) : shape_image_threshold));
       (fun t ->
+        (* Sec. 10.8 again: no keyword is a [<calc-value>]. *)
         Cursor.enum_or_calls "shape-image-threshold"
-          [
-            ("inherit", (Inherit : shape_image_threshold));
-            ("initial", Initial);
-            ("unset", Unset);
-            ("revert", Revert);
-            ("revert-layer", Revert_layer);
-          ]
+          ([] : (string * shape_image_threshold) list)
           ~calls:
             [
               ("var", fun t -> Var (Values.read_var read_threshold_dim_only t));

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -598,27 +598,38 @@ let flex_basis_of_length t (length : length) : flex_basis =
   | Dimension { value; unit; repr } -> Dimension { value; unit; repr }
   | _ -> Cursor.err_invalid t "unsupported flex-basis value"
 
-let rec read_flex_basis t : flex_basis =
+(* CSS Values 4 sec. 10.8 gives an operand no keyword: [auto], [content], the
+   intrinsic sizes and the CSS-wide keywords are not [<calc-value>]s, so
+   [keywords] is off here and [calc(auto)] fails the way the browser drops
+   it. *)
+let rec read_flex_basis_in_math t : flex_basis =
+  read_flex_basis_with ~keywords:false t
+
+and read_flex_basis_with ?(keywords = true) t : flex_basis =
   Cursor.enum_or_calls "flex-basis"
-    [
-      ("auto", (Auto : flex_basis));
-      ("content", Content);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
+    (if keywords then
+       [
+         ("auto", (Auto : flex_basis));
+         ("content", Content);
+         ("inherit", Inherit);
+         ("initial", Initial);
+         ("unset", Unset);
+         ("revert", Revert);
+         ("revert-layer", Revert_layer);
+       ]
+     else [])
     ~calls:
       [
-        ("var", fun t -> Var (read_var read_flex_basis t));
-        ("calc", fun t -> Calc (read_calc ~result_type:`Value read_flex_basis t));
+        ("var", fun t -> Var (read_var (read_flex_basis_with ~keywords) t));
+        ( "calc",
+          fun t ->
+            Calc (read_calc ~result_type:`Value read_flex_basis_in_math t) );
       ]
       (* CSS Flexbox 1 sec. 7.2.3 reads the basis as a [<'width'>], so it takes
          the intrinsic sizes the box sizes take. *)
     ~default:(fun t ->
       let size t =
-        read_length ~allow_negative:false ~sizing:true t
+        read_length ~allow_negative:false ~sizing:true ~with_keywords:keywords t
         |> flex_basis_of_length t
       in
       let pos = Cursor.save t in
@@ -629,6 +640,8 @@ let rec read_flex_basis t : flex_basis =
           size t
       | None -> size t)
     t
+
+let read_flex_basis t : flex_basis = read_flex_basis_with t
 
 module Flex = struct
   (* Helper functions for flex parsing *)

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -104,10 +104,18 @@ let rec read_font_style t : font_style =
           Oblique_range (first, second))
     t
 
-let rec read_font_size t : font_size =
-  let read_var t : font_size = Var (read_var read_font_size t) in
+(* CSS Values 4 sec. 10.8 gives an operand no keyword: the absolute and relative
+   sizes and the CSS-wide keywords are not [<calc-value>]s, so [keywords] is off
+   here and [calc(medium)] fails the way the browser drops it. *)
+let rec read_font_size_in_math t : font_size =
+  read_font_size_with ~keywords:false t
+
+and read_font_size_with ?(keywords = true) t : font_size =
+  let read_var t : font_size =
+    Var (read_var (read_font_size_with ~keywords) t)
+  in
   let read_calc t : font_size =
-    Calc (read_calc ~result_type:`Value read_font_size t)
+    Calc (read_calc ~result_type:`Value read_font_size_in_math t)
   in
   let read_length t : font_size =
     let len = read_non_negative_length ~with_keywords:false t in
@@ -119,29 +127,33 @@ let rec read_font_size t : font_size =
     Pct n
   in
   Cursor.enum_or_calls "font-size"
-    [
-      ("xx-small", (Xx_small : font_size));
-      ("x-small", X_small);
-      ("small", Small);
-      ("medium", Medium);
-      ("large", Large);
-      ("x-large", X_large);
-      ("xx-large", Xx_large);
-      ("xxx-large", Xxx_large);
-      ("larger", Larger);
-      ("smaller", Smaller);
-      ("math", Math);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
+    (if keywords then
+       [
+         ("xx-small", (Xx_small : font_size));
+         ("x-small", X_small);
+         ("small", Small);
+         ("medium", Medium);
+         ("large", Large);
+         ("x-large", X_large);
+         ("xx-large", Xx_large);
+         ("xxx-large", Xxx_large);
+         ("larger", Larger);
+         ("smaller", Smaller);
+         ("math", Math);
+         ("inherit", Inherit);
+         ("initial", Initial);
+         ("unset", Unset);
+         ("revert", Revert);
+         ("revert-layer", Revert_layer);
+       ]
+     else [])
     ~calls:[ ("var", read_var); ("calc", read_calc) ]
     ~default:(fun t ->
       (* Try percentage first, then length *)
       Cursor.one_of [ read_pct; read_length ] t)
     t
+
+let read_font_size t : font_size = read_font_size_with t
 
 let rec pp_font_optical_sizing : font_optical_sizing Pp.t =
  fun ctx -> function
@@ -1460,7 +1472,10 @@ let rec pp_font : font Pp.t =
 
 (* CSS Values 4 sec. 10.12: a math function is valid wherever its type is, and
    the [0,inf] range of sec. 5.1 is checked on the value it resolves to, not on
-   each operand, so [calc(-10%)] reads where a literal [-10%] does not. *)
+   each operand, so [calc(-10%)] reads where a literal [-10%] does not. Sec.
+   10.8 gives an operand no keyword, so [normal] and the CSS-wide keywords are
+   left out and [calc(normal)] fails the way the browser drops it; the unitless
+   [<number>] of sec. 5.1 is a [<calc-value>] and [calc(1.5)] still reads. *)
 let rec read_line_height_in_math t : line_height =
   let read_var t : line_height = Var (read_var read_line_height_in_math t) in
   let read_calc t : line_height =
@@ -1468,15 +1483,7 @@ let rec read_line_height_in_math t : line_height =
       (read_calc ~result_type:`Number_or_value read_line_height_in_math t
       |> numeric_line_height_calc_leaves)
   in
-  Cursor.enum_or_calls "line-height"
-    [
-      ("normal", Normal);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
+  Cursor.enum_or_calls "line-height" []
     ~calls:[ ("var", read_var); ("calc", read_calc) ]
     ~default:(read_line_height_length ~allow_negative:true)
     t

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -666,6 +666,15 @@ val read_calc_expr : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
 (** [read_calc_expr read t] parses a calc expression body -- the contents of a
     [calc(...)] form without the surrounding [calc(] and [)]. *)
 
+val validate_calc_type :
+  Cursor.t -> [ `Number | `Number_or_value | `Value ] -> 'a calc -> unit
+(** [validate_calc_type t result_type calc] raises unless [calc] infers to
+    [result_type], the check CSS Values 4 sec. 10.9 makes on a calculation's
+    type. {!val-read_calc} runs it for a whole [calc()]; a caller reading the
+    arguments of [min()], [max()] or [clamp()] with {!val-read_calc_expr} runs
+    it per argument, which is what sec. 10.2 asks for when it requires them to
+    "have a consistent type or else the function is invalid". *)
+
 val eval_numeric_calc : 'a calc -> float option
 (** [eval_numeric_calc calc] tries to evaluate a calc expression containing only
     numbers to a float. Returns [None] if the expression contains variables or

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3542,12 +3542,82 @@ let invalid () =
   neg "border-width: calc(thick)";
   neg "outline-width: calc(thin)";
   neg "outline-width: min(thin,1px)";
+  (* The same rule over the properties that hand their own value reader to the
+     calc leaf: the sizing keywords of [flex-basis] and [flex], the absolute
+     sizes of [font-size], the [normal] of [line-height] and the CSS-wide
+     keywords all five [<opacity-value>] properties take. *)
+  neg "flex-basis: calc(auto)";
+  neg "flex-basis: calc(content)";
+  neg "flex-basis: calc(min-content)";
+  neg "flex-basis: calc(1px + initial)";
+  neg "flex: calc(auto)";
+  neg "flex: calc(content)";
+  neg "flex: calc(inherit)";
+  neg "flex: calc(1px + initial)";
+  neg "font-size: calc(inherit)";
+  neg "font-size: calc(1px + initial)";
+  neg "line-height: calc(normal)";
+  neg "line-height: calc(inherit)";
+  neg "line-height: calc(1px + initial)";
+  neg "opacity: calc(inherit)";
+  neg "fill-opacity: calc(inherit)";
+  neg "flood-opacity: calc(inherit)";
+  neg "stop-opacity: calc(inherit)";
+  neg "stroke-opacity: calc(inherit)";
+  neg "shape-image-threshold: calc(inherit)";
+  (* A keyword operand is no more valid for being arithmetic: sec. 10.9 fails
+     the whole calculation's type, not just the bare-keyword spelling. *)
+  neg "font-size: calc(medium)";
+  neg "font-size: calc(2 * medium)";
+  neg "font-size: calc(medium * 2)";
+  neg "font-size: calc(medium / 2)";
+  neg "font-size: calc(medium + 0px)";
+  neg "font-size: calc(medium + 1em)";
+  neg "font-size: calc((medium) + (1px))";
+  (* Each keyword still reads on its own, and a well-typed operand still folds:
+     [line-height] takes a unitless [<number>], so [calc(1.5)] stays valid where
+     [calc(normal)] does not. *)
+  check ~expected:"flex-basis:auto" "flex-basis: auto";
+  check ~expected:"flex-basis:content" "flex-basis: content";
+  check ~expected:"flex-basis:min-content" "flex-basis: min-content";
+  check ~expected:"font-size:medium" "font-size: medium";
+  check ~expected:"font-size:inherit" "font-size: inherit";
+  check ~expected:"line-height:normal" "line-height: normal";
+  check ~expected:"line-height:1.5" "line-height: calc(1.5)";
+  check ~expected:"flex-basis:calc(50% - 10px)" "flex-basis: calc(50% - 10px)";
+  check ~expected:"opacity:inherit" "opacity: inherit";
+  check ~expected:"opacity:.5" "opacity: 0.5";
+  check ~expected:"fill-opacity:.5" "fill-opacity: 50%";
 
   (* CSS Values 4 sec. 10.2: the arguments of [min()] / [max()] / [clamp()]
      "must have a consistent type or else the function is invalid", and sec.
      10.9 gives a unitless zero inside a math function the [<number>] type. *)
   neg "width: min(0,1px)";
   neg "width: clamp(0px,0,100px)";
+  (* [<line-width>] runs the same check: without it a mistyped argument folds to
+     a wrong value rather than dropping, so [min(0,1px)] became [0]. The
+     longhands, the shorthands that carry one and a nested math argument all
+     read through the same leaf. *)
+  neg "border-width: min(0,1px)";
+  neg "border-width: max(0,1px)";
+  neg "outline-width: clamp(0px,0,3px)";
+  neg "column-rule-width: min(1,1px)";
+  neg "column-rule-width: clamp(0px,1,100px)";
+  neg "column-rule-width: calc(min(1,1px) + max(1px,2px))";
+  neg "-webkit-text-stroke-width: min(1,1px)";
+  neg "-webkit-text-stroke-width: clamp(0px,1,100px)";
+  neg "outline: min(0,1px) solid red";
+  neg "border-right: min(0,1px) solid red";
+  neg "border-inline-end: min(0,1px) solid red";
+  neg "outline: calc(min(0,1px) + max(1px,2px)) solid red";
+  check ~expected:"border-width:min(1px,2em)" "border-width: min(1px,2em)";
+  check ~expected:"column-rule-width:min(1px,2em)"
+    "column-rule-width: min(1px,2em)";
+  check ~expected:"-webkit-text-stroke-width:2px"
+    "-webkit-text-stroke-width: 2px";
+  check ~expected:"outline:min(1px,2em) solid red"
+    "outline: min(1px,2em) solid red";
+  check ~expected:"border-right:1px solid red" "border-right: 1px solid red";
 
   (* CSS Sizing 3 sec. 5 gives the intrinsic sizes to the sizing properties, so
      a property reading a plain length does not take them. Chrome 146 refuses


### PR DESCRIPTION
Follow-up to #1139, which fixed the length family and left the same shape at the other readers. `font-size: calc(inherit)` was written back as a live `inherit`, and `border-width: min(0, 1px)` folded to `0` rather than being dropped, because that reader validated no type at all. The opacity family leaked through `read_opacity_dim_only`, whose name means "no bare unitless number" and never meant "no keywords".