### PR TITLE
values: read a math function where calc() reads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,13 +24,16 @@ entry points both moved.
 
 ### Breaking
 
-- A math function reads wherever the grammar names a number, an integer or a
-  percentage, so `font-weight: calc(400)`, `zoom: calc(.5)`,
-  `border-image-slice: calc(10%)` and `grid-row-start: calc(2) center` read
-  where they were dropped. `Cascade.Properties.font_weight`,
+- A math function reads wherever the grammar allows its type, with no `calc()`
+  wrapper needed, so `font-weight: calc(400)`, `zoom: calc(.5)`,
+  `grid-row-start: calc(2) center`, `width: abs(-1px)`, `opacity: pow(2, 3)`
+  and `border-top-width: hypot(3px, 4px)` read where they were dropped. CSS
+  Values 4 sec. 10.6 gives `abs()` the type of its input and `sign()` a
+  `<number>` whatever goes in, so `width: sign(-1px)` is dropped where
+  `opacity: sign(-1px)` reads. `Cascade.Properties.font_weight`,
   `webkit_line_clamp`, `zoom`, `border_image_slice_item` and
   `shape_image_threshold` gain `Calc`, and `grid_line` gains `Calc_name`
-  (#1072, #1086, #1124, #1125, #1126)
+  (#1072, #1086, #1124, #1125, #1126, #1145)
 - A math function takes only the operands CSS Values 4 sec. 10.8 grants, so
   `width: calc(inherit)`, `height: calc(auto)`, `border-width: calc(medium)`,
   `width: calc(fit-content(20rem))` and `width: min(unset, 1px)` are dropped

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1413,7 +1413,6 @@ module Length = struct
       | Values.Hypot values ->
           Values.Hypot (List.map (simplify ~visited) values)
       | Values.Abs value -> Values.Abs (simplify ~visited value)
-      | Values.Sign value -> Values.Sign (simplify ~visited value)
       | Values.Calc_size (basis, calc) ->
           Values.Calc_size (simplify ~visited basis, simplify_calc ~visited calc)
       | Values.Anchor (name, side, fallback) ->
@@ -2142,13 +2141,7 @@ let simplify_opacity ?layer_order ?layer cascade value =
     | Properties.Opacity_number n -> Some n
     | _ -> None
   in
-  let simplify_leaf simplify _simplify_calc ~visited (leaf : Properties.opacity)
-      : Properties.opacity =
-    match leaf with
-    | Abs value -> Abs (simplify ~visited value)
-    | Sign value -> Sign (simplify ~visited value)
-    | value -> value
-  in
+  let simplify_leaf _simplify _simplify_calc ~visited:_ value = value in
   let ops : Properties.opacity Calc_residual.ops =
     let of_number n = Properties.Opacity_number n in
     {

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -907,7 +907,6 @@ type length = Values.length =
   | Rem_fn of length * length  (** CSS [rem()] math function *)
   | Hypot of length list  (** CSS [hypot()] math function *)
   | Abs of length  (** CSS [abs()] math function *)
-  | Sign of length  (** CSS [sign()] math function *)
   | Calc_size of length * length calc  (** CSS [calc-size()] function *)
   | Anchor_size of string
       (** CSS [anchor-size()] function, from
@@ -2005,8 +2004,6 @@ type z_index = Properties.z_index =
 type opacity = Properties.opacity =
   | Opacity_number of float
   | Calc of opacity calc
-  | Abs of opacity  (** [abs(<opacity>)] *)
-  | Sign of opacity  (** [sign(<opacity>)] *)
   | Inherit
   | Initial
   | Unset

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -763,6 +763,13 @@ let looking_at_func name t =
       String.lowercase_ascii_preserve n = name
   | _ -> false
 
+let peek_function_name t =
+  drop_ws t;
+  match t.cvs with
+  | Component.Func { node = { name; _ }; _ } :: _ ->
+      Some (String.lowercase_ascii_preserve name)
+  | _ -> None
+
 let looking_at_calc t =
   looking_at_func "calc" t || looking_at_func "-webkit-calc" t
 

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -476,6 +476,11 @@ val looking_at_calc : t -> bool
 (** [looking_at_calc t] is [true] if the next component is [calc()] or the
     legacy [-webkit-calc()] spelling. *)
 
+val peek_function_name : t -> string option
+(** [peek_function_name t] is the name of the function call the cursor is on,
+    lowercased (CSS Values 4 sec. 4.1), without consuming it. Use it where the
+    caller decides on a set of names rather than on one. *)
+
 (** {1 Expectations} *)
 
 val expect : char -> t -> unit

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1511,13 +1511,9 @@ and read_border_width_with ?(keywords = true) ~allow_negative t : border_width =
        ]
      else [])
     ~calls:
-      [
-        ("var", read_var);
-        ("calc", read_calc);
-        ("min", read_min);
-        ("max", read_max);
-        ("clamp", read_clamp);
-      ]
+      (("var", read_var) :: ("calc", read_calc) :: ("min", read_min)
+     :: ("max", read_max) :: ("clamp", read_clamp)
+      :: Values.typed_math_function_calls read_calc)
     ~default:(read_length_as_border_width ~allow_negative)
     t
 
@@ -2373,14 +2369,16 @@ let read_border_image_slice_item t : border_image_slice_item =
   | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
   | None ->
       (* The number side reads its own math; a percentage one reaches the second
-         arm only because [read_border_image_number] refuses it. *)
+         arm only because [read_border_image_number] refuses it. Sec. 6.2 spells
+         the slot [<number> | <percentage>] with no length in it, so a call
+         answering its arguments' type stands here only as a percentage. *)
       Cursor.one_of
         [
           (fun t ->
             (Number (read_border_image_number t) : border_image_slice_item));
           (fun t ->
             Calc
-              (Values.read_calc ~result_type:`Number_or_value
+              (Values.read_calc ~result_type:`Number_or_percentage
                  read_slice_percentage_leaf t));
         ]
         t

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -427,8 +427,6 @@ let rec pp_opacity : opacity Pp.t =
  fun ctx -> function
   | Opacity_number f -> Pp.float ctx f
   | Calc c -> pp_calc pp_opacity ctx c
-  | Abs v -> Pp.call "abs" pp_opacity ctx v
-  | Sign v -> Pp.call "sign" pp_opacity ctx v
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -465,7 +463,7 @@ let rec read_opacity_dim_only t : opacity =
 let rec read_opacity t : opacity =
   let read_var t : opacity = Var (read_var read_opacity t) in
   let read_numeric_math t : opacity =
-    Opacity_number (Values.read_numeric_expression t)
+    Opacity_number (Values.read_number_percentage_expression t)
   in
   let read_number_or_percentage t =
     let n, unit = Cursor.number_with_unit t in
@@ -486,25 +484,13 @@ let rec read_opacity t : opacity =
       ("revert-layer", Revert_layer);
     ]
     ~calls:
-      [
-        ("var", read_var);
-        ( "calc",
-          fun t ->
-            Calc
-              (Values.read_calc ~result_type:`Number_or_value
-                 read_opacity_dim_only t) );
-        ("min", read_numeric_math);
-        ("max", read_numeric_math);
-        ("clamp", read_numeric_math);
-        ( "abs",
-          fun t ->
-            Cursor.call "abs" t (fun inner ->
-                (Abs (read_opacity inner) : opacity)) );
-        ( "sign",
-          fun t ->
-            Cursor.call "sign" t (fun inner ->
-                (Sign (read_opacity inner) : opacity)) );
-      ]
+      (("var", read_var)
+      :: ( "calc",
+           fun t ->
+             Calc
+               (Values.read_calc ~result_type:`Number_or_percentage
+                  read_opacity_dim_only t) )
+      :: Values.math_function_calls read_numeric_math)
     ~default:read_number_or_percentage t
 
 let rec pp_shape_image_threshold : shape_image_threshold Pp.t =
@@ -543,7 +529,7 @@ let rec read_shape_image_threshold t : shape_image_threshold =
     Var (read_var read_shape_image_threshold t)
   in
   let read_numeric_math t : shape_image_threshold =
-    Number (Values.read_numeric_expression t)
+    Number (Values.read_number_percentage_expression t)
   in
   (* CSS Shapes 1 sec. 6.2 takes an [<opacity-value>], which CSS Color 4 spells
      [<number> | <percentage>], and computes it "clamped to the range [0,1]":
@@ -564,17 +550,13 @@ let rec read_shape_image_threshold t : shape_image_threshold =
       ("revert-layer", Revert_layer);
     ]
     ~calls:
-      [
-        ("var", read_var);
-        ( "calc",
-          fun t ->
-            Calc
-              (Values.read_calc ~result_type:`Number_or_value
-                 read_threshold_dim_only t) );
-        ("min", read_numeric_math);
-        ("max", read_numeric_math);
-        ("clamp", read_numeric_math);
-      ]
+      (("var", read_var)
+      :: ( "calc",
+           fun t ->
+             Calc
+               (Values.read_calc ~result_type:`Number_or_percentage
+                  read_threshold_dim_only t) )
+      :: Values.math_function_calls read_numeric_math)
     ~default:read_number t
 
 let rec pp_overflow : overflow Pp.t =
@@ -922,7 +904,9 @@ let rec read_z_index t : z_index =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("calc", read_calc_z); ("var", read_var_z) ]
+    ~calls:
+      (("calc", read_calc_z) :: ("var", read_var_z)
+      :: Values.math_function_calls read_calc_z)
     ~default:(fun t -> (Index (Cursor.int t) : z_index))
     t
 
