### PR TITLE
read: give each value list the arity its grammar grants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -219,6 +219,14 @@ to lose a whole rule over one bad piece. Both are gone.
   `animation-name: "default"` still reads. Six productions each carried their
   own exclusion list, five of which had forgotten `default`; they now share
   `Cascade.Cursor.custom_ident` (#1143)
+- A value list carries the number of items its grammar grants, so
+  `mask: none, none` and `transition-behavior: normal, normal` read where they
+  were dropped, while `text-shadow: none, none`, `box-shadow: none, none` and
+  `list-style: none none none` are dropped with a warning: `none` is a whole
+  value there, not a list item, and CSS Values 4 sec. 2.2 takes each option of
+  a `||` at most once. An unquoted `font-family` name refuses a generic keyword
+  only where it heads the sequence, so `font-family: serif serif` is dropped
+  and `font-family: Cambria Math` reads (#1147)
 - A `@keyframes` name is spelled the way its value requires, so
   `@keyframes "default"` keeps its quotes where it used to print as
   `@keyframes default`, which every browser drops, and `@keyframes "none"` is

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6749,6 +6749,8 @@ type transition_property = transition_property_value list
 type transition_behavior = Properties.transition_behavior =
   | Normal
   | Allow_discrete
+  | Behaviors of transition_behavior list
+      (** The [<transition-behavior-value>#] list of two or more behaviours. *)
   | Inherit
   | Initial
   | Unset

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1848,7 +1848,7 @@ let read_object_transition_value : type a.
   | Transition_property ->
       Some (v Transition_property (read_transition_property t))
   | Transition_behavior ->
-      Some (v Transition_behavior (Properties.read_transition_behavior t))
+      Some (v Transition_behavior (Properties.read_transition_behavior_list t))
   | Overlay -> Some (v Overlay (read_overlay t))
   | Will_change -> Some (v Will_change (read_will_change t))
   | Contain -> Some (v Contain (read_contain t))

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -560,6 +560,7 @@ let rec pp_transition_behavior : transition_behavior Pp.t =
   | Var v -> pp_var pp_transition_behavior ctx v
   | Normal -> Pp.string ctx "normal"
   | Allow_discrete -> Pp.string ctx "allow-discrete"
+  | Behaviors l -> Pp.list ~sep:Pp.comma pp_transition_behavior ctx l
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -1085,6 +1086,16 @@ let rec read_transition_behavior t : transition_behavior =
     ]
     ~var:(fun t -> Var (read_var read_transition_behavior t))
     t
+
+(* CSS Transitions 2 sec. 2 spells the property [<transition-behavior-value>#],
+   one behaviour per transition. The single reader stays the [<single-
+   transition>] slot of the [transition] shorthand. *)
+let read_transition_behavior_list t : transition_behavior =
+  match
+    Cursor.list ~sep:Cursor.comma ~at_least:1 read_transition_behavior t
+  with
+  | [ one ] -> one
+  | many -> Behaviors many
 
 let rec read_overlay t : overlay =
   Cursor.enum_or_var "overlay"

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -130,10 +130,19 @@ let rec read_shadow_single t : shadow =
         ~calls:[ ("var", read_var_shadow) ]
         ~default:Shadow.read t
 
+(* CSS Backgrounds 3 sec. 6.1 spells the property [none | <shadow>#], so [none]
+   names the whole value and is no item of the list. *)
 let read_shadow t : shadow =
   match Cursor.list ~sep:Cursor.comma ~at_least:1 read_shadow_single t with
   | [ x ] -> x
-  | l -> List l
+  | l ->
+      let whole_value : shadow -> bool = function
+        | None | Inherit | Initial | Unset | Revert | Revert_layer -> true
+        | Shadow _ | Inset _ | List _ | Var _ -> false
+      in
+      if List.exists whole_value l then
+        Cursor.err_invalid t "box-shadow keyword beside another shadow";
+      List l
 
 let pp_color_after_length ctx color =
   Pp.space ctx ();

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -709,16 +709,14 @@ let is_font_family_ident_word s =
   in
   starts_ident && String.for_all is_name_char s
 
-(* CSS Fonts 4 sec. 2.1.1: in an unquoted [<font-family-name>] "any identifier
-   which could be misinterpreted as a pre-defined keyword in the font-family
-   value definition, or the CSS-wide keywords, is not allowed", and a user agent
-   "must not consider these keywords as matching the [<font-family-name>] type".
-   Sec. 2.1.2 spells the pre-defined keywords out: the bare
-   [<generic-font-family>] names listed below, the script-specific generics
-   being functional instead ([generic(fangsong)]). CSS Values 4 sec. 4.2 adds
-   the CSS-wide keywords and the reserved [default], and excludes every entry in
-   all ASCII case permutations. *)
-let font_family_reserved_words =
+(* CSS Fonts 4 sec. 2.1.2 spells the bare [<generic-font-family>] names, the
+   script-specific generics being functional instead ([generic(fangsong)]). Sec.
+   2.1.1 keeps them out of [<font-family-name>], and the property reads a
+   [<generic-font-family>] only where the alternative starts, so a generic is
+   turned away as the first word of a sequence and is an ordinary
+   [<custom-ident>] after it: Chrome 153 refuses [serif serif] and [serif Foo]
+   and takes [Foo serif] and [Cambria Math], which are installed font names. *)
+let font_family_generic_words =
   [
     "serif";
     "sans-serif";
@@ -731,17 +729,25 @@ let font_family_reserved_words =
     "ui-sans-serif";
     "ui-monospace";
     "ui-rounded";
-    "inherit";
-    "initial";
-    "unset";
-    "revert";
-    "revert-layer";
-    "default";
   ]
+
+(* CSS Values 4 sec. 4.2 excludes the CSS-wide keywords and the reserved
+   [default] from [<custom-ident>] itself, so no word of a sequence is one
+   wherever it stands. Chrome takes [inherit inherit] as a name; the exclusion
+   is on the type rather than on the position, so cascade is the strict side. *)
+let font_family_css_wide_words =
+  [ "inherit"; "initial"; "unset"; "revert"; "revert-layer"; "default" ]
+
+let font_family_reserved_words =
+  font_family_generic_words @ font_family_css_wide_words
 
 let is_font_family_reserved_word w =
   let w = String.lowercase_ascii w in
   List.exists (String.equal w) font_family_reserved_words
+
+let is_font_family_css_wide w =
+  let w = String.lowercase_ascii w in
+  List.exists (String.equal w) font_family_css_wide_words
 
 (* A lone word has to clear more than the excluded idents: [read_font_family]
    below also maps a bare [emoji], [fangsong] or [none] to a keyword rather than
@@ -762,10 +768,11 @@ let can_unquote_font_family_name s =
          words only a lone position reads as a keyword are excluded too. *)
       is_font_family_ident_word w && not (is_font_family_keyword_name w)
   | _ :: _ :: _ as words ->
-      (* The exclusion is stated per identifier, so it holds at every word of a
-         [<custom-ident>+] sequence and not only at a lone one: [inherit test]
-         and [Foo serif] are no more valid family names than [inherit] and
-         [serif] are, and quoting is their only spelling. *)
+      (* A reserved word anywhere in the sequence keeps the quotes, which is
+         stricter than what the reader takes back: sec. 2.1.1 reads flat as
+         excluding [Cambria Math], and only some browsers go on to take it, so
+         the quoted spelling is the one every UA reads. Unquoting is a size win
+         the printer declines rather than a spelling it owes. *)
       List.for_all
         (fun w ->
           is_font_family_ident_word w && not (is_font_family_reserved_word w))
@@ -1697,27 +1704,33 @@ let is_font_family_name_value : font_family -> bool = function
   | Victor_mono | Inconsolata | Hack | Name _ | Var _ ->
       true
 
-let rec read_font_family_single t : font_family =
-  let read_var t : font_family = Var (read_var read_font_family t) in
-  (* CSS Fonts 4 sec. 2.1.1 / CSS Cascade 5 sec. 7.3: the CSS-wide keywords and
-     the reserved [default] are excluded from [<custom-ident>], so none may
-     appear as any word of an unquoted family name. *)
-  let is_reserved_word word =
-    List.mem
-      (String.lowercase_ascii word)
-      [ "inherit"; "initial"; "unset"; "revert"; "revert-layer"; "default" ]
-  in
-  (* Read unquoted multi-word font names, e.g., "arial rounded" *)
-  let rec read_unquoted_name_words acc =
+(* An unquoted multi-word family name, e.g. [arial rounded]. The two exclusions
+   have different reaches. A [<generic-font-family>] is the alternative the
+   property reads instead of a name, so it is turned away where that alternative
+   starts, at the first word, and reads as an ordinary [<custom-ident>] after
+   it: [Cambria Math] and [Foo serif] are installed font names, [serif Foo] is
+   not. A CSS-wide keyword or [default] is excluded from [<custom-ident>] itself
+   (CSS Values 4 sec. 4.2), so it is turned away at every word. *)
+let read_unquoted_family_name t =
+  let rec loop acc =
     let word = Cursor.ident ~keep_case:true t in
-    if is_reserved_word word then
+    let reserved =
+      match acc with
+      | [] -> is_font_family_reserved_word word
+      | _ :: _ -> is_font_family_css_wide word
+    in
+    if reserved then
       Cursor.err_invalid t
         "font-family: reserved word cannot appear in an unquoted family name";
     let acc = word :: acc in
     Cursor.ws t;
-    if Option.is_some (Cursor.peek_ident t) then read_unquoted_name_words acc
+    if Option.is_some (Cursor.peek_ident t) then loop acc
     else String.concat " " (List.rev acc)
   in
+  loop []
+
+let rec read_font_family_single t : font_family =
+  let read_var t : font_family = Var (read_var read_font_family t) in
   let read_single_word t : font_family =
     (* A single word is a keyword before it is a name *)
     (Cursor.enum_or_calls "font-family" font_family_keywords
@@ -1747,10 +1760,7 @@ let rec read_font_family_single t : font_family =
             Option.is_some (Cursor.peek_ident t))
           t
       in
-      if is_multi_word then
-        (* Multi-word unquoted name; [read_unquoted_name_words] rejects any
-           reserved word in the sequence. *)
-        Name (read_unquoted_name_words [])
+      if is_multi_word then Name (read_unquoted_family_name t)
       else
         (* Single word - try the keyword match *)
         read_single_word t

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -835,23 +835,36 @@ let read_mask_layer t : mask_layer =
     Cursor.err_expected t "mask value";
   layer
 
+let read_mask_layers t : mask =
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_mask_layer t with
+  | [ layer ] -> Layer layer
+  | layers -> Layers layers
+
+(* CSS Masking 1 sec. 8.7 spells [mask] as [<mask-layer>#] and sec. 8.1 puts
+   [none] in the [<mask-reference>] of a layer, so it names the whole value only
+   where it is the whole value: anything after it belongs to the layer list. *)
 let rec read_mask t : mask =
-  Cursor.enum_or_var "mask"
-    [
-      ("none", (None : mask));
-      ("initial", Initial);
-      ("inherit", Inherit);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
-    ~var:(fun t -> Var (Values.read_var read_mask t))
-    ~default:(fun t ->
-      let layers =
-        Cursor.list ~sep:Cursor.comma ~at_least:1 read_mask_layer t
-      in
-      match layers with [ layer ] -> Layer layer | layers -> Layers layers)
-    t
+  Cursor.ws t;
+  let snap = Cursor.save t in
+  match Cursor.peek_keyword t with
+  | Some "none" ->
+      ignore (Cursor.ident t : string);
+      Cursor.ws t;
+      if Cursor.is_done t then (None : mask)
+      else (
+        Cursor.restore t snap;
+        read_mask_layers t)
+  | _ ->
+      Cursor.enum_or_var "mask"
+        [
+          ("initial", (Initial : mask));
+          ("inherit", Inherit);
+          ("unset", Unset);
+          ("revert", Revert);
+          ("revert-layer", Revert_layer);
+        ]
+        ~var:(fun t -> Var (Values.read_var read_mask t))
+        ~default:read_mask_layers t
 
 (* Reader for clip property (deprecated) *)
 let rec read_clip t : clip =

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -2257,8 +2257,19 @@ let rec read_text_shadow t : text_shadow =
       | _ -> err_invalid_value t "text-shadow" "expected at least two lengths")
     t
 
+(* CSS Text Decoration 4 sec. 6.2 spells the property [none | <shadow>#], so
+   [none] names the whole value and is no item of the list. *)
 let read_text_shadows t : text_shadow list =
-  Cursor.list ~sep:Cursor.comma ~at_least:1 read_text_shadow t
+  let shadows = Cursor.list ~sep:Cursor.comma ~at_least:1 read_text_shadow t in
+  let whole_value : text_shadow -> bool = function
+    | None | Initial | Inherit | Unset | Revert | Revert_layer -> true
+    | Text_shadow _ | Var _ -> false
+  in
+  (match shadows with
+  | _ :: _ :: _ when List.exists whole_value shadows ->
+      Cursor.err_invalid t "text-shadow keyword beside another shadow"
+  | _ -> ());
+  shadows
 
 let text_decoration_shorthand ?lines ?style ?color ?thickness () :
     text_decoration =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2493,11 +2493,26 @@ let try_list_style_slot r read_fn (slot : 'a option ref) =
         Cursor.restore r pos;
         false
 
+(* CSS Values 4 sec. 2.2 takes each option of a [||] at most once, and sec. 3.6
+   lands a [none] on whichever of the image and the type the shorthand does not
+   otherwise set, so the two of them hold every [none] there is. *)
+let resolve_list_style_nones r nones (type_ : list_style_type option ref)
+    (image : list_style_image option ref) =
+  let free =
+    (if !type_ = Option.None then 1 else 0)
+    + if !image = Option.None then 1 else 0
+  in
+  if nones > free then Cursor.err_invalid r "too many none in list-style";
+  if nones > 0 then begin
+    if !type_ = Option.None then type_ := Some (None : list_style_type);
+    if !image = Option.None then image := Some (None : list_style_image)
+  end
+
 let read_list_style_shorthand r : list_style_shorthand =
   let type_ : list_style_type option ref = ref Option.None in
   let position : list_style_position option ref = ref Option.None in
   let image : list_style_image option ref = ref Option.None in
-  let saw_none = ref false in
+  let nones = ref 0 in
   let try_one () =
     try_list_style_slot r read_list_style_position position
     || try_list_style_slot r read_list_style_image image
@@ -2511,7 +2526,7 @@ let read_list_style_shorthand r : list_style_shorthand =
       let kw = Cursor.peek_keyword r in
       if kw = Some "none" then begin
         let _ = Cursor.ident r in
-        saw_none := true;
+        incr nones;
         consume ()
       end
       else if try_one () then consume ()
@@ -2521,13 +2536,10 @@ let read_list_style_shorthand r : list_style_shorthand =
   Cursor.ws r;
   if not (Cursor.is_done r) then
     Cursor.err_invalid r "invalid list-style shorthand";
-  if !saw_none then begin
-    if !type_ = Option.None then type_ := Some (None : list_style_type);
-    if !image = Option.None then image := Some (None : list_style_image)
-  end;
+  resolve_list_style_nones r !nones type_ image;
   if
     !type_ = Option.None && !position = Option.None && !image = Option.None
-    && not !saw_none
+    && !nones = 0
   then Cursor.err_invalid r "invalid list-style shorthand";
   { type_ = !type_; position = !position; image = !image }
 

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1524,6 +1524,10 @@ val read_transition_behavior : Cursor.t -> transition_behavior
 (** [read_transition_behavior t] is the [transition_behavior] parsed from [t].
 *)
 
+val read_transition_behavior_list : Cursor.t -> transition_behavior
+(** [read_transition_behavior_list t] is the [<transition-behavior-value>#] the
+    property takes, one behaviour per transition. *)
+
 val pp_overlay : overlay Pp.t
 (** [pp_overlay] is the pretty-printer for [overlay]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2352,6 +2352,8 @@ type transition_property = transition_property_value list
 type transition_behavior =
   | Normal
   | Allow_discrete
+  | Behaviors of transition_behavior list
+      (** The [<transition-behavior-value>#] list of two or more behaviours. *)
   | Inherit
   | Initial
   | Unset

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4790,12 +4790,14 @@ let tr_delay_part : declaration -> Values.duration option = function
 (* [transition-behavior] is a [<single-transition>] component, so a run can
    carry it into the shorthand. A CSS-wide keyword has no component spelling,
    and a [var()] there reads back into the property slot, which the reader tries
-   first. *)
+   first. A [#] list of behaviours spans several transitions and fills no one
+   slot. *)
 let behavior_singleton :
     Properties.transition_behavior -> Properties.transition_behavior option =
   function
-  | Inherit | Initial | Unset | Revert | Revert_layer | Var _ -> None
-  | b -> Some b
+  | Inherit | Initial | Unset | Revert | Revert_layer | Var _ | Behaviors _ ->
+      None
+  | (Normal | Allow_discrete) as b -> Some b
 
 let tr_behavior_part : declaration -> Properties.transition_behavior option =
   function

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1612,8 +1612,11 @@ let rec vars_of_animation_iteration_count
   | Count n -> vars_of_number_value n
   | _ -> []
 
-let vars_of_transition_behavior (value : Properties.transition_behavior) =
-  match value with Var v -> [ V v ] | _ -> []
+let rec vars_of_transition_behavior (value : Properties.transition_behavior) =
+  match value with
+  | Var v -> [ V v ]
+  | Behaviors l -> List.concat_map vars_of_transition_behavior l
+  | _ -> []
 
 let vars_of_overlay (value : Properties.overlay) =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4768,6 +4768,13 @@ let spec_platform_property_vectors () =
       ("animation-range: Cover 10%", "animation-range:cover 10%");
       ( "transition-behavior: allow-discrete",
         "transition-behavior:allow-discrete" );
+      (* CSS Transitions 2 sec. 2 spells the property
+         [<transition-behavior-value>#], so it takes one behaviour per
+         transition the way every other transition longhand does. *)
+      ( "transition-behavior: normal, normal",
+        "transition-behavior:normal,normal" );
+      ( "transition-behavior: allow-discrete, normal",
+        "transition-behavior:allow-discrete,normal" );
       ("view-transition-name: card", "view-transition-name:card");
       ("image-orientation: from-image", "image-orientation:from-image");
       ("background-clip: text", "background-clip:text");

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1843,6 +1843,19 @@ let mask_drained_layer () =
     ~optimized:"-webkit-mask:url(a.png),none;mask:url(a.png),none"
     "mask: url(a.png), none"
 
+(* CSS Masking 1 (ED) sec. 8.7 spells [mask] as [<mask-layer>#] and sec. 8.1
+   puts [none] in the [<mask-reference>] of one layer, so it names the whole
+   value only where no layer follows it and no slot of its own layer does. *)
+let mask_none_is_a_layer_reference () =
+  check_declaration ~expected:"mask:none,none"
+    ~optimized:"-webkit-mask:none,none;mask:none,none" "mask: none, none";
+  check_declaration ~expected:"mask:none luminance" "mask: none luminance";
+  (* Controls: a lone [none] is still the property keyword, and a layer list
+     that never spells [none] reads as before. *)
+  check_declaration ~expected:"mask:none" "mask: none";
+  check_declaration ~expected:"mask:url(a.png),url(b.png)"
+    "mask: url(a.png), url(b.png)"
+
 (* CSS Values 4 (ED) sec. 10.3 keeps a [calc()] valid where its range is
    exceeded and clamps at used-value time, so a property whose range starts at
    zero reads [calc(-10px)] and drops [-10px]. Chrome 146 computes the first as
@@ -7142,6 +7155,8 @@ let declaration_tests =
     test_case "background repeat axes" `Quick background_repeat_axes;
     test_case "negative calc keeps the call" `Quick negative_calc_keeps_the_call;
     test_case "mask drained layer" `Quick mask_drained_layer;
+    test_case "mask none is a layer reference" `Quick
+      mask_none_is_a_layer_reference;
     test_case "background drained layer" `Quick background_drained_layer;
     test_case "border line-color" `Quick border_line_color;
     test_case "empty shorthand value" `Quick empty_shorthand_value;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1002,6 +1002,24 @@ let font_properties () =
   check_declaration ~expected:"font-family:revert" "font-family: revert";
   check_declaration ~expected:"font-family:revert-layer"
     "font-family: revert-layer";
+  (* Sec. 2.1.1 keeps a [<generic-font-family>] out of [<font-family-name>], and
+     the property reads the generic only where that alternative starts, so one
+     is turned away as the first word of a sequence and reads as an ordinary
+     [<custom-ident>] after it. Chrome 153 takes each of these as a name, and
+     they are installed fonts, so dropping them changes what a page renders. *)
+  check_declaration ~expected:"font-family:\"Cambria Math\""
+    "font-family: Cambria Math";
+  check_declaration ~expected:"font-family:\"Cambria math\""
+    "font-family: Cambria math";
+  check_declaration ~expected:"font-family:\"Foo serif\""
+    "font-family: Foo serif";
+  check_declaration ~expected:"font-family:\"system-ui system-ui\""
+    "font-family: 'system-ui system-ui'";
+  check_declaration ~expected:"font-family:My Font" "font-family: My Font";
+  check_declaration ~expected:"font-family:Noto Color Emoji"
+    "font-family: Noto Color Emoji";
+  check_declaration ~expected:"font-family:system-ui" "font-family: system-ui";
+  check_declaration ~expected:"font-family:math" "font-family: Math";
 
   (* Line height *)
   check_declaration ~expected:"line-height:1.5" "line-height: 1.5";
@@ -3509,6 +3527,21 @@ let invalid () =
   neg "font-weight: green";
   neg "font-family: default";
   neg "font-family: system-ui default";
+  (* CSS Fonts 4 sec. 2.1.1: a generic family heads the alternative the property
+     reads instead of a [<font-family-name>], so it is turned away as the first
+     word of a sequence. WPT css-fonts/parsing/font-family-invalid pins the
+     first of these, and Chrome 153 refuses all four. *)
+  neg "font-family: cursive serif";
+  neg "font-family: system-ui system-ui";
+  neg "font-family: serif serif";
+  neg "font-family: serif Foo";
+  (* CSS Values 4 sec. 4.2 excludes a CSS-wide keyword and [default] from
+     [<custom-ident>] itself, so those are turned away at every word rather than
+     only at the first. Chrome takes [Foo inherit] as a name; the exclusion is
+     on the type, and cascade holds the strict side. *)
+  neg "font-family: inherit inherit";
+  neg "font-family: Foo inherit";
+  neg "font-family: Foo default";
   typed_invalid "font-family: Arial, inherit";
   typed_invalid "font-family: revert-layer, serif";
   neg "font-family: system-ui revert-layer, serif";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2695,6 +2695,16 @@ let list_properties () =
   neg_cursor read_declaration "box-shadow: 0";
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
+  (* Sec. 6.1 and CSS Text Decoration 4 sec. 6.2 both spell the property [none |
+     <shadow>#], so [none] is the whole value and never one item of the list. *)
+  neg_cursor read_declaration "box-shadow: none, none";
+  neg_cursor read_declaration "text-shadow: none, none";
+  neg_cursor read_declaration "box-shadow: 1px 1px red, none";
+  neg_cursor read_declaration "text-shadow: none, 1px 1px red";
+  check_declaration ~expected:"text-shadow:none" "text-shadow: none";
+  check_declaration ~expected:"box-shadow:1px 1px red" "box-shadow: 1px 1px red";
+  check_declaration ~expected:"text-shadow:1px 1px red,2px 2px blue"
+    "text-shadow: 1px 1px red, 2px 2px blue";
   (* Sec. 6.2 writes the run [<length>{2} [ <length [0,inf]> <length>? ]?]: a
      plain length in every slot, and a floor on the blur alone. Chrome 153
      agrees on each of these. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -659,6 +659,15 @@ let special_cases () =
   (* A non-initial position stands. *)
   check_declaration ~expected:"list-style:square inside"
     ~optimized:"list-style:square inside" "list-style: square inside";
+  (* One [none] beside a position still lands on both the image and the type,
+     which is the node all three slots print. *)
+  check_declaration ~expected:"list-style:none inside none"
+    ~optimized:"list-style:none inside" "list-style: none inside";
+  (* CSS Values 4 sec. 2.2 takes each option of a [||] at most once, so the
+     image and the type hold two [none] between them and no more. Sec. 3.6
+     spells the third out as a syntax error itself. *)
+  neg_cursor read_declaration "list-style: none none none";
+  neg_cursor read_declaration "list-style: none disc url(bullet.png)";
 
   (* clip-path/object-view-box inset() and margin-inline/margin-block hit the
      same CSS Syntax 3 sec. 4.3.3 percentage-token boundary as margin/padding


### PR DESCRIPTION
Five readers disagreed with their own grammars in both directions. `mask: none, none` and `transition-behavior: normal, normal` were dropped though both take a `#` list; `text-shadow: none, none`, `box-shadow: none, none` and `list-style: none none none` were kept though `none` is a whole value rather than a list item. An unquoted `font-family` name refuses a generic keyword only where it heads the sequence, which is what Chrome 153 does: `serif Foo` is invalid and `Cambria Math` is a font.