### PR TITLE
keyframes: settle the name's arm by the name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -219,6 +219,14 @@ to lose a whole rule over one bad piece. Both are gone.
   `animation-name: "default"` still reads. Six productions each carried their
   own exclusion list, five of which had forgotten `default`; they now share
   `Cascade.Cursor.custom_ident` (#1143)
+- A `@keyframes` name is spelled the way its value requires, so
+  `@keyframes "default"` keeps its quotes where it used to print as
+  `@keyframes default`, which every browser drops, and `@keyframes "none"` is
+  read where it was refused. CSS Animations 1 sec. 3 makes the two syntaxes
+  equivalent and the name the value of the ident or string, serialised as an
+  ident unless it is a disallowed keyword. `color-scheme` reads its list items
+  as `<custom-ident>`, so `color-scheme: default` is dropped with a warning
+  (#1146)
 - A property whose grammar names a `<length>` takes neither a percentage nor an
   intrinsic-sizing keyword, and a `<time>` or `<angle>` needs its unit. Cascade
   read them wherever it read a length, so `border-width: 50%`, `top:

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -576,11 +576,14 @@ let ident ?(keep_case = true) t =
 let custom_ident_reserved =
   [ "default"; "initial"; "inherit"; "unset"; "revert"; "revert-layer" ]
 
-let custom_ident ?(reserved = []) label t =
+let is_reserved_custom_ident ?(reserved = []) name =
+  let folded = String.lowercase_ascii_preserve name in
+  List.mem folded custom_ident_reserved || List.mem folded reserved
+
+let custom_ident ?reserved label t =
   let loc = position t in
   let name = ident ~keep_case:true t in
-  let folded = String.lowercase_ascii_preserve name in
-  if List.mem folded custom_ident_reserved || List.mem folded reserved then
+  if is_reserved_custom_ident ?reserved name then
     err_invalid ~loc t (String.concat "" [ "reserved "; label; ": "; name ])
   else name
 

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -258,6 +258,12 @@ val custom_ident : ?reserved:string list -> string -> t -> string
     all ASCII case permutations, and [label] names the production in the error.
 *)
 
+val is_reserved_custom_ident : ?reserved:string list -> string -> bool
+(** [is_reserved_custom_ident name] is whether {!custom_ident} refuses [name],
+    over the same exclusions and the same [reserved] extension. A printer asks
+    it where a grammar spells the same name as an ident or a string, since a
+    reserved name has no ident spelling and has to keep its quotes. *)
+
 val number : ?allow_negative:bool -> t -> float
 (** [number t] consumes the next numeric token. *)
 

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -108,13 +108,10 @@ let rec pp_animation_iteration_count : animation_iteration_count Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
 
 (* The names a [<custom-ident>] may not spell, so the string arm is the only one
-   that carries them and the quotes are part of the value. *)
+   that carries them and the quotes are part of the value. CSS Animations 1 sec.
+   3 adds [none] to what CSS Values 4 sec. 4.2 reserves. *)
 let keyframes_name_needs_quotes name =
-  match String.lowercase_ascii name with
-  | "none" | "default" | "inherit" | "initial" | "unset" | "revert"
-  | "revert-layer" ->
-      true
-  | _ -> false
+  Cursor.is_reserved_custom_ident ~reserved:[ "none" ] name
 
 let rec pp_animation_name : animation_name Pp.t =
  fun ctx -> function

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -1226,11 +1226,31 @@ let color_scheme_of_idents t names : color_scheme =
         Cursor.err_invalid t "color-scheme: [only] cannot be repeated";
       Custom names
 
+(* Every ident of the grammar above that is not the [<custom-ident>]: sec. 2.2
+   names the four keywords the property spells, and a CSS-wide keyword stands
+   alone, which [color_scheme_of_idents] answers once it has the list. *)
+let color_scheme_keywords =
+  [
+    "normal";
+    "light";
+    "dark";
+    "only";
+    "inherit";
+    "initial";
+    "unset";
+    "revert";
+    "revert-layer";
+  ]
+
 let rec read_color_scheme t : color_scheme =
+  let read_name t =
+    match Cursor.peek_keyword t with
+    | Some k when List.mem k color_scheme_keywords -> Cursor.ident t
+    | Some _ | None -> Cursor.custom_ident "color scheme" t
+  in
   let rec read_idents acc =
     Cursor.ws t;
-    if Cursor.is_done t then List.rev acc
-    else read_idents (Cursor.ident t :: acc)
+    if Cursor.is_done t then List.rev acc else read_idents (read_name t :: acc)
   in
   match Cursor.peek t with
   | Some (Component.Func { node = { name; _ }; _ })

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -754,10 +754,13 @@ let pp_property_rule : 'a property_rule Pp.t =
     ctx ()
 
 (* CSS Animations 1 sec. 3 [<keyframes-name>] is [<custom-ident> | <string>].
-   The reader normalizes either form to a plain OCaml string; on output we
-   prefer the bare identifier when the value is a syntactically valid CSS ident
-   (shorter than the quoted form), falling back to a double-quoted string when
-   the name contains characters that would otherwise need escaping. *)
+   The two arms give the same name, so the reader keeps the name alone and sec.
+   3 settles the arm on output: "the value is serialized as an <ident> unless
+   it's a disallowed keyword, in which case it's serialized as a <string>". A
+   name an escape would rewrite takes the string too, which is no longer. *)
+let keyframes_name_reserved name =
+  Cursor.is_reserved_custom_ident ~reserved:[ "none" ] name
+
 let pp_keyframes_name ctx name =
   let len = String.length name in
   let is_ident_continue c =
@@ -780,7 +783,8 @@ let pp_keyframes_name ctx name =
     String.iter (fun c -> if not (is_ident_continue c) then ok := false) name;
     !ok
   in
-  if is_safe_ident then Pp.string ctx name else Pp.quoted_string ctx name
+  if is_safe_ident && not (keyframes_name_reserved name) then Pp.string ctx name
+  else Pp.quoted_string ctx name
 
 let pp_keyframe_position : Keyframe.position Pp.t =
  fun ctx pos ->
@@ -2172,15 +2176,16 @@ let read_keyframes_block inner =
     read_keyframes_step inner []
 
 (* CSS Animations 1 sec. 3: [@keyframes <keyframes-name>], [<keyframes-name> =
-   <custom-ident> | <string>]. The reserved spellings ([none], CSS-wide
-   keywords, [default]) are excluded from [<custom-ident>], but every mainstream
-   minifier accepts them as [<string>], so cascade keeps them too rather than
-   leak input that downstream tools preserve verbatim. *)
+   <custom-ident> | <string>]. The ident arm loses [none] on top of what sec.
+   4.2 already keeps out of a [<custom-ident>]; the string arm takes every one
+   of those names and loses the empty string instead. *)
 let read_keyframes_name r =
   Cursor.ws r;
+  let loc = Cursor.position r in
   match Cursor.string_opt r with
+  | Some "" -> Cursor.err_invalid ~loc r "empty keyframes name"
   | Some s -> s
-  | None -> Cursor.ident ~keep_case:true r
+  | None -> Cursor.custom_ident ~reserved:[ "none" ] "keyframes name" r
 
 let read_keyframes_named at_keyword make_statement (r : Cursor.t) : statement =
   Cursor.with_context r ("@" ^ at_keyword) @@ fun () ->
@@ -4572,14 +4577,6 @@ let validate_partial_statement loc = function
       Some
         (Error.bad_value loc ~property:"@font-palette-values"
            ~reason:"missing font-family descriptor")
-  | (Keyframes (name, _) | Webkit_keyframes (name, _) | Moz_keyframes (name, _))
-    when List.mem
-           (String.lowercase_ascii name)
-           [ "none"; "initial"; "inherit"; "unset"; "revert"; "revert-layer" ]
-    ->
-      Some
-        (Error.bad_value loc ~property:"@keyframes"
-           ~reason:"forbidden keyframes name")
   | _ -> None
 
 let rec statement_has_invalid_declaration = function

--- a/test/spec/inventory/at_rule_grammar.ml
+++ b/test/spec/inventory/at_rule_grammar.ml
@@ -70,6 +70,12 @@ let positive =
     row "keyframes" "invalid-selector-list-block-dropped" "@keyframes bad{}"
       "@keyframes bad { 50%, { opacity: 1 } from, 120% { opacity: 1 } 50px { \
        opacity: 1 } }";
+    (* CSS Animations 1 sec. 3: the string arm of <keyframes-name> takes the
+       names the ident arm excludes, and the name is serialized as a string
+       wherever that is the only arm spelling it. *)
+    row "keyframes" "reserved-string-name"
+      "@keyframes \"default\"{0%{opacity:0}}"
+      "@keyframes \"default\" { from { opacity: 0 } }";
     (* CSS Counter Styles 3 sec. 2: the prelude is a <counter-style-name>, so
        CSS Values 4 sec. 4.2 keeps the reserved [default] out of it. *)
     row "counter-style" "named-prelude"
@@ -159,6 +165,10 @@ let negative =
     invalid "page" "bad-margin-descriptor-value"
       "@page { @top-center { display: 1px } }";
     invalid "keyframes" "missing-block" "@keyframes missing-block";
+    invalid "keyframes" "reserved-ident-name"
+      "@keyframes default { from { opacity: 0 } }";
+    invalid "keyframes" "empty-string-name"
+      "@keyframes \"\" { from { opacity: 0 } }";
     invalid "counter-style" "reserved-prelude"
       "@counter-style default { system: cyclic; symbols: \"x\" }";
     invalid "font-palette-values" "bad-name"

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -2116,9 +2116,20 @@ let matrix =
         negatives = [ "contain cover"; "auto" ];
       };
       {
+        (* CSS Color Adjust 1 sec. 2.2 spells the list item [light | dark |
+           <custom-ident>], so CSS Values 4 sec. 4.2 keeps the reserved
+           [default] out of it in every ASCII case permutation. *)
         property = "color-scheme";
         positives = [ "normal"; "light"; "dark"; "only light" ];
-        negatives = [ "normal light"; "light normal"; "only" ];
+        negatives =
+          [
+            "normal light";
+            "light normal";
+            "only";
+            "default";
+            "DEFAULT";
+            "light default";
+          ];
       };
       {
         property = "print-color-adjust";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4790,6 +4790,7 @@ let spec_platform_property_vectors () =
       ("margin-trim: block", "margin-trim:block");
       ("field-sizing: content", "field-sizing:content");
       ("color-scheme: light dark", "color-scheme:light dark");
+      ("color-scheme: light mytheme", "color-scheme:light mytheme");
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
@@ -5426,6 +5427,12 @@ let spec_remaining_prop_vectors () =
       "color-scheme: only only";
       "color-scheme: only light only";
       "color-scheme: only dark only";
+      (* CSS Color Adjust 1 sec. 2.2 spells the list item [light | dark |
+         <custom-ident>], and CSS Values 4 sec. 4.2 keeps [default] out of every
+         one of those in all ASCII case permutations. *)
+      "color-scheme: default";
+      "color-scheme: DEFAULT";
+      "color-scheme: light default";
       "forced-color-adjust: auto none";
       "print-color-adjust: exact economy";
       "isolation: isolate auto";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1498,6 +1498,54 @@ let counter_style_symbol_reserved_default () =
   strict_reject "reserved default in counter-style additive-symbols"
     "@counter-style c { system: additive; additive-symbols: 3 default }"
 
+(* CSS Animations 1 sec. 3: [<keyframes-name> = <custom-ident> | <string>], the
+   two arms name the same animation, and only the ident arm excludes [none], the
+   CSS-wide keywords and the [default] of CSS Values 4 sec. 4.2; the string arm
+   takes all of those and excludes the empty string instead. The section
+   serializes the name as an ident "unless it's a disallowed keyword, in which
+   case it's serialized as a <string>", so a reserved name keeps its quotes:
+   dropping them writes a rule Blink 153 refuses. Blink 153 answers every case
+   below the same way. *)
+let spec_keyframes_name_arms () =
+  check_stylesheet "@keyframes \"default\"{0%{opacity:0}}";
+  check_stylesheet "@keyframes \"none\"{0%{opacity:0}}";
+  check_stylesheet "@keyframes \"initial\"{0%{opacity:0}}";
+  check_stylesheet "@-webkit-keyframes \"default\"{0%{opacity:0}}";
+  check_stylesheet "@-moz-keyframes \"revert-layer\"{0%{opacity:0}}";
+  check_stylesheet "@keyframes slide{0%{opacity:0}}";
+  check_stylesheet ~expected:"@keyframes slide{0%{opacity:0}}"
+    "@keyframes \"slide\"{0%{opacity:0}}";
+  strict_accept "quoted default as a keyframes name"
+    "@keyframes \"default\" { from { opacity: 0 } }";
+  strict_accept "quoted none as a keyframes name"
+    "@keyframes \"none\" { from { opacity: 0 } }";
+  strict_reject "reserved default as a keyframes name"
+    "@keyframes default { from { opacity: 0 } }";
+  strict_reject "folded reserved default as a keyframes name"
+    "@keyframes Default { from { opacity: 0 } }";
+  strict_reject "reserved default as a -webkit- keyframes name"
+    "@-webkit-keyframes default { from { opacity: 0 } }";
+  strict_reject "reserved default as a -moz- keyframes name"
+    "@-moz-keyframes default { from { opacity: 0 } }";
+  strict_reject "empty string as a keyframes name"
+    "@keyframes \"\" { from { opacity: 0 } }";
+  (* Sec. 3: "the following two @keyframes rules have the same name, so the
+     first will be ignored". *)
+  assert_minify_and_optimize
+    "@keyframes foo { from { opacity: 0 } } @keyframes \"foo\" { from { \
+     opacity: 1 } }"
+    ~minified:"@keyframes foo{0%{opacity:0}}@keyframes foo{0%{opacity:1}}"
+    ~optimized:"@keyframes foo{0%{opacity:1}}";
+  (* An animation named through the string arm is the one [animation-name]
+     reaches through the same arm. *)
+  assert_minify_and_optimize
+    "@keyframes \"default\" { from { opacity: 0 } } .a { animation-name: \
+     \"default\" }"
+    ~minified:
+      "@keyframes \"default\"{0%{opacity:0}}.a{animation-name:\"default\"}"
+    ~optimized:
+      "@keyframes \"default\"{0%{opacity:0}}.a{animation-name:\"default\"}"
+
 let lenient_recover name css expected min_warnings =
   let { Css.stylesheet; warnings; _ } =
     match Css.of_string ~strict:false css with
@@ -2580,6 +2628,7 @@ let stylesheet_tests =
     ( "counter-style symbol reserves default",
       `Quick,
       counter_style_symbol_reserved_default );
+    ("spec keyframes name arms", `Quick, spec_keyframes_name_arms);
     ("spec keyframes selector matrix", `Quick, spec_keyframes_selector_matrix);
     ("spec keyframes shadow colour var", `Quick, spec_keyframes_shadow_color_var);
     ("page", `Quick, page_case);


### PR DESCRIPTION
Cascade printed `@keyframes "default"` as `@keyframes default`, turning valid CSS into a rule every browser drops: the string form is valid and the ident form is reserved. CSS Animations 1 sec. 3 makes the arm a function of the name rather than authored state, so the name is stored as before and the printer quotes what the ident arm may not spell; that also lifts the matching over-rejection of `@keyframes "none"`. `color-scheme` reads its list items as `<custom-ident>`, which `#1143` could not reach.