@@ -1187,7 +1171,9 @@ let rec read_zoom (t : Cursor.t) : zoom =
         | None ->
             Cursor.err_invalid t "expected a number or percentage for zoom")
   in
-  let read_numeric_math t : zoom = Num (Values.read_numeric_expression t) in
+  let read_numeric_math t : zoom =
+    Num (Values.read_number_percentage_expression t)
+  in
   Cursor.enum_or_calls "zoom"
     [
       ("normal", (Normal : zoom));
@@ -1199,17 +1185,13 @@ let rec read_zoom (t : Cursor.t) : zoom =
       ("revert-layer", Revert_layer);
     ]
     ~calls:
-      [
-        ("var", fun t -> Var (Values.read_var read_zoom t));
-        ( "calc",
-          fun t ->
-            Calc
-              (Values.read_calc ~result_type:`Number_or_value read_zoom_dim_only
-                 t) );
-        ("min", read_numeric_math);
-        ("max", read_numeric_math);
-        ("clamp", read_numeric_math);
-      ]
+      (("var", fun t -> Var (Values.read_var read_zoom t))
+      :: ( "calc",
+           fun t ->
+             Calc
+               (Values.read_calc ~result_type:`Number_or_percentage
+                  read_zoom_dim_only t) )
+      :: Values.math_function_calls read_numeric_math)
     ~default:read_value t
 
 let read_object_view_box_inset t =

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -330,7 +330,9 @@ let rec read_order t : order =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("calc", read_calc_order); ("var", read_var) ]
+    ~calls:
+      (("calc", read_calc_order) :: ("var", read_var)
+      :: Values.math_function_calls read_calc_order)
     ~default:(fun t -> (Int (Cursor.int t) : order))
     t
 
@@ -479,6 +481,15 @@ let rec read_flex_factor t : flex_factor =
   let read_number t =
     (Number (read_non_negative_flex_number t) : flex_factor)
   in
+  (* A bare call carries no [calc()] wrapper for a printer to put back, so one
+     that folds to a factor the literal grammar takes is that factor. CSS Values
+     4 sec. 10.12 keeps a call whose value leaves the [0,inf] range instead of
+     invalidating it, and only the call round-trips. *)
+  let read_math t : flex_factor =
+    match read_calc ~result_type:`Number read_flex_factor t with
+    | Num n when n >= 0. -> Number n
+    | expr -> Calc expr
+  in
   Cursor.enum_or_calls "flex factor"
     [
       ("inherit", (Inherit : flex_factor));
@@ -488,11 +499,9 @@ let rec read_flex_factor t : flex_factor =
       ("revert-layer", Revert_layer);
     ]
     ~calls:
-      [
-        ("var", fun t -> Var (Values.read_var read_flex_factor t));
-        ( "calc",
-          fun t -> Calc (read_calc ~result_type:`Number read_flex_factor t) );
-      ]
+      (("var", fun t -> Var (Values.read_var read_flex_factor t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:read_number t
 
 let flex_basis_of_length t (length : length) : flex_basis =
@@ -653,12 +662,12 @@ module Flex = struct
     | basis -> Basis basis
 
   let read_factor t : flex_factor =
-    (* A flex factor is a [<number>]: a [var()], a [calc()] (held unfolded; the
-       optimize+minify pass folds a constant calc to a literal), or a literal
+    (* A flex factor is a [<number>]: a [var()], a math function (held unfolded;
+       the optimize+minify pass folds a constant one to a literal), or a literal
        number. *)
     if Cursor.looking_at_func "var" t then Var (read_var read_flex_factor t)
-    else if Cursor.looking_at_func "calc" t then
-      Calc (read_calc ~result_type:`Number read_flex_factor t)
+    else if Cursor.looking_at_func "calc" t || Values.looking_at_math_function t
+    then Calc (read_calc ~result_type:`Number read_flex_factor t)
     else Number (read_non_negative_flex_number t)
 
   let read_grow_shrink_basis t =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -46,6 +46,15 @@ let rec numeric_line_height_calc_leaves : line_height calc -> line_height calc =
 
 let rec read_font_weight t : font_weight =
   let read_var t : font_weight = Var (read_var read_font_weight t) in
+  (* A bare call carries no [calc()] wrapper for a printer to put back, so one
+     that folds to a weight the literal grammar takes is that weight. CSS Values
+     4 sec. 10.12 keeps a call whose value leaves [1,1000] instead of
+     invalidating it, and only the call round-trips. *)
+  let read_math t : font_weight =
+    match read_calc ~result_type:`Number read_font_weight t with
+    | Num n when n >= 1. && n <= 1000. -> Weight n
+    | expr -> Calc expr
+  in
   Cursor.ws t;
   Cursor.enum_or_calls "font-weight"
     [
@@ -59,15 +68,13 @@ let rec read_font_weight t : font_weight =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
+    (* CSS Values 4 sec. 10.1 allows a math function wherever a [<number>] is
+       allowed, [calc()] being one of them rather than the gate to the rest. One
+       that folds to a constant becomes that weight and is range-checked with
+       it; one that does not stays a calc. *)
     ~calls:
-      [
-        ("var", read_var);
-        (* CSS Values 4 sec. 10 allows a math function wherever a [<number>] is
-           allowed. One that folds to a constant becomes that weight and is
-           range-checked with it; one that does not stays a calc. *)
-        ( "calc",
-          fun t -> Calc (read_calc ~result_type:`Number read_font_weight t) );
-      ]
+      (("var", read_var) :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:(fun t ->
       let weight = Cursor.number t in
       if weight >= 1. && weight <= 1000. then (Weight weight : font_weight)
@@ -1476,6 +1483,15 @@ let rec pp_font : font Pp.t =
    10.8 gives an operand no keyword, so [normal] and the CSS-wide keywords are
    left out and [calc(normal)] fails the way the browser drops it; the unitless
    [<number>] of sec. 5.1 is a [<calc-value>] and [calc(1.5)] still reads. *)
+(* A bare call carries no [calc()] wrapper for a printer to put back, so one
+   that folds to a factor the literal grammar takes is that factor. CSS Values 4
+   sec. 10.12 keeps a call whose value leaves the [0,inf] range of sec. 5.1
+   instead of invalidating it, and only the call round-trips. *)
+let read_bare_math read t : line_height =
+  match (read t : line_height) with
+  | Calc (Num n) when n >= 0. -> Num n
+  | value -> value
+
 let rec read_line_height_in_math t : line_height =
   let read_var t : line_height = Var (read_var read_line_height_in_math t) in
   let read_calc t : line_height =
@@ -1484,7 +1500,9 @@ let rec read_line_height_in_math t : line_height =
       |> numeric_line_height_calc_leaves)
   in
   Cursor.enum_or_calls "line-height" []
-    ~calls:[ ("var", read_var); ("calc", read_calc) ]
+    ~calls:
+      (("var", read_var) :: ("calc", read_calc)
+      :: Values.math_function_calls (read_bare_math read_calc))
     ~default:(read_line_height_length ~allow_negative:true)
     t
 
@@ -1504,7 +1522,9 @@ let rec read_line_height t : line_height =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("var", read_var); ("calc", read_calc) ]
+    ~calls:
+      (("var", read_var) :: ("calc", read_calc)
+      :: Values.math_function_calls (read_bare_math read_calc))
     ~default:read_line_height_length t
 
 let rec read_font_palette (t : Cursor.t) : font_palette =

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -784,10 +784,11 @@ let read_grid_line_name_value t : grid_line =
       Cursor.ws t;
       if grid_line_at_end t then Name name
       else
-        (* CSS Values 4 sec. 10 allows a math function wherever an [<integer>]
-           is allowed, so the index of a named line may be one. *)
+        (* CSS Values 4 sec. 10.1 allows a math function wherever an [<integer>]
+           is allowed, so the index of a named line may be one, and [calc()] is
+           one such function rather than the gate to the rest. *)
         let index t =
-          if Cursor.looking_at_calc t then
+          if Cursor.looking_at_calc t || Values.looking_at_math_function t then
             match read_integer_calc "grid-line" t with
             | `Int n -> Num_name (check_grid_line_index t n, name)
             | `Calc expr -> Calc_name (expr, name)
@@ -817,10 +818,9 @@ let rec read_grid_line t : grid_line =
   Cursor.enum_or_calls "grid-line"
     [ ("auto", (Auto : grid_line)) ]
     ~calls:
-      [
-        ("calc", read_grid_line_calc);
-        ("var", fun t -> (Var (Values.read_var read_grid_line t) : grid_line));
-      ]
+      (("calc", read_grid_line_calc)
+      :: ("var", fun t -> (Var (Values.read_var read_grid_line t) : grid_line))
+      :: Values.math_function_calls read_grid_line_calc)
     ~default:(fun t ->
       (* The span form is tried first: it is the only alternative that reads a
          trailing [span], and the other two match its group on their own and

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -328,8 +328,8 @@ let is_plain_length (l : length) =
      grammar holds. A math function reaches here only once [length_only] has had
      it, so its own type is settled. *)
   | Zero | Clamp _ | Min _ | Max _ | Minmax _ | Round _ | Mod _ | Rem_fn _
-  | Hypot _ | Abs _ | Sign _ | Calc_size _ | Anchor_size _ | Anchor _ | Attr _
-  | Env _ | Var _ | Calc _ ->
+  | Hypot _ | Abs _ | Calc_size _ | Anchor_size _ | Anchor _ | Attr _ | Env _
+  | Var _ | Calc _ ->
       true
   | Pct _ -> false
   (* The dimension table decides the rest, so a sizing keyword answers

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -195,8 +195,6 @@ type z_index =
 type opacity =
   | Opacity_number of float
   | Calc of opacity calc
-  | Abs of opacity  (** [abs(<opacity>)] *)
-  | Sign of opacity  (** [sign(<opacity>)] *)
   | Inherit
   | Initial
   | Unset

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1393,28 +1393,34 @@ let pp_unit ?always:_ ctx f suffix =
     Pp.string ctx (Pp.string_of_float ~drop_leading_zero:true f);
     Pp.string ctx suffix)
 
-(** Try to evaluate a calc expression containing only numbers to a float.
-    Returns None if the expression contains variables or non-numeric values. *)
-let rec eval_numeric_calc : type a. a calc -> float option = function
-  | Num f -> Some f
-  | Math_const c -> Some (math_const_value c)
-  | Math_fn fn -> eval_math_fn fn
+(** What a calc expression over static operands reduces to, keeping the unit CSS
+    Values 4 sec. 10.5 [hypot()] and sec. 10.6 [abs()] carry over from their
+    arguments. Returns [None] on a variable or a typed leaf. *)
+let rec numeric_calc_result : type a. a calc -> math_result option = function
+  | Num f -> Some (Scalar f)
+  | Math_const c -> Some (Scalar (math_const_value c))
+  | Math_fn fn -> math_fn_result fn
   | Sibling_index -> None
   | Sibling_count -> None
   | Val _ -> None (* Can't evaluate typed values *)
   | Var _ -> None (* Can't evaluate variables *)
-  | Nested inner -> eval_numeric_calc inner
-  | Parens inner -> eval_numeric_calc inner
+  | Nested inner -> numeric_calc_result inner
+  | Parens inner -> numeric_calc_result inner
   | Expr (left, op, right) -> (
-      match (eval_numeric_calc left, eval_numeric_calc right) with
-      | Some l, Some r -> (
-          match op with
-          | Add -> Some (l +. r)
-          | Sub -> Some (l -. r)
-          | Mul -> Some (l *. r)
-          | Div when r <> 0.0 -> Some (l /. r)
-          | Div -> None)
+      match (numeric_calc_result left, numeric_calc_result right) with
+      | Some l, Some r -> combine_math_result op l r
       | _ -> None)
+
+(** Try to evaluate a calc expression containing only numbers to a float.
+    Returns None if the expression contains variables or non-numeric values. *)
+let eval_numeric_calc : type a. a calc -> float option =
+ fun calc ->
+  (* A result carrying a unit is not a [<number>]: sec. 10.6 gives [abs(-1px)]
+     the type of its argument, so folding it to a bare coefficient here would
+     hand a length to a slot that asked for a number. *)
+  match numeric_calc_result calc with
+  | Some (Scalar v) -> Some v
+  | Some (United _) | None -> None
 
 (** Map [f] over every [Val] leaf, preserving the calc structure. Useful when
     the caller wants to simplify a typed calc by applying a per-type rewrite
@@ -2326,11 +2332,6 @@ let rec pp_length ?(always = false) : length Pp.t =
   | Rem_fn (a, b) -> pp_rem_length ~always ctx a b
   | Hypot values -> pp_hypot_length ~always ctx values
   | Abs v -> Pp.call "abs" (pp_length ~always) ctx v
-  | Sign v ->
-      (* CSS Values 4 10.7: [sign(<length>)] returns a [<number>], not a
-         [<length>], so we cannot reduce to a single dimension without breaking
-         the length round-trip. Keep [sign()] verbatim. *)
-      Pp.call "sign" (pp_length ~always) ctx v
   | Calc_size (basis, calc) ->
       Pp.call "calc-size"
         (fun ctx (basis, calc) ->
@@ -3788,7 +3789,6 @@ let rec normalize_length ?(strip = true) ?(non_negative = false)
           cv |> eval_length_calc ~ctx |> linear_length_calc
           |> eval_length_calc ~ctx
         with
-        | Val v when non_negative && negative_length v -> l
         | Val v -> v
         | folded -> Calc folded)
     | Clamp (mn, v, mx) -> (
@@ -3839,7 +3839,6 @@ let rec normalize_length ?(strip = true) ?(non_negative = false)
                         (List.fold_left (fun acc f -> acc +. (f *. f)) 0. vs)))
             | _ -> Hypot xs))
     | Abs v -> ( match nf v with Px x -> Px (Float.abs x) | v -> Abs v)
-    | Sign v -> Sign (nf v)
     | Fit_content_arg arg -> Fit_content_arg (nf arg)
     | Calc_size (basis, calc) -> (
         let basis = nf basis in
@@ -3849,6 +3848,15 @@ let rec normalize_length ?(strip = true) ?(non_negative = false)
         with
         | folded -> Calc_size (basis, folded))
     | _ -> l
+  in
+  (* CSS Values 4 sec. 10.12 clamps a math function whose value falls outside
+     the property's range at computed-value time and keeps the declaration, so
+     folding one to a literal the reader then refuses would drop it: keep the
+     call. A literal that was already negative is the reader's business, not
+     this fold's. *)
+  let result =
+    if non_negative && negative_length result && not (negative_length l) then l
+    else result
   in
   if strip then strip_zero_length result else result
 
@@ -5680,30 +5688,49 @@ type inferred_calc_type =
     (* Exponent 0 is a number, 1 is the contextual numeric value, and
        multiplication/division add/subtract exponents. This retains valid
        cancellation such as [1 / (1 / 50px)]. *)
+  | Result_unit of string
+    (* A math function answering the type of its arguments (CSS Values 4 sec.
+       10.5 [hypot()], sec. 10.6 [abs()]). Which slots take it turns on the
+       unit, so it is not the contextual [Dimension 1]. *)
   | Deferred
   | Invalid
 
-let rec infer_calc_type : type a. a calc -> inferred_calc_type = function
+(* Inside an operand tree a call that answers its arguments' type is the
+   contextual dimension: the leaf reader beside it has already vouched for the
+   unit. Only a whole calculation keeps the unit for the slot to judge. *)
+let rec infer_calc_operand : type a. a calc -> inferred_calc_type =
+ fun calc ->
+  match infer_calc_type calc with
+  | Result_unit _ -> Dimension 1
+  | inferred -> inferred
+
+and infer_calc_type : type a. a calc -> inferred_calc_type = function
   | Num _ | Math_const _ | Sibling_index | Sibling_count -> Dimension 0
   | Val _ -> Dimension 1
-  (* A var() is substituted before a math function is type-checked. The generic
-     math-function AST does not retain enough result-type information to prove
-     its type here either, so both stay deferred rather than being guessed. *)
-  | Var _ | Math_fn _ -> Deferred
+  (* A var() is substituted before a math function is type-checked, so it stays
+     deferred rather than being guessed. *)
+  | Var _ -> Deferred
+  | Math_fn fn -> (
+      match math_fn_result fn with
+      | Some (United (_, unit)) -> Result_unit unit
+      | Some (Scalar _) | None -> Deferred)
   | Nested inner | Parens inner -> infer_calc_type inner
   | Expr (left, (Add | Sub), right) -> (
-      match (infer_calc_type left, infer_calc_type right) with
+      match (infer_calc_operand left, infer_calc_operand right) with
       | Invalid, _ | _, Invalid -> Invalid
+      | Result_unit _, _ | _, Result_unit _ -> Invalid
       | Deferred, _ | _, Deferred -> Deferred
       | Dimension l, Dimension r -> if l = r then Dimension l else Invalid)
   | Expr (left, Mul, right) -> (
-      match (infer_calc_type left, infer_calc_type right) with
+      match (infer_calc_operand left, infer_calc_operand right) with
       | Invalid, _ | _, Invalid -> Invalid
+      | Result_unit _, _ | _, Result_unit _ -> Invalid
       | Deferred, _ | _, Deferred -> Deferred
       | Dimension l, Dimension r -> Dimension (l + r))
   | Expr (left, Div, right) -> (
-      match (infer_calc_type left, infer_calc_type right) with
+      match (infer_calc_operand left, infer_calc_operand right) with
       | Invalid, _ | _, Invalid -> Invalid
+      | Result_unit _, _ | _, Result_unit _ -> Invalid
       | Deferred, _ | _, Deferred -> Deferred
       | Dimension l, Dimension r -> Dimension (l - r))
 
@@ -5712,14 +5739,65 @@ let validate_calc_type t result_type calc =
   let accepted =
     match (result_type, inferred) with
     | _, Deferred -> true
+    (* A call answering its arguments' type stands where that type stands: at a
+       [<number>] slot it does not, and at an [<opacity-value>] only the
+       [<percentage>] the slot resolves against its number does. *)
+    | `Number, Result_unit _ -> false
+    | `Number_or_percentage, Result_unit unit -> String.equal unit "%"
+    | (`Value | `Number_or_value), Result_unit _ -> true
     | `Number, Dimension 0 | `Value, Dimension 1 -> true
-    | `Number_or_value, (Dimension 0 | Dimension 1) -> true
-    | (`Number | `Value | `Number_or_value), (Invalid | Dimension _) -> false
+    | (`Number_or_value | `Number_or_percentage), (Dimension 0 | Dimension 1) ->
+        true
+    | ( (`Number | `Value | `Number_or_value | `Number_or_percentage),
+        (Invalid | Dimension _) ) ->
+        false
   in
   if not accepted then Cursor.err_invalid t "incompatible calc types"
 
+(* CSS Values 4 sec. 10.2 comparison and stepped-value functions, sec. 10.5
+   [hypot()] and sec. 10.6 [abs()]: each answers the type of its arguments, so a
+   [<length>] slot takes them as readily as a [<number>] one. *)
+let typed_math_function_names =
+  [ "min"; "max"; "clamp"; "round"; "mod"; "rem"; "hypot"; "abs" ]
+
+(* Sec. 10.5 exponential functions, sec. 10.4 trigonometric ones and sec. 10.6
+   [sign()]: all answer a [<number>] whatever went in, so only a [<number>] slot
+   takes them. Together with the list above these are the names
+   [read_calc_numeric_function] dispatches; [calc()] is not among them, having
+   its own entry. *)
+let number_math_function_names =
+  [
+    "sign";
+    "sqrt";
+    "exp";
+    "log";
+    "pow";
+    "sin";
+    "cos";
+    "tan";
+    "asin";
+    "acos";
+    "atan";
+    "atan2";
+  ]
+
+let looking_at_math_function t =
+  match Cursor.peek_function_name t with
+  | Some name ->
+      List.mem name typed_math_function_names
+      || List.mem name number_math_function_names
+  | None -> false
+
+let math_function_calls read =
+  List.map
+    (fun n -> (n, read))
+    (typed_math_function_names @ number_math_function_names)
+
+let typed_math_function_calls read =
+  List.map (fun n -> (n, read)) typed_math_function_names
+
 let read_calc : type a.
-    ?result_type:[ `Number | `Number_or_value | `Value ] ->
+    ?result_type:[ `Number | `Number_or_percentage | `Number_or_value | `Value ] ->
     (Cursor.t -> a) ->
     Cursor.t ->
     a calc =
@@ -5741,6 +5819,18 @@ let read_calc : type a.
   if Cursor.looking_at_func "calc" t then read "calc"
   else if Cursor.looking_at_func "-webkit-calc" t then read "-webkit-calc"
   else if Cursor.looking_at_func "var" t then Var (read_var read_a t)
+  else if looking_at_math_function t then (
+    (* CSS Values 4 sec. 10.1: a math function is usable "wherever a <number>,
+       <dimension>, or <percentage> is allowed", so [calc()] is one of them
+       rather than the gate to the rest. A bare call is already a whole
+       calculation and stands as the expression itself, with no wrapper node for
+       a printer to put back, and takes the slot's type check the way the
+       wrapped spelling does. *)
+    let result = read_calc_numeric_function t in
+    Option.iter
+      (fun result_type -> validate_calc_type t result_type result)
+      result_type;
+    result)
   else Cursor.err t "calc() or var()"
 
 (* CSS Values 4 (ED) sec. 10.9: a math function resolving to [<number>] stands
@@ -5765,7 +5855,7 @@ let read_integer_calc : type a.
   | Some _ | None -> `Calc expr
 
 let read_integer name t =
-  if Cursor.looking_at_calc t then
+  if Cursor.looking_at_calc t || looking_at_math_function t then
     match
       (read_integer_calc name t : [ `Int of int | `Calc of number calc ])
     with
@@ -5776,6 +5866,17 @@ let read_integer name t =
   else Cursor.int t
 
 let read_numeric_expression t = read_num_expr t
+
+(* An [<opacity-value>] slot takes [<number> | <percentage>], and CSS Values 4
+   sec. 10.5 and 10.6 give [hypot()] and [abs()] the type of their arguments:
+   the call stands here on the two types the slot takes from a literal, and the
+   percentage resolves against the number the way [50%] does. *)
+let read_number_percentage_expression t =
+  let calc = read_calc_expr (fun t -> Cursor.err t "expected number") t in
+  match numeric_calc_result calc with
+  | Some (Scalar v) -> v
+  | Some (United (v, unit)) when String.equal unit "%" -> v /. 100.
+  | Some (United _) | None -> Cursor.err_invalid t "non-numeric math function"
 
 (* The typed [clamp / minmax / min / max] length readers are part of the
    [read_length] mutual-recursion group (see below); the function-call
@@ -5878,11 +5979,18 @@ and read_length_function_body ~allow_negative ~length_only ~with_keywords t name
   if
     length_only
     && List.mem name
-         [
-           "minmax"; "fit-content"; "calc-size"; "anchor"; "anchor-size"; "sign";
-         ]
+         [ "minmax"; "fit-content"; "calc-size"; "anchor"; "anchor-size" ]
   then Cursor.err_invalid t "expected a length-valued math function";
-  let allow_negative = allow_negative || (length_only && name <> "attr") in
+  (* CSS Values 4 sec. 10.12 checks a property's range on the value a math
+     function resolves to, not on each operand, the same exception
+     [read_calc_length] makes for [calc()]: [width: abs(-1px)] reads where a
+     literal [-1px] does not. The substitutions and the sizing functions are not
+     math functions and keep the property's range. *)
+  let allow_negative =
+    allow_negative
+    || List.mem name typed_math_function_names
+    || (length_only && name <> "attr")
+  in
   match
     List.assoc_opt name
       (length_function_readers ~allow_negative ~length_only ~with_keywords)
@@ -5915,7 +6023,6 @@ and length_function_readers ~allow_negative ~length_only ~with_keywords =
       ("rem", read_rem_length ~allow_negative ~length_only);
       ("hypot", read_hypot_length ~allow_negative ~length_only);
       ("abs", read_abs_length ~allow_negative ~length_only);
-      ("sign", read_sign_length ~allow_negative ~length_only);
       ("anchor-size", read_anchor_size_length);
       ("anchor", read_anchor_length ~allow_negative ~length_only ~with_keywords);
       ("attr", read_attr_length ~allow_negative ~length_only ~with_keywords);
@@ -6044,11 +6151,6 @@ and read_unary_length ~allow_negative ~length_only make inner =
 and read_abs_length ~allow_negative ~length_only inner =
   read_unary_length ~allow_negative ~length_only
     (fun (value : length) -> (Abs value : length))
-    inner
-
-and read_sign_length ~allow_negative ~length_only inner =
-  read_unary_length ~allow_negative ~length_only
-    (fun (value : length) -> (Sign value : length))
     inner
 
 (* CSS Values 5 (ED) sec. 12: [calc-size()] takes a sizing basis and then a
@@ -7435,6 +7537,21 @@ and read_number_function t =
                     Cursor.expect_eof inner;
                     Float.max min_value (Float.min value max_value))))
       | "round" -> Some (read_round_number t)
+      (* CSS Values 4 sec. 10.6: [sign(A)] answers a [<number>] whatever A's own
+         type was, so [Sign] holds only the [<number>] case and an argument of
+         another type reads as the untyped math node the calc grammar carries.
+         [sign(-1px)] is a number the way [calc(sign(-1px))] is. *)
+      | "sign" ->
+          Some
+            (Cursor.one_of
+               [
+                 (fun t ->
+                   read_unary_number_function "sign"
+                     (fun value -> (Sign value : number))
+                     t);
+                 (fun t -> (Calc (read_calc_numeric_function t) : number));
+               ]
+               t)
       | _ -> read_math_number_function t name)
   | _ -> None
 

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -641,7 +641,7 @@ val read_number_percentage : Cursor.t -> number_percentage
 (** [read_number_percentage t] parses a CSS number or percentage. *)
 
 val read_calc :
-  ?result_type:[ `Number | `Number_or_value | `Value ] ->
+  ?result_type:[ `Number | `Number_or_percentage | `Number_or_value | `Value ] ->
   (Cursor.t -> 'a) ->
   Cursor.t ->
   'a calc
@@ -649,7 +649,30 @@ val read_calc :
     promotable value and checks that its statically knowable result type matches
     the property's numeric grammar. Expressions containing [var()] remain
     deferred until substitution. Omitting [result_type] retains the generic AST
-    reader behaviour. *)
+    reader behaviour.
+
+    [`Number_or_percentage] is the [<number> | <percentage>] slot of an
+    [<opacity-value>]: it parts with [`Number_or_value] on a math function
+    answering its arguments' type, which stands there only as a percentage. *)
+
+val looking_at_math_function : Cursor.t -> bool
+(** [looking_at_math_function t] is [true] on a call to a math function other
+    than [calc()]. CSS Values 4 sec. 10.1 makes such a call usable "wherever a
+    [<number>], [<dimension>], or [<percentage>] is allowed", so a reader that
+    guards its math path on [Cursor.looking_at_calc] guards it on this too. *)
+
+val math_function_calls : (Cursor.t -> 'a) -> (string * (Cursor.t -> 'a)) list
+(** [math_function_calls read] pairs every math-function name other than
+    [calc()] with [read], for the [~calls] of a {!Cursor.enum_or_calls} whose
+    [calc()] entry already reads one. For a [<number>] slot: it includes the
+    functions of CSS Values 4 sec. 10.4 to 10.6 that answer a [<number>]
+    whatever their arguments were. *)
+
+val typed_math_function_calls :
+  (Cursor.t -> 'a) -> (string * (Cursor.t -> 'a)) list
+(** [typed_math_function_calls read] is {!math_function_calls} restricted to the
+    functions that answer the type of their arguments, for a slot that takes a
+    [<length>] or another dimension rather than a [<number>]. *)
 
 val read_integer_calc : string -> Cursor.t -> [ `Int of int | `Calc of 'a calc ]
 (** [read_integer_calc name t] parses the math function at an [<integer>]
@@ -667,7 +690,10 @@ val read_calc_expr : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
     [calc(...)] form without the surrounding [calc(] and [)]. *)
 
 val validate_calc_type :
-  Cursor.t -> [ `Number | `Number_or_value | `Value ] -> 'a calc -> unit
+  Cursor.t ->
+  [ `Number | `Number_or_percentage | `Number_or_value | `Value ] ->
+  'a calc ->
+  unit
 (** [validate_calc_type t result_type calc] raises unless [calc] infers to
     [result_type], the check CSS Values 4 sec. 10.9 makes on a calculation's
     type. {!val-read_calc} runs it for a whole [calc()]; a caller reading the
@@ -689,6 +715,13 @@ val read_numeric_expression : Cursor.t -> float
 (** [read_numeric_expression t] parses and evaluates a numeric math expression,
     including top-level math functions such as [min()], [max()], and [clamp()].
 *)
+
+val read_number_percentage_expression : Cursor.t -> float
+(** [read_number_percentage_expression t] is {!read_numeric_expression} at a
+    [<number> | <percentage>] slot, where a percentage resolves against the
+    number it denotes. CSS Values 4 sec. 10.5 [hypot()] and sec. 10.6 [abs()]
+    answer the type of their arguments, so a call carrying any other unit is
+    rejected here rather than shedding it. *)
 
 val map_calc : ('a -> 'b) -> 'a calc -> 'b calc
 (** [map_calc f calc] rewrites every [Val] leaf via [f], preserving the calc

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -209,7 +209,6 @@ type length =
   | Rem_fn of length * length
   | Hypot of length list
   | Abs of length
-  | Sign of length
   | Calc_size of length * length calc
   | Anchor_size of string
   | Anchor of string option * string * length option

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -423,7 +423,7 @@ let rec vars_of_length (value : Values.length) : any_var list =
   | Round (_, value, step) -> vars_of_length value @ vars_of_length step
   | Mod (a, b) | Rem_fn (a, b) -> vars_of_length a @ vars_of_length b
   | Hypot values -> List.concat_map vars_of_length values
-  | Abs value | Sign value -> vars_of_length value
+  | Abs value -> vars_of_length value
   | Calc_size (basis, calc) -> vars_of_length basis @ vars_of_calc calc
   | Anchor (_, _, Some fallback) -> vars_of_length fallback
   | _ -> []
@@ -1023,11 +1023,10 @@ let vars_of_vertical_align (value : Properties.vertical_align) : any_var list =
 let vars_of_will_change (value : Properties.will_change) : any_var list =
   match value with Var v -> [ V v ] | _ -> []
 
-let rec vars_of_opacity (value : Properties.opacity) : any_var list =
+let vars_of_opacity (value : Properties.opacity) : any_var list =
   match value with
   | Opacity_number _ -> []
   | Calc calc -> vars_of_calc calc
-  | Abs v | Sign v -> vars_of_opacity v
   | Var v -> [ V v ]
   | Inherit | Initial | Unset | Revert | Revert_layer -> []
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4863,7 +4863,7 @@ let spec_platform_property_vectors () =
       ("width: clamp(10px, 5vw, 100px)", "width:clamp(10px,5vw,100px)");
       ( "width: calc-size(auto, size + 1rem)",
         "width:calc-size(auto,size + 1rem)" );
-      ("opacity: abs(-0.5)", "opacity:abs(-.5)");
+      ("opacity: abs(-0.5)", "opacity:.5");
       ("opacity: sign(var(--delta))", "opacity:sign(var(--delta))");
       ( "background-image: image-set(url(a.avif) type(\"image/avif\") 1x, \
          url(a.png) type(\"image/png\") 1x)",

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4834,10 +4834,12 @@ let test_opacity () =
   (* CSS Values 4 sec. 11.4 gives [abs()]/[sign()] exactly one [<calc-sum>]
      argument; [Cursor.call] did not require the reader to consume its whole
      sub-cursor, so e.g. [abs(.5 .5)] read only the first [.5] and answered
-     [abs(.5)] instead of invalidating the declaration. *)
-  check_opacity "abs(.5)";
-  check_opacity "sign(.5)";
-  check_opacity "abs( .5 )" ~expected:"abs(.5)";
+     [abs(.5)] instead of invalidating the declaration. An [<opacity-value>]
+     math function resolves to its number as it reads, the way [min()] and
+     [calc(abs())] already do here. *)
+  check_opacity ~expected:".5" "abs(.5)";
+  check_opacity ~expected:"1" "sign(.5)";
+  check_opacity ~expected:".5" "abs( .5 )";
   neg_cursor read_opacity "abs(.5 .5)";
   neg_cursor read_opacity "sign(.5 red)"
 

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1717,7 +1717,6 @@ let spec_math_function_edges () =
     "hypot(3px, 4px)";
   check_length ~expected:"abs(-10px)" "abs(-10px)";
   decl_optimizes ~prop:"margin" ~held:"abs(-10px)" ~into:"10px" "abs(-10px)";
-  check_length ~expected:"sign(10px)" "sign(10px)";
   (* CSS Color 4 (ED) sec. 5.1 gives rgb() and rgba() the same grammar and its
      Changes section calls them aliases of each other, and sec. 16.2.2 uses the
      rgb() form wherever the alpha is implicit. A var() standing for the whole
@@ -1777,6 +1776,138 @@ let spec_math_function_edges () =
   neg_cursor read_number "pow(2)";
   neg_cursor read_number "sqrt()";
   neg_cursor read_number "sin()"
+
+(* CSS Values 4 (ED) sec. 10.12 checks a property's range on the value a math
+   function resolves to rather than on each operand, the exception [calc()]
+   already had: a negative operand under a non-negative property is fine. *)
+let spec_math_operand_range () =
+  (* <length> and <length-percentage>, all at properties whose range is
+     [0,inf]. *)
+  decl_optimizes ~prop:"width" ~held:"abs(-1px)" ~into:"1px" "abs(-1px)";
+  decl_optimizes ~prop:"padding-top" ~held:"abs(-1px)" ~into:"1px" "abs(-1px)";
+  decl_optimizes ~prop:"font-size" ~held:"abs(-1px)" ~into:"1px" "abs(-1px)";
+  decl_optimizes ~prop:"border-top-left-radius" ~held:"abs(-1px)" ~into:"1px"
+    "abs(-1px)";
+  decl_optimizes ~prop:"width" ~held:"mod(-5px,2px)" ~into:"1px"
+    "mod(-5px, 2px)";
+  (* Sec. 10.6 gives [abs(A)] the type of its argument and [sign(A)] a <number>
+     whatever the argument is, so [abs()] stands at a <length> and [sign()]
+     never does. *)
+  neg_cursor read_length "sign(10px)";
+  neg_cursor read_length "sign(-1px)";
+  neg_cursor read_length_percentage "sign(-1px)"
+
+(* Sec. 10.1: a math function "can be used wherever a <number>, <dimension>, or
+   <percentage> is allowed", so a bare call reads wherever the same call wrapped
+   in [calc()] does; [calc()] is one math function among several, not the gate
+   to the others. *)
+let spec_bare_math_functions () =
+  (* The [sign()] sec. 10.6 keeps out of a <length> is exactly what an
+     <opacity-value> takes. *)
+  decl_optimizes ~prop:"opacity" ~into:"-1" "sign(-1px)";
+  decl_optimizes ~prop:"opacity" ~into:"8" "pow(2,3)";
+  decl_optimizes ~prop:"opacity" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"opacity" ~into:"5" "hypot(3,4)";
+  (* A bare call and a [calc()]-wrapped one agree on acceptance and on the value
+     they fold to. *)
+  decl_optimizes ~prop:"opacity" ~into:".5" "abs(-.5)";
+  decl_optimizes ~prop:"opacity" ~into:".5" "calc(abs(-.5))";
+  decl_optimizes ~prop:"zoom" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"flex-grow" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"font-weight" ~into:"8" "pow(2,3)";
+  decl_optimizes ~prop:"aspect-ratio" ~into:"2" "sqrt(4)";
+  (* Sec. 10.9: a math function resolving to <number> stands wherever an
+     <integer> is accepted. *)
+  decl_optimizes ~prop:"z-index" ~into:"1" "abs(-1)";
+  decl_optimizes ~prop:"order" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"grid-row-start" ~into:"1" "abs(-1)";
+  (* CSS Backgrounds 3 sec. 3.3 spells <line-width> without a percentage, which
+     is a narrower slot than <length> but still one a math function stands
+     in. *)
+  decl_optimizes ~prop:"border-top-width" ~into:"5px" "hypot(3px,4px)";
+  decl_optimizes ~prop:"outline-width" ~into:"1px" "abs(-1px)";
+  decl_optimizes ~prop:"column-rule-width" ~into:"1px" "abs(-1px)"
+
+(* Sec. 10.5 [hypot()] and sec. 10.6 [abs()] return "the same type as the
+   input", and sec. 10.2 gives the comparison and stepped-value functions their
+   arguments' type too: what the call answers, not the name it is spelled with,
+   decides the slots it stands in. Both directions are pinned per function, a
+   <number> argument at a <number> slot and a <length> one. *)
+let spec_math_result_type () =
+  let module P = Css.Properties in
+  (* <number> in, <number> out: the call is the number it resolves to. *)
+  decl_optimizes ~prop:"opacity" ~into:".2" "min(.2,.5)";
+  decl_optimizes ~prop:"opacity" ~into:".5" "max(.2,.5)";
+  decl_optimizes ~prop:"opacity" ~into:".5" "clamp(.1,.5,.9)";
+  decl_optimizes ~prop:"opacity" ~into:"2" "round(1.5,1)";
+  decl_optimizes ~prop:"opacity" ~into:"1" "mod(5,2)";
+  decl_optimizes ~prop:"opacity" ~into:"1" "rem(5,2)";
+  decl_optimizes ~prop:"opacity" ~into:"5" "hypot(3,4)";
+  decl_optimizes ~prop:"opacity" ~into:".5" "abs(-.5)";
+  (* <length> in, <length> out: the same call is no longer a <number>, so the
+     <number> slot refuses it rather than shedding the unit. *)
+  neg_cursor P.read_opacity "min(1px,2px)";
+  neg_cursor P.read_opacity "max(1px,2px)";
+  neg_cursor P.read_opacity "clamp(1px,2px,3px)";
+  neg_cursor P.read_opacity "round(1.5px,1px)";
+  neg_cursor P.read_opacity "mod(5px,2px)";
+  neg_cursor P.read_opacity "rem(5px,2px)";
+  neg_cursor P.read_opacity "hypot(3px,4px)";
+  neg_cursor P.read_opacity "abs(-1px)";
+  (* The same pair at the <integer> slots of sec. 10.9. *)
+  decl_optimizes ~prop:"z-index" ~into:"1" "min(1,2)";
+  decl_optimizes ~prop:"order" ~into:"5" "hypot(3,4)";
+  decl_optimizes ~prop:"grid-row-end" ~into:"1" "abs(-1)";
+  neg_cursor P.read_z_index "abs(-1px)";
+  neg_cursor P.read_order "abs(-1px)";
+  neg_cursor P.read_order "hypot(3px,4px)";
+  neg_cursor P.read_grid_line "abs(-1px)";
+  neg_cursor P.read_column_count "abs(-1px)";
+  neg_cursor P.read_zoom "abs(-1px)";
+  neg_cursor P.read_shape_image_threshold "abs(-1px)";
+  neg_cursor P.read_flex_factor "abs(-1px)";
+  neg_cursor P.read_font_weight "abs(-1px)";
+  (* Sec. 10.6 gives [sign(A)] a <number> "whatever the input calculation's
+     type", the mirror of [abs()]: it narrows to a number where [abs()]
+     preserves, so a <length> argument reads at the <number> slot and the call
+     itself never stands at a <length> one. *)
+  decl_optimizes ~prop:"opacity" ~into:"-1" "sign(-1px)";
+  neg_cursor read_length "sign(-1px)";
+  (* An <opacity-value> is <number> | <percentage>, so a call answering a
+     <percentage> is one of the two types the slot takes and resolves against
+     the number the way the literal does. *)
+  decl_optimizes ~prop:"opacity" ~into:".5" "abs(-50%)";
+  decl_optimizes ~prop:"shape-image-threshold" ~into:".5" "abs(-50%)";
+  (* CSS Backgrounds 3 sec. 6.2 spells <border-image-slice> over [<number> |
+     <percentage>] with no length among them, so the slot answers the same way
+     an <opacity-value> does, longhand and shorthand alike. *)
+  decl_optimizes ~prop:"border-image-slice" ~into:"abs(-1)" "abs(-1)";
+  decl_optimizes ~prop:"border-image-slice" ~into:"30%" "30%";
+  decl_optimizes ~prop:"border-image-slice" ~into:"calc(abs(-30%))" "abs(-30%)";
+  neg_cursor P.read_border_image_slice "abs(-1px)";
+  neg_cursor P.read_border_image_slice "hypot(3px,4px)";
+  neg_cursor P.read_border_image_slice "calc(abs(-1px))";
+  neg_cursor P.read_border_image "abs(-1px)";
+  (* Sec. 6.3 and 6.4 give <border-image-width> and <border-image-outset> a
+     length, so the call the slice slot refuses stands at both. *)
+  decl_optimizes ~prop:"border-image-width" ~into:"abs(-1px)" "abs(-1px)";
+  decl_optimizes ~prop:"border-image-outset" ~into:"abs(-1px)" "abs(-1px)";
+  (* A <length> slot takes what it refuses at a <number> one. *)
+  decl_optimizes ~prop:"width" ~into:"1px" "abs(-1px)";
+  decl_optimizes ~prop:"width" ~into:"5px" "hypot(3px,4px)";
+  (* [line-height] is <number> | <length-percentage>, so the length the call
+     answers is one of its types and the call stands, where the same call at an
+     <opacity-value> does not. *)
+  decl_optimizes ~prop:"line-height" ~into:"calc(abs(-1px))" "abs(-1px)";
+  decl_optimizes ~prop:"line-height" ~into:"2" "abs(-2)";
+  (* Sec. 10.1 puts [calc()] among the math functions rather than above them, so
+     the wrapped spelling answers the same type and lands the same way. *)
+  neg_cursor P.read_z_index "calc(abs(-1px))";
+  neg_cursor P.read_opacity "calc(abs(-1px))";
+  neg_cursor P.read_opacity "calc(hypot(3px,4px))";
+  decl_optimizes ~prop:"z-index" ~into:"1" "calc(abs(-1))";
+  decl_optimizes ~prop:"opacity" ~into:".5" "calc(abs(-.5))";
+  decl_optimizes ~prop:"width" ~into:"1px" "calc(abs(-1px))"
 
 let test_attr_syntax () =
   check_attr_syntax "<length>";
@@ -1958,6 +2089,9 @@ let value_tests =
     test_case "spec color invalid mutation matrix" `Quick
       spec_color_invalid_mutation_matrix;
     test_case "spec math function edges" `Quick spec_math_function_edges;
+    test_case "spec math operand range" `Quick spec_math_operand_range;
+    test_case "spec bare math functions" `Quick spec_bare_math_functions;
+    test_case "spec math result type" `Quick spec_math_result_type;
   ]
 
 let suite = ("values", value_tests)


### PR DESCRIPTION
CSS Values 4 sec. 10.1 puts a math function wherever its type is allowed, with no `calc()` wrapper needed, but `width: abs(-1px)` was dropped while `width: calc(abs(-1px))` read. Two causes: the bare-call path range-checked the operand rather than the resolved value, and each property reader spelled its own list of accepted function names. The `abs()`/`sign()` return types now follow sec. 10.6, so `width: sign(-1px)` drops where `opacity: sign(-1px)` reads.