### PR TITLE
values: wire the remaining readers to the math grammar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,10 +30,15 @@ entry points both moved.
   and `border-top-width: hypot(3px, 4px)` read where they were dropped. CSS
   Values 4 sec. 10.6 gives `abs()` the type of its input and `sign()` a
   `<number>` whatever goes in, so `width: sign(-1px)` is dropped where
-  `opacity: sign(-1px)` reads. `Cascade.Properties.font_weight`,
+  `opacity: sign(-1px)` reads, and `round()`, `mod()` and `rem()` take the
+  dimension arguments sec. 10.9 grants them, so `border-top-width:
+  round(1.5px, 1px)` reads where only `width` did. Thirteen readers that
+  admitted no math at all now do, among them `stroke-width`, `initial-letter`,
+  `font-size-adjust`, `baseline-shift`, `columns`, `font-stretch` and
+  `interest-delay`. `Cascade.Properties.font_weight`,
   `webkit_line_clamp`, `zoom`, `border_image_slice_item` and
   `shape_image_threshold` gain `Calc`, and `grid_line` gains `Calc_name`
-  (#1072, #1086, #1124, #1125, #1126, #1145)
+  (#1072, #1086, #1124, #1125, #1126, #1145, #1148)
 - A math function takes only the operands CSS Values 4 sec. 10.8 grants, so
   `width: calc(inherit)`, `height: calc(auto)`, `border-width: calc(medium)`,
   `width: calc(fit-content(20rem))` and `width: min(unset, 1px)` are dropped

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -982,7 +982,12 @@ module Calc_residual = struct
     | Values.Sign_n a
     | Values.Abs_n a ->
         math_arg_contains_var a
-    | Values.Atan2 (a, b) | Values.Log (a, Some b) | Values.Pow (a, b) ->
+    | Values.Atan2 (a, b)
+    | Values.Log (a, Some b)
+    | Values.Pow (a, b)
+    | Values.Round_n (_, a, b)
+    | Values.Mod_n (a, b)
+    | Values.Rem_n (a, b) ->
         math_arg_contains_var a || math_arg_contains_var b
     | Values.Log (a, None) -> math_arg_contains_var a
     | Values.Hypot args -> List.exists math_arg_contains_var args

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2249,6 +2249,8 @@ type columns_value = Properties.columns_value =
   | Width of length
   | Both of length * int
   | Auto_count of int
+  | Count_calc of columns_value calc
+      (** A count given as a math function, with no width beside it *)
   | Inherit
   | Initial
   | Unset
@@ -2309,6 +2311,7 @@ val column_width : column_width -> declaration
 type column_count = Properties.column_count =
   | Auto
   | Count of int
+  | Calc of column_count calc  (** A math function answering an [<integer>] *)
   | Inherit
   | Initial
   | Unset
@@ -2790,6 +2793,8 @@ type initial_letter = Properties.initial_letter =
   | Raise
   | Size of float
   | Size_sink of float * int
+  | Calc of initial_letter calc * int option
+      (** A math function in the size slot *)
   | Inherit
   | Initial
   | Unset
@@ -4523,6 +4528,8 @@ type text_size_adjust = Properties.text_size_adjust =
   | None
   | Auto
   | Pct of float
+  | Calc of text_size_adjust calc
+      (** A math function answering a [<percentage>] *)
   | Inherit
   | Initial
   | Unset
@@ -4876,6 +4883,7 @@ val hyphens : hyphens -> declaration
 (** CSS font-stretch values *)
 type font_stretch = Properties.font_stretch =
   | Pct of float  (** Percentage values from 50% to 200% *)
+  | Calc of font_stretch calc  (** A math function answering a [<percentage>] *)
   | Ultra_condensed
   | Extra_condensed
   | Condensed
@@ -5131,6 +5139,7 @@ type font_size_adjust_metric = Properties.font_size_adjust_metric =
 type font_size_adjust = Properties.font_size_adjust =
   | None
   | Number of float
+  | Calc of font_size_adjust calc
   | From_font
   | Metric_number of font_size_adjust_metric * float
   | Metric_from_font of font_size_adjust_metric
@@ -8583,6 +8592,7 @@ val stroke : svg_paint -> declaration
     width in user units rather than a CSS [<length>]. *)
 type stroke_width = Properties.stroke_width =
   | Number of float  (** A width in user units *)
+  | Calc of stroke_width calc  (** A math function answering a [<number>] *)
   | Length of length_percentage
   | Inherit
   | Initial

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -735,6 +735,10 @@ and math_fn = Values.math_fn =
   | Hypot of math_arg list
   | Sign_n of math_arg
   | Abs_n of math_arg
+  | Round_n of string * math_arg * math_arg
+      (** Sec. 10.9 [round(<rounding-strategy>?, A, B)]. *)
+  | Mod_n of math_arg * math_arg
+  | Rem_n of math_arg * math_arg
 
 (** [sin] / [cos] / [tan] arg: an [<angle>] or unitless [<number>] (radians).
     {!constructor-Operation} and {!constructor-Grouped} support arithmetic over

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1078,6 +1078,13 @@ let rec pp_font_stretch : font_stretch Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_font_stretch ctx v
   | Pct f -> Pp.pct ctx f
+  (* Sec. 2.3 refuses a negative width written on its own, so the wrapper comes
+     off only around a leaf that is a width by itself. *)
+  | Calc c ->
+      pp_calc
+        ~unwrap:(fun (v : font_stretch) ->
+          match v with Pct f -> f >= 0. | _ -> true)
+        pp_font_stretch ctx c
   | Ultra_condensed -> Pp.string ctx "ultra-condensed"
   | Extra_condensed -> Pp.string ctx "extra-condensed"
   | Condensed -> Pp.string ctx "condensed"
@@ -1105,6 +1112,12 @@ let rec pp_font_size_adjust : font_size_adjust Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
   | Number f -> Pp.float ctx f
+  (* CSS Fonts 5 sec. 2.5 refuses a negative aspect value written on its own, so
+     the wrapper comes off only around a leaf that is one by itself. *)
+  | Calc c ->
+      pp_calc
+        ~unwrap_num:(match c with Num n -> n >= 0. | _ -> true)
+        pp_font_size_adjust ctx c
   | From_font -> Pp.string ctx "from-font"
   | Metric_number (metric, f) ->
       pp_font_size_adjust_metric ctx metric;
@@ -1432,7 +1445,9 @@ let font_width_css3 : font_stretch -> font_stretch option = function
   | Pct 125. | Expanded -> Some Expanded
   | Pct 150. | Extra_expanded -> Some Extra_expanded
   | Pct 200. | Ultra_expanded -> Some Ultra_expanded
-  | Pct _ | Var _ | Inherit | Initial | Unset | Revert | Revert_layer -> None
+  | Pct _ | Calc _ | Var _ | Inherit | Initial | Unset | Revert | Revert_layer
+    ->
+      None
 
 let pp_font_width_css3 : font_stretch Pp.t =
  fun ctx width ->
@@ -2007,7 +2022,14 @@ let rec read_font_stretch t : font_stretch =
     if n < 0. then err_invalid_value t "font-stretch" (string_of_float n);
     Pct n
   in
-  Cursor.enum_or_var "font-stretch"
+  (* CSS Values 4 sec. 10.1 puts a math function wherever the [<percentage>]
+     stands, [calc()] being one of them rather than the gate to the rest, and
+     sec. 10.12 checks the [0,inf] range on the value it resolves to: the call
+     keeps out of [read_percentage], which is the literal's range check. *)
+  let read_math t : font_stretch =
+    Calc (read_calc ~result_type:`Value read_font_stretch t)
+  in
+  Cursor.enum_or_calls "font-stretch"
     [
       ("ultra-condensed", Ultra_condensed);
       ("extra-condensed", Extra_condensed);
@@ -2024,7 +2046,10 @@ let rec read_font_stretch t : font_stretch =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~var:(fun t -> Var (read_var read_font_stretch t))
+    ~calls:
+      (("var", fun t -> Var (read_var read_font_stretch t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:read_percentage t
 
 let rec read_font_display t : font_display =
@@ -2468,12 +2493,46 @@ let rec normalize_font_weight : font_weight -> font_weight = function
       | folded -> if folded == c then value else Calc folded)
   | value -> value
 
+let rec numeric_size_adjust_calc_leaves :
+    font_size_adjust calc -> font_size_adjust calc = function
+  | Val (Number n) -> Num n
+  | Nested inner -> Nested (numeric_size_adjust_calc_leaves inner)
+  | Parens inner -> Parens (numeric_size_adjust_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        ( numeric_size_adjust_calc_leaves left,
+          op,
+          numeric_size_adjust_calc_leaves right )
+  | other -> other
+
+let rec normalize_font_size_adjust : font_size_adjust -> font_size_adjust =
+  function
+  (* CSS Fonts 5 sec. 2.5 spells the aspect value [<number [0,inf]>], and CSS
+     Values 4 sec. 10.12 clamps a math function past that range at
+     computed-value time: unwrapping a negative one would write CSS a browser
+     drops. *)
+  | Calc c as value -> (
+      match eval_calc (numeric_size_adjust_calc_leaves c) with
+      | Num n when n >= 0. -> Number n
+      | Val v -> normalize_font_size_adjust v
+      | folded -> if folded == c then value else Calc folded)
+  | value -> value
+
 (* sec. 2.3 maps each width keyword onto a percentage, and getComputedStyle()
    serializes the property as a percentage however the value was written, so the
    keyword and its percentage name one width and the percentage is never
    longer. *)
-let normalize_font_stretch (value : font_stretch) : font_stretch =
-  match font_stretch_pct value with Some pct -> Pct pct | None -> value
+let rec normalize_font_stretch (value : font_stretch) : font_stretch =
+  match value with
+  (* Sec. 2.3 spells the width [<percentage [0,inf]>], and CSS Values 4 sec.
+     10.12 clamps a math function past that range at computed-value time:
+     unwrapping a negative one would write CSS a browser drops. *)
+  | Calc c -> (
+      match eval_calc c with
+      | Val (Pct p as leaf) when p >= 0. -> normalize_font_stretch leaf
+      | folded -> if folded == c then value else Calc folded)
+  | value -> (
+      match font_stretch_pct value with Some pct -> Pct pct | None -> value)
 
 (* sec. 2.1 has the user agent walk the family list until one matches, so an
    entry repeating an earlier one is never reached and names nothing: drop it,
@@ -2604,7 +2663,14 @@ let rec read_font_size_adjust t : font_size_adjust =
         Metric_from_font metric
     | _ -> Metric_number (metric, read_non_negative_number t)
   in
-  Cursor.enum_or_var "font-size-adjust"
+  (* CSS Values 4 sec. 10.1 puts a math function wherever the [<number>] stands,
+     [calc()] being one of them rather than the gate to the rest, and sec. 10.12
+     checks the [0,inf] range on the value it resolves to: the call keeps out of
+     [read_non_negative_number], which is the literal's range check. *)
+  let read_math t : font_size_adjust =
+    Calc (read_calc ~result_type:`Number read_font_size_adjust t)
+  in
+  Cursor.enum_or_calls "font-size-adjust"
     [
       ("none", (None : font_size_adjust));
       ("from-font", From_font);
@@ -2614,7 +2680,10 @@ let rec read_font_size_adjust t : font_size_adjust =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~var:(fun t -> Var (Values.read_var read_font_size_adjust t))
+    ~calls:
+      (("var", fun t -> Var (Values.read_var read_font_size_adjust t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:(fun t ->
       match Cursor.peek_ident t with
       | Some _ -> read_metric_value t

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -118,11 +118,32 @@ let break_inside_of_page_break (value : page_break_inside_value) :
   | Revert_layer -> Some Revert_layer
   | Var _ -> None
 
+let rec numeric_columns_calc_leaves : columns_value calc -> columns_value calc =
+  function
+  | Val (Count n) -> Num (float_of_int n)
+  | Nested inner -> Nested (numeric_columns_calc_leaves inner)
+  | Parens inner -> Parens (numeric_columns_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        (numeric_columns_calc_leaves left, op, numeric_columns_calc_leaves right)
+  | other -> other
+
 (* CSS Multicol 2 sec. 4.5 leaves an omitted component at its longhand's
    initial, and [auto] is the width's (sec. 4.1), so [auto <count>] names what
-   [<count>] names and the shorter spelling wins. *)
+   [<count>] names and the shorter spelling wins. Sec. 4.2 spells the count
+   [<integer [1,inf]>], and CSS Values 4 sec. 10.12 rounds a math function at an
+   [<integer>] slot and clamps it to the range at computed-value time: a call
+   that folds to a count is that count, and one that does not keeps its wrapper
+   rather than becoming CSS a browser drops. *)
 let normalize_columns_value : columns_value -> columns_value =
- fun value -> match value with Auto_count n -> Count n | other -> other
+ fun value ->
+  match value with
+  | Auto_count n -> Count n
+  | Count_calc c as value -> (
+      match eval_calc (numeric_columns_calc_leaves c) with
+      | Num n when Float.is_integer n && n >= 1. -> Count (int_of_float n)
+      | folded -> if folded == c then value else Count_calc folded)
+  | other -> other
 
 let rec pp_columns_value : columns_value Pp.t =
  fun ctx -> function
@@ -137,6 +158,11 @@ let rec pp_columns_value : columns_value Pp.t =
       Pp.string ctx "auto";
       Pp.space ctx ();
       Pp.int ctx n
+  | Count_calc c ->
+      pp_calc
+        ~unwrap_num:
+          (match c with Num n -> Float.is_integer n && n >= 1. | _ -> true)
+        pp_columns_value ctx c
   | Var v -> pp_var pp_columns_value ctx v
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -179,10 +205,36 @@ let rec pp_column_wrap : column_wrap Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+let rec numeric_column_count_calc_leaves :
+    column_count calc -> column_count calc = function
+  | Val (Count n) -> Num (float_of_int n)
+  | Nested inner -> Nested (numeric_column_count_calc_leaves inner)
+  | Parens inner -> Parens (numeric_column_count_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        ( numeric_column_count_calc_leaves left,
+          op,
+          numeric_column_count_calc_leaves right )
+  | other -> other
+
+let normalize_column_count : column_count -> column_count =
+ fun value ->
+  match value with
+  | Calc c -> (
+      match eval_calc (numeric_column_count_calc_leaves c) with
+      | Num n when Float.is_integer n && n >= 1. -> Count (int_of_float n)
+      | folded -> if folded == c then value else Calc folded)
+  | other -> other
+
 let rec pp_column_count : column_count Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"
   | Count n -> Pp.int ctx n
+  | Calc c ->
+      pp_calc
+        ~unwrap_num:
+          (match c with Num n -> Float.is_integer n && n >= 1. | _ -> true)
+        pp_column_count ctx c
   | Var v -> pp_var pp_column_count ctx v
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -390,7 +442,21 @@ let rec read_columns_value t : columns_value =
      length to the width slot and the integer to the count slot. An explicit
      [auto] keeps the width unset; [columns: auto 3] therefore differs from the
      bare [columns: 3] only in spelling, captured by [Auto_count]. *)
-  Cursor.enum_or_var "columns"
+  (* A math function stands in either slot, so the pair is read first and the
+     count-only call after: sec. 10.12 checks the count's [1,inf] range on the
+     value the call resolves to, which is what [read_columns_components]
+     refuses. *)
+  let read_math t : columns_value =
+    Cursor.one_of
+      [
+        read_columns_components;
+        (fun t ->
+          (Count_calc (read_calc ~result_type:`Number read_columns_value t)
+            : columns_value));
+      ]
+      t
+  in
+  Cursor.enum_or_calls "columns"
     [
       ("inherit", (Inherit : columns_value));
       ("initial", Initial);
@@ -398,7 +464,10 @@ let rec read_columns_value t : columns_value =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~var:(fun t -> Var (Values.read_var read_columns_value t))
+    ~calls:
+      (("var", fun t -> Var (Values.read_var read_columns_value t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:read_columns_components t
 
 let rec read_column_width t : column_width =
@@ -457,7 +526,19 @@ let rec read_column_wrap t : column_wrap =
     t
 
 let rec read_column_count t : column_count =
-  Cursor.enum_or_var "column-count"
+  (* CSS Values 4 sec. 10.1 puts a math function wherever the [<integer>]
+     stands, [calc()] being one of them rather than the gate to the rest, and
+     sec. 10.12 checks the [1,inf] range on the value it resolves to: the call
+     keeps out of [read_columns_count], which is the literal's range check. *)
+  let read_math t : column_count =
+    Cursor.one_of
+      [
+        (fun t -> (Count (read_columns_count t) : column_count));
+        (fun t -> Calc (read_calc ~result_type:`Number read_column_count t));
+      ]
+      t
+  in
+  Cursor.enum_or_calls "column-count"
     [
       ("auto", (Auto : column_count));
       ("inherit", Inherit);
@@ -466,7 +547,10 @@ let rec read_column_count t : column_count =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~var:(fun t -> Var (Values.read_var read_column_count t))
+    ~calls:
+      (("var", fun t -> Var (Values.read_var read_column_count t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:(fun t -> (Count (read_columns_count t) : column_count))
     t
 

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -57,11 +57,31 @@ let normalize_paint_order (value : paint_order) : paint_order =
       shortest 0
   | _ -> value
 
-let normalize_stroke_width ~ctx (value : stroke_width) : stroke_width =
+let rec numeric_stroke_width_calc_leaves :
+    stroke_width calc -> stroke_width calc = function
+  | Val (Number n) -> Num n
+  | Nested inner -> Nested (numeric_stroke_width_calc_leaves inner)
+  | Parens inner -> Parens (numeric_stroke_width_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        ( numeric_stroke_width_calc_leaves left,
+          op,
+          numeric_stroke_width_calc_leaves right )
+  | other -> other
+
+let rec normalize_stroke_width ~ctx (value : stroke_width) : stroke_width =
   match value with
   | Length lp ->
       let lp' = Values.normalize_length_percentage ~ctx lp in
       if lp' == lp then value else Length lp'
+  (* Sec. 13.5.3 calls a negative width invalid, and CSS Values 4 sec. 10.12
+     clamps a math function past that range at computed-value time: unwrapping a
+     negative one would write CSS a browser drops. *)
+  | Calc c -> (
+      match eval_calc (numeric_stroke_width_calc_leaves c) with
+      | Num n when n >= 0. -> Number n
+      | Val v -> normalize_stroke_width ~ctx v
+      | folded -> if folded == c then value else Calc folded)
   | _ -> value
 
 let normalize_dash_length ~ctx (value : dash_length) : dash_length =
@@ -94,7 +114,11 @@ let rec normalize_stroke_miterlimit (value : stroke_miterlimit) :
   match value with
   | Calc c -> (
       match eval_calc (numeric_miterlimit_calc_leaves c) with
-      | Num f -> Number f
+      (* Sec. 13.5.5 makes a negative miterlimit illegal, and CSS Values 4 sec.
+         10.12 clamps a math function past the property's range at
+         computed-value time instead of invalidating it: folding one to a
+         literal the reader then refuses would drop the declaration. *)
+      | Num f when f >= 0. -> Number f
       | Val v -> normalize_stroke_miterlimit v
       | folded -> if folded == c then value else Calc folded)
   | _ -> value
@@ -158,6 +182,12 @@ let rec pp_stroke_width : stroke_width Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_stroke_width ctx v
   | Number n -> Pp.float ctx n
+  (* Sec. 13.5.3 refuses a negative width written on its own, so the wrapper
+     comes off only around a leaf that is a width by itself. *)
+  | Calc c ->
+      pp_calc
+        ~unwrap_num:(match c with Num n -> n >= 0. | _ -> true)
+        pp_stroke_width ctx c
   | Length lp -> Values.pp_length_percentage ctx lp
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -196,7 +226,12 @@ let rec pp_stroke_miterlimit : stroke_miterlimit Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_stroke_miterlimit ctx v
   | Number value -> Pp.float ctx value
-  | Calc c -> pp_calc pp_stroke_miterlimit ctx c
+  (* Sec. 13.5.5 refuses a negative miterlimit written on its own, so the
+     wrapper comes off only around a leaf that is a miterlimit by itself. *)
+  | Calc c ->
+      pp_calc
+        ~unwrap_num:(match c with Num n -> n >= 0. | _ -> true)
+        pp_stroke_miterlimit ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -487,6 +522,11 @@ let rec read_stroke_dasharray t : stroke_dasharray =
       (Dashes (go []) : stroke_dasharray))
     t
 
+(* The grammar has no keyword branch, so the intrinsic-sizing keywords a bare
+   length would accept are out. *)
+let read_stroke_width_length t =
+  Values.read_length_percentage ~allow_negative:false ~with_keywords:false t
+
 (* SVG 2 sec. 13.5.3: "A <number> value represents a value in user units", and
    "A negative value is invalid", so both branches of the production refuse one.
    Only a literal can be checked here; calc() and var() resolve later. *)
@@ -496,14 +536,23 @@ let read_stroke_width_value t : stroke_width =
       let n = Cursor.number t in
       if n < 0. then Cursor.err_invalid t "negative stroke-width";
       Number n
-  (* The grammar has no keyword branch, so the intrinsic-sizing keywords a bare
-     length would accept are out. *)
-  | _ ->
-      Length
-        (Values.read_length_percentage ~allow_negative:false
-           ~with_keywords:false t)
+  | _ -> Length (read_stroke_width_length t)
 
 let rec read_stroke_width t : stroke_width =
+  (* CSS Values 4 sec. 10.1 puts a math function wherever either branch of the
+     production stands, so the call is offered the [<length-percentage>] first
+     and the [<number>] after: sec. 10.6 gives [abs(-1px)] a length and
+     [sign(-1px)] a number, and each lands in the branch its own type names.
+     Sec. 10.12 checks the [0,inf] range on the value it resolves to, which is
+     why the number branch here is not [read_stroke_width_value]. *)
+  let read_math t : stroke_width =
+    Cursor.one_of
+      [
+        (fun t -> (Length (read_stroke_width_length t) : stroke_width));
+        (fun t -> Calc (read_calc ~result_type:`Number read_stroke_width t));
+      ]
+      t
+  in
   Cursor.enum_or_calls "stroke-width"
     [
       ("inherit", (Inherit : stroke_width));
@@ -512,7 +561,10 @@ let rec read_stroke_width t : stroke_width =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("var", fun t -> Var (Values.read_var read_stroke_width t)) ]
+    ~calls:
+      (("var", fun t -> Var (Values.read_var read_stroke_width t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:read_stroke_width_value t
 
 (* SVG 2 sec. 13.5.5: "A negative value for stroke-miterlimit must be treated as
@@ -529,6 +581,14 @@ let read_miterlimit_number t =
   value
 
 let rec read_stroke_miterlimit t : stroke_miterlimit =
+  (* CSS Values 4 sec. 10.1 puts a math function wherever a [<number>] stands,
+     [calc()] being one of them rather than the gate to the rest, and sec. 10.12
+     checks the property's [0,inf] range on the value the call resolves to. So
+     the call keeps out of [read_miterlimit_number], which is the literal's
+     range check. *)
+  let read_math t : stroke_miterlimit =
+    Calc (read_calc ~result_type:`Number read_stroke_miterlimit t)
+  in
   Cursor.enum_or_calls "stroke-miterlimit"
     [
       ("inherit", (Inherit : stroke_miterlimit));
@@ -538,12 +598,9 @@ let rec read_stroke_miterlimit t : stroke_miterlimit =
       ("revert-layer", Revert_layer);
     ]
     ~calls:
-      [
-        ("var", fun t -> Var (Values.read_var read_stroke_miterlimit t));
-        ( "calc",
-          fun t ->
-            Calc (read_calc ~result_type:`Number read_stroke_miterlimit t) );
-      ]
+      (("var", fun t -> Var (Values.read_var read_stroke_miterlimit t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:(fun t -> (Number (read_miterlimit_number t) : stroke_miterlimit))
     t
 

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1285,6 +1285,17 @@ let rec pp_initial_letter : initial_letter Pp.t =
       Pp.float ctx size;
       Pp.space ctx ();
       Pp.int ctx sink
+  (* CSS Inline 3 sec. 5.1 refuses a size below 1 written on its own, so the
+     wrapper comes off only around a leaf that is a size by itself. *)
+  | Calc (c, sink) ->
+      pp_calc
+        ~unwrap_num:(match c with Num n -> n >= 1. | _ -> true)
+        pp_initial_letter ctx c;
+      Option.iter
+        (fun sink ->
+          Pp.space ctx ();
+          Pp.int ctx sink)
+        sink
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -1479,6 +1490,13 @@ let rec pp_text_size_adjust : text_size_adjust Pp.t =
   | None -> Pp.string ctx "none"
   | Auto -> Pp.string ctx "auto"
   | Pct n -> Pp.pct ctx n
+  (* CSS Size Adjustment 1 sec. 3 refuses a negative percentage written on its
+     own, so the wrapper comes off only around a leaf that is one by itself. *)
+  | Calc c ->
+      pp_calc
+        ~unwrap:(fun (v : text_size_adjust) ->
+          match v with Pct n -> n >= 0. | _ -> true)
+        pp_text_size_adjust ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -2091,8 +2109,13 @@ let rec read_text_size_adjust t : text_size_adjust =
         Cursor.err t "text-size-adjust percentages cannot be negative"
       else Pct n
   | _ ->
-      (* Keyword *)
-      Cursor.enum_or_var "text-size-adjust"
+      (* CSS Values 4 sec. 10.1 puts a math function wherever the [<percentage>]
+         stands, [calc()] being one of them rather than the gate to the rest,
+         and sec. 10.12 checks the [0,inf] range on the value it resolves to. *)
+      let read_math t : text_size_adjust =
+        Calc (Values.read_calc ~result_type:`Value read_text_size_adjust t)
+      in
+      Cursor.enum_or_calls "text-size-adjust"
         [
           ("none", (None : text_size_adjust));
           ("auto", Auto);
@@ -2102,7 +2125,10 @@ let rec read_text_size_adjust t : text_size_adjust =
           ("revert", Revert);
           ("revert-layer", Revert_layer);
         ]
-        ~var:(fun t -> Var (Values.read_var read_text_size_adjust t))
+        ~calls:
+          (("var", fun t -> Var (Values.read_var read_text_size_adjust t))
+          :: ("calc", read_math)
+          :: Values.math_function_calls read_math)
         t
 
 let rec read_tab_size (t : Cursor.t) : tab_size =
@@ -2282,6 +2308,43 @@ let normalize_vertical_align (va : vertical_align) : vertical_align =
       if lp' == lp then va else Length lp'
   | _ -> va
 
+let rec numeric_initial_letter_calc_leaves :
+    initial_letter calc -> initial_letter calc = function
+  | Val (Size n) -> Num n
+  | Nested inner -> Nested (numeric_initial_letter_calc_leaves inner)
+  | Parens inner -> Parens (numeric_initial_letter_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        ( numeric_initial_letter_calc_leaves left,
+          op,
+          numeric_initial_letter_calc_leaves right )
+  | other -> other
+
+(* CSS Inline 3 sec. 5.1 spells the size [<number [1,inf]>], and CSS Values 4
+   sec. 10.12 clamps a math function past that range at computed-value time:
+   unwrapping one below 1 would write CSS a browser drops. *)
+let normalize_initial_letter (value : initial_letter) : initial_letter =
+  match value with
+  | Calc (c, sink) -> (
+      match (eval_calc (numeric_initial_letter_calc_leaves c), sink) with
+      | Num n, Option.None when n >= 1. -> Size n
+      | Num n, Option.Some sink when n >= 1. -> Size_sink (n, sink)
+      | folded, _ -> if folded == c then value else Calc (folded, sink))
+  | value -> value
+
+(* CSS Size Adjustment 1 sec. 3 spells the adjustment [<percentage [0,inf]>],
+   and CSS Values 4 sec. 10.12 clamps a math function past that range at
+   computed-value time: unwrapping a negative one would write CSS a browser
+   drops. *)
+let rec normalize_text_size_adjust (value : text_size_adjust) : text_size_adjust
+    =
+  match value with
+  | Calc c -> (
+      match eval_calc c with
+      | Val (Pct n as leaf) when n >= 0. -> normalize_text_size_adjust leaf
+      | folded -> if folded == c then value else Calc folded)
+  | value -> value
+
 let read_initial_letter_align_keyword t : initial_letter_align_keyword =
   Cursor.enum "initial-letter-align"
     [
@@ -2294,17 +2357,30 @@ let read_initial_letter_align_keyword t : initial_letter_align_keyword =
     t
 
 let rec read_initial_letter t : initial_letter =
-  let read_number t =
-    let size = Cursor.number t in
-    if size < 1. then Cursor.err_invalid t "initial-letter size must be >= 1";
+  let read_sink t =
     Cursor.ws t;
-    if Cursor.is_done t then (Size size : initial_letter)
+    if Cursor.is_done t then Option.none
     else
       let sink = Cursor.int t in
       if sink < 1 then Cursor.err_invalid t "initial-letter sink must be >= 1";
       Cursor.ws t;
       Cursor.expect_eof t;
-      Size_sink (size, sink)
+      Option.some sink
+  in
+  let read_number t =
+    let size = Cursor.number t in
+    if size < 1. then Cursor.err_invalid t "initial-letter size must be >= 1";
+    match read_sink t with
+    | Option.None -> (Size size : initial_letter)
+    | Option.Some sink -> Size_sink (size, sink)
+  in
+  (* CSS Values 4 sec. 10.1 puts a math function wherever the size [<number>]
+     stands, [calc()] being one of them rather than the gate to the rest, and
+     sec. 10.12 checks the [1,inf] range on the value it resolves to: the call
+     keeps out of [read_number], which is the literal's range check. *)
+  let read_math t : initial_letter =
+    let size = read_calc ~result_type:`Number read_initial_letter t in
+    Calc (size, read_sink t)
   in
   Cursor.enum_or_calls "initial-letter"
     [
@@ -2317,7 +2393,10 @@ let rec read_initial_letter t : initial_letter =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("var", fun t -> Var (Values.read_var read_initial_letter t)) ]
+    ~calls:
+      (("var", fun t -> Var (Values.read_var read_initial_letter t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:read_number t
 
 let rec read_initial_letter_align t : initial_letter_align =

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -231,6 +231,12 @@ let read_non_negative_duration t =
 
 let read_interest_delay_item t : interest_delay_item =
   if Cursor.try_ident "normal" t then Normal
+  else if Cursor.looking_at_calc t || Values.looking_at_math_function t then
+    (* CSS Values 4 sec. 10.12 checks the [0s,inf] range on the value a math
+       function resolves to, at computed-value time, and clamps rather than
+       invalidating: [interest-delay: calc(-1s)] is a delay Chrome computes as
+       [0s] where the literal [-1s] is one it drops. *)
+    Time (Values.read_duration_preserve_ms ~allow_negative:true t)
   else Time (read_non_negative_duration t)
 
 let rec read_interest_delay ?(longhand = false) t : interest_delay =
@@ -256,7 +262,8 @@ let normalize_interest_delay_item : interest_delay_item -> interest_delay_item =
   | Normal -> item
   | Time duration ->
       let duration' =
-        Values.normalize_duration ~canonicalize_ms:false duration
+        Values.normalize_duration ~canonicalize_ms:false ~non_negative:true
+          duration
       in
       if duration' == duration then item else Time duration'
 
@@ -1118,6 +1125,11 @@ let rec read_webkit_line_clamp t : webkit_line_clamp =
   let read_var t : webkit_line_clamp =
     Var (read_var read_webkit_line_clamp t)
   in
+  (* CSS Values 4 sec. 10.1 allows a math function wherever an [<integer>] is
+     allowed, [calc()] being one of them rather than the gate to the rest. *)
+  let read_math t : webkit_line_clamp =
+    Calc (read_calc ~result_type:`Number read_webkit_line_clamp t)
+  in
   Cursor.enum_or_calls "-webkit-line-clamp"
     [
       ("none", (None : webkit_line_clamp));
@@ -1128,14 +1140,8 @@ let rec read_webkit_line_clamp t : webkit_line_clamp =
       ("revert-layer", Revert_layer);
     ]
     ~calls:
-      [
-        ("var", read_var);
-        (* CSS Values 4 sec. 10 allows a math function wherever an [<integer>]
-           is allowed. *)
-        ( "calc",
-          fun t ->
-            Calc (read_calc ~result_type:`Number read_webkit_line_clamp t) );
-      ]
+      (("var", read_var) :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:(fun t ->
       let n = Cursor.int t in
       if n <= 0 then Cursor.err_invalid t "-webkit-line-clamp must be positive";

--- a/lib/prop_writing.ml
+++ b/lib/prop_writing.ml
@@ -239,7 +239,26 @@ let rec read_alignment_baseline t : alignment_baseline =
     t
 
 let rec read_baseline_shift t : baseline_shift =
-  Cursor.enum_or_var "baseline-shift"
+  (* CSS Values 4 sec. 10.1 puts a math function wherever the shift stands, and
+     SVG 2 sec. 11.3 reads a bare coefficient here as a length in user units, so
+     the call answers on either type: [sqrt(4)] is a shift where a length-typed
+     [abs(-1px)] is one too. Sec. 10.8 gives an operand no keyword. *)
+  let read_math t : baseline_shift =
+    Cursor.one_of
+      [
+        (fun t ->
+          (Shift (Values.read_length_percentage ~with_keywords:false t)
+            : baseline_shift));
+        (fun t ->
+          Shift
+            (Calc
+               (Values.read_calc ~result_type:`Number
+                  (Values.read_length_percentage ~with_keywords:false)
+                  t)));
+      ]
+      t
+  in
+  Cursor.enum_or_calls "baseline-shift"
     [
       ("sub", (Sub : baseline_shift));
       ("super", Super);
@@ -252,7 +271,10 @@ let rec read_baseline_shift t : baseline_shift =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~var:(fun t -> Var (Values.read_var read_baseline_shift t))
+    ~calls:
+      (("var", fun t -> Var (Values.read_var read_baseline_shift t))
+      :: ("calc", read_math)
+      :: Values.math_function_calls read_math)
     ~default:(fun t ->
       Shift (Values.read_length_percentage ~with_keywords:false t))
     t

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4498,6 +4498,10 @@ let normalize_property_value : type a.
   | Webkit_line_clamp -> normalize_webkit_line_clamp value
   | Font_family -> normalize_font_family value
   | Font_stretch -> normalize_font_stretch value
+  | Font_size_adjust -> normalize_font_size_adjust value
+  | Initial_letter -> normalize_initial_letter value
+  | Text_size_adjust -> normalize_text_size_adjust value
+  | Webkit_text_size_adjust -> normalize_text_size_adjust value
   | Font -> normalize_font value
   | Display -> normalize_display value
   | Overflow -> normalize_overflow value
@@ -4619,6 +4623,7 @@ let normalize_property_value : type a.
   | Vertical_align -> normalize_vertical_align value
   | Border_image -> normalize_border_image value
   | Columns -> normalize_columns_value value
+  | Column_count -> normalize_column_count value
   | Border_width ->
       normalize_box_shorthand ~is_substitution:is_border_width_substitution
         normalize_border_width value

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1521,6 +1521,10 @@ type initial_letter =
   | Raise
   | Size of float
   | Size_sink of float * int
+  | Calc of initial_letter calc * int option
+      (** A math function in the size slot. CSS Values 4 sec. 10.12 checks the
+          [1,inf] range on what it resolves to, so a call the literal grammar
+          refuses is still a declaration. *)
   | Inherit
   | Initial
   | Unset
@@ -2017,6 +2021,10 @@ type font_family =
 
 type font_stretch =
   | Pct of float
+  | Calc of font_stretch calc
+      (** CSS Values 4 sec. 10.1 puts a math function where the [<percentage>]
+          stands, and sec. 10.12 checks the [0,inf] range on what it resolves
+          to. *)
   | Ultra_condensed
   | Extra_condensed
   | Condensed
@@ -2075,6 +2083,10 @@ type font_size_adjust_metric =
 type font_size_adjust =
   | None
   | Number of float
+  | Calc of font_size_adjust calc
+      (** CSS Values 4 sec. 10.1 puts a math function where the [<number>]
+          stands, and sec. 10.12 checks the [0,inf] range on what it resolves
+          to, so a call the literal grammar refuses is still a declaration. *)
   | From_font
   | Metric_number of font_size_adjust_metric * float
   | Metric_from_font of font_size_adjust_metric
@@ -4179,6 +4191,10 @@ type columns_value =
       (** [auto <column-count>]: an explicit [auto] column-width paired with a
           count, e.g. [columns: auto 3]. Distinct from [Count] (bare
           [columns: 3]) so the explicit-[auto] spelling round-trips. *)
+  | Count_calc of columns_value calc
+      (** A count given as a math function with no width beside it. CSS Values 4
+          sec. 10.12 checks the [1,inf] range on what it resolves to, so a call
+          the literal grammar refuses is still a declaration. *)
   | Inherit
   | Initial
   | Unset
@@ -4201,6 +4217,10 @@ type column_width =
 type column_count =
   | Auto
   | Count of int
+  | Calc of column_count calc
+      (** CSS Values 4 sec. 10.1 puts a math function where the [<integer>]
+          stands, and sec. 10.12 checks the [1,inf] range on what it resolves
+          to, so a call the literal grammar refuses is still a declaration. *)
   | Inherit
   | Initial
   | Unset
@@ -4428,6 +4448,10 @@ type fill_rule =
     gives the dash lengths the same shape. A negative width is invalid. *)
 type stroke_width =
   | Number of float
+  | Calc of stroke_width calc
+      (** A math function answering the [<number>] branch. CSS Values 4 sec.
+          10.12 checks the [0,inf] range on what it resolves to, so a call the
+          literal grammar refuses is still a declaration. *)
   | Length of length_percentage
   | Inherit
   | Initial
@@ -4681,6 +4705,10 @@ type text_size_adjust =
   | None
   | Auto
   | Pct of float
+  | Calc of text_size_adjust calc
+      (** CSS Values 4 sec. 10.1 puts a math function where the [<percentage>]
+          stands, and sec. 10.12 checks the [0,inf] range on what it resolves
+          to. *)
   | Inherit
   | Initial
   | Unset

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4049,11 +4049,17 @@ let eval_time_calc ?(ctx = default_calc_ctx) (c : duration calc) : duration calc
     ~zero:(Val (S 0.) : duration calc)
     ~ctx c
 
+(* The [<time>] counterpart of [negative_length]: a duration a property whose
+   range starts at [0s] refuses when it is written as a literal. *)
+let negative_duration : duration -> bool = function
+  | Ms f | S f -> f < 0.
+  | _ -> false
+
 (* Choose equivalent time units and evaluate static stepped functions in the
    AST, before declaration hashes are compared. *)
 let rec normalize_duration ?(ctx = default_calc_ctx) ?(canonicalize_ms = true)
-    (d : duration) : duration =
-  let normalize = normalize_duration ~ctx ~canonicalize_ms in
+    ?(non_negative = false) (d : duration) : duration =
+  let normalize = normalize_duration ~ctx ~canonicalize_ms ~non_negative in
   let preserve rebuilt = if rebuilt = d then d else rebuilt in
   match d with
   | Ms f when canonicalize_ms ->
@@ -4085,6 +4091,11 @@ let rec normalize_duration ?(ctx = default_calc_ctx) ?(canonicalize_ms = true)
       | _ -> preserve (Mod (a, b)))
   | Calc c -> (
       match eval_time_calc ~ctx c with
+      (* CSS Values 4 sec. 10.12 clamps a math function past the property's
+         range at computed-value time and keeps the declaration, so folding one
+         to a literal the reader then refuses would drop it: keep the call. *)
+      | Val v when non_negative && negative_duration v ->
+          preserve (Calc (Val v))
       | Val v -> normalize v
       | folded -> preserve (Calc folded))
   | Var v ->
@@ -4983,8 +4994,14 @@ let rec pp_duration_with ~shorten_ms : duration Pp.t =
      output stay as authored - a [var()] fallback among them. Shortening one
      here would print two unequal declarations alike and lose them a
      factoring. *)
+  (* A negative time has no spelling at a property whose range starts at [0s],
+     and which properties those are is not knowable here, so the wrapper stays
+     on a leaf that reads back differently without it. *)
   | Calc c ->
-      pp_calc_with ~unwrap_num:false (pp_duration_with ~shorten_ms:false) ctx c
+      pp_calc_with ~unwrap_num:false
+        ~unwrap:(fun d -> not (negative_duration d))
+        (pp_duration_with ~shorten_ms:false)
+        ctx c
 
 let pp_duration : duration Pp.t = pp_duration_with ~shorten_ms:true
 let pp_duration_preserve_ms : duration Pp.t = pp_duration_with ~shorten_ms:false
@@ -7421,9 +7438,10 @@ let duration_css_wide =
 (* CSS Values 4 (ED) sec. 6.2: "the unit may be omitted [...] only for zero
    lengths", so a bare [0] is not a time. Reading one as [0s] turned input a
    browser refuses into a declaration that works. *)
-let read_duration_number ~canonicalize_ms:_ t : duration =
+let read_duration_number ~allow_negative t : duration =
   let n, unit_raw = Cursor.number_with_unit t in
-  if n < 0.0 then Cursor.err_invalid t "negative durations are not allowed"
+  if (not allow_negative) && n < 0.0 then
+    Cursor.err_invalid t "negative durations are not allowed"
   else
     let unit = String.lowercase_ascii (Option.value unit_raw ~default:"") in
     match unit with
@@ -7446,39 +7464,45 @@ let read_duration_round read_duration_self t =
     (fun s v step -> (Round (s, v, step) : duration))
     read_duration_self t
 
-let rec read_duration_with ?(css_wide = true) ~canonicalize_ms t : duration =
-  let read_duration_self t = read_duration_with ~css_wide ~canonicalize_ms t in
+let rec read_duration_with ?(css_wide = true) ?(allow_negative = false)
+    ~canonicalize_ms t : duration =
+  (* CSS Values 4 sec. 10.8 gives a math operand no keyword, and sec. 10.12
+     checks the property's range on the value the whole calculation resolves to
+     rather than on each operand: whether a negative one stands is the caller's
+     [allow_negative], not the operand reader's. *)
+  let read_operand t =
+    read_duration_with ~css_wide:false ~allow_negative ~canonicalize_ms:false t
+  in
   Cursor.enum_or_calls
-    ~default:(read_duration_number ~canonicalize_ms)
+    ~default:(read_duration_number ~allow_negative)
     "duration"
     (if css_wide then duration_css_wide else [])
     ~calls:
       [
-        ("var", fun t -> Var (read_var read_duration_self t));
-        ( "calc",
-          fun t -> Calc (read_calc ~result_type:`Value read_duration_in_calc t)
-        );
-        ("round", read_duration_round read_duration_self);
+        ( "var",
+          fun t ->
+            Var
+              (read_var
+                 (read_duration_with ~css_wide ~allow_negative ~canonicalize_ms)
+                 t) );
+        ("calc", fun t -> Calc (read_calc ~result_type:`Value read_operand t));
+        ("round", read_duration_round read_operand);
         ( "rem",
           read_binary_call "rem"
             (fun a b -> (Rem (a, b) : duration))
-            read_duration_self );
+            read_operand );
         ( "mod",
           read_binary_call "mod"
             (fun a b -> (Mod (a, b) : duration))
-            read_duration_self );
+            read_operand );
       ]
     t
 
 (** Read a duration value *)
-and read_duration_in_calc t : duration =
-  read_duration_with ~css_wide:false ~canonicalize_ms:false t
-
-(** Read a duration value *)
 let read_duration t : duration = read_duration_with ~canonicalize_ms:true t
 
-let read_duration_preserve_ms t : duration =
-  read_duration_with ~canonicalize_ms:false t
+let read_duration_preserve_ms ?allow_negative t : duration =
+  read_duration_with ?allow_negative ~canonicalize_ms:false t
 
 (** Read a time value that can be negative (for animation-delay,
     transition-delay) *)
@@ -7730,14 +7754,13 @@ let rec read_number_percentage_dim_only t : number_percentage =
 let rec read_number_percentage t : number_percentage =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then Var (read_var read_number_percentage t)
-  else if Cursor.looking_at_calc t then
+  else if Cursor.looking_at_calc t || looking_at_math_function t then
+    (* CSS Values 4 sec. 10.1 puts every math function where [calc()] stands,
+       and sec. 10.12 checks the property's range on what the call resolves to,
+       so the call is held rather than folded to a literal the reader would then
+       refuse. *)
     Calc
       (read_calc ~result_type:`Number_or_value read_number_percentage_dim_only t)
-  else if
-    Cursor.looking_at_func "min" t
-    || Cursor.looking_at_func "max" t
-    || Cursor.looking_at_func "clamp" t
-  then Num (read_numeric_expression t)
   else
     (* Try to read as percentage or number *)
     Cursor.one_of

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -673,6 +673,25 @@ let rec minify_angle_arg : angle_arg -> angle_arg = function
       | inner -> inner)
   | arg -> arg
 
+let round_to_step strategy value step =
+  if step = 0. then value
+  else
+    let q = value /. step in
+    let q =
+      match strategy with
+      | "up" -> Float.ceil q
+      | "down" -> Float.floor q
+      | "to-zero" -> Float.trunc q
+      | _ -> Float.round q
+    in
+    q *. step
+
+let mod_value a b =
+  if b = 0. then a
+  else
+    let q = Float.floor (a /. b) in
+    a -. (q *. b)
+
 let rec pp_math_arg ctx = function
   | Lit f -> pp_calc_number ctx f
   | Dim (f, unit_) -> Pp.unit ctx f unit_
@@ -720,6 +739,19 @@ and pp_math_fn ctx fn =
   | Hypot args -> call "hypot" args
   | Sign_n a -> call "sign" [ a ]
   | Abs_n a -> call "abs" [ a ]
+  | Round_n (strategy, value, step) ->
+      (* Sec. 10.9 defaults the strategy to [nearest], so the keyword is the
+         longer spelling of the same call and is dropped. *)
+      Pp.string ctx "round(";
+      if not (String.equal strategy "nearest") then (
+        Pp.string ctx strategy;
+        Pp.comma ctx ());
+      pp_math_arg ctx value;
+      Pp.comma ctx ();
+      pp_math_arg ctx step;
+      Pp.char ctx ')'
+  | Mod_n (a, b) -> call "mod" [ a; b ]
+  | Rem_n (a, b) -> call "rem" [ a; b ]
 
 and pp_angle_arg ctx arg =
   match if Pp.minified ctx then minify_angle_arg arg else arg with
@@ -812,6 +844,10 @@ and eval_math_fn fn =
           else v)
         a
   | Abs_n a -> unary Float.abs a
+  | Round_n (strategy, value, step) ->
+      binary (round_to_step strategy) value step
+  | Mod_n (a, b) -> binary mod_value a b
+  | Rem_n (a, b) -> binary Float.rem a b
 
 (* What a static math function reduces to: a plain coefficient, or one that
    carries a unit. CSS Values 4 sec. 10.7 gives [abs()] and [hypot()] the type
@@ -888,10 +924,23 @@ and math_fn_result (fn : math_fn) : math_result option =
             | Some unit -> United (root, unit)
             | None -> Scalar root)
       | _ -> Option.none)
+  | Round_n (strategy, value, step) ->
+      stepped_result (round_to_step strategy) value step
+  | Mod_n (a, b) -> stepped_result mod_value a b
+  | Rem_n (a, b) -> stepped_result Float.rem a b
   (* Every other math function is typed [<number>] in, [<number>] out, bar the
      inverse trig functions, whose [<angle>] result only the angle evaluator can
      place. *)
   | _ -> Option.map (fun v -> Scalar v) (eval_math_fn fn)
+
+(* Sec. 10.9 gives the stepped-value functions arguments of one type and answers
+   with that type, so two units have to match and the result keeps theirs. *)
+and stepped_result f a b =
+  match (math_arg_result a, math_arg_result b) with
+  | Some (Scalar a), Some (Scalar b) -> Option.some (Scalar (f a b))
+  | Some (United (a, u)), Some (United (b, v)) when String.equal u v ->
+      Option.some (United (f a b, u))
+  | _ -> Option.none
 
 (* CSS Values 4 (ED) sec. 10.9.2: NaN belongs to a calculation tree and has no
    leaf spelling outside one, so folding a math function down to a NaN would
@@ -936,7 +985,12 @@ and math_fn_contains_var = function
   | Sin a | Cos a | Tan a -> angle_arg_contains_var a
   | Asin a | Acos a | Atan a | Sqrt a | Exp a | Sign_n a | Abs_n a ->
       math_arg_contains_var a
-  | Atan2 (a, b) | Log (a, Some b) | Pow (a, b) ->
+  | Atan2 (a, b)
+  | Log (a, Some b)
+  | Pow (a, b)
+  | Round_n (_, a, b)
+  | Mod_n (a, b)
+  | Rem_n (a, b) ->
       math_arg_contains_var a || math_arg_contains_var b
   | Log (a, None) -> math_arg_contains_var a
   | Hypot args -> List.exists math_arg_contains_var args
@@ -2634,25 +2688,6 @@ let alpha_is_full = function
   | Num 1.0 -> true
   | Pct 100.0 -> true
   | _ -> false
-
-let round_to_step strategy value step =
-  if step = 0. then value
-  else
-    let q = value /. step in
-    let q =
-      match strategy with
-      | "up" -> Float.ceil q
-      | "down" -> Float.floor q
-      | "to-zero" -> Float.trunc q
-      | _ -> Float.round q
-    in
-    q *. step
-
-let mod_value a b =
-  if b = 0. then a
-  else
-    let q = Float.floor (a /. b) in
-    a -. (q *. b)
 
 (* Byte value [0..255] for an alpha component, when the alpha is a static number
    or percentage. Returns [None] for symbolic forms ([Var] / [Calc]) that can't
@@ -5271,14 +5306,6 @@ let read_binary_call name make read_x t =
       Cursor.expect_eof inner;
       make a b)
 
-let read_numeric_arg inner = Cursor.number inner
-
-let read_numeric_round : type a. Cursor.t -> a calc =
- fun t -> Num (read_round_call round_to_step read_numeric_arg t)
-
-let read_numeric_rem : type a. Cursor.t -> a calc =
- fun t -> Num (read_binary_call "rem" Float.rem read_numeric_arg t)
-
 let read_var_calc_factor : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
  fun read_a t ->
   if Cursor.looking_at_func "var" t then Var (read_var read_a t)
@@ -5334,6 +5361,24 @@ let skip_sum_operator t ~ws_before =
   Cursor.skip t;
   if not (Cursor.skip_ws t) then
     Cursor.err t "expected whitespace after '+' or '-'"
+
+(* Sec. 10.9 requires the arguments of a stepped-value function to "have a
+   consistent type or else the function is invalid" and answers with that type,
+   so a pair whose units do not combine is no calculation at all. A [var()] is
+   substituted before the type check, so it defers rather than fails.
+
+   A [<number>] result is the coefficient itself: folding it here keeps the call
+   out of the calculation tree, where it would read as a type the inference
+   cannot place and would then stand at a [<length>] slot that takes no number.
+   A result carrying a unit is the one the tree has to hold. *)
+let checked_stepped_call : type a. Cursor.t -> math_fn -> a calc =
+ fun t fn ->
+  match math_fn_result fn with
+  | Some (Scalar v) -> Num v
+  | Some (United _) -> Math_fn fn
+  | None ->
+      if math_fn_contains_var fn then Math_fn fn
+      else Cursor.err_invalid t "inconsistent stepped-value arguments"
 
 let rec read_calc_expr : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
  fun read_a t ->
@@ -5412,9 +5457,13 @@ and read_calc_numeric_function : type a. Cursor.t -> a calc =
   match Cursor.peek t with
   | Some (Component.Func { node = { name; _ }; _ }) -> (
       match String.lowercase_ascii name with
-      | "round" -> read_numeric_round t
-      | "rem" -> read_numeric_rem t
-      | "mod" -> read_numeric_binary_call "mod" mod_value t
+      (* CSS Values 4 (ED) sec. 10.9 spells all three arguments [<calc-sum>], so
+         a dimension is one, and answers with the arguments' own type: the call
+         is read into the typed [Math_fn] AST rather than folded to a
+         coefficient, which is what kept it out of a [<length>] slot. *)
+      | "round" -> read_stepped_round t
+      | "mod" -> read_stepped_binary "mod" (fun a b -> Mod_n (a, b)) t
+      | "rem" -> read_stepped_binary "rem" (fun a b -> Rem_n (a, b)) t
       | "min" -> read_numeric_list_call "min" Float.min Float.infinity t
       | "max" -> read_numeric_list_call "max" Float.max Float.neg_infinity t
       | "clamp" -> read_numeric_clamp t
@@ -5594,18 +5643,21 @@ and read_angle_call_arg name t : angle_arg =
       Cursor.expect_eof inner;
       arg)
 
-and read_numeric_binary_call : type a.
-    string -> (float -> float -> float) -> Cursor.t -> a calc =
- fun name fn t ->
-  Num
-    (Cursor.call name t (fun inner ->
-         let a = read_num_expr inner in
-         Cursor.ws inner;
-         Cursor.comma inner;
-         let b = read_num_expr inner in
-         Cursor.ws inner;
-         Cursor.expect_eof inner;
-         fn a b))
+and read_math_arg_ws t =
+  Cursor.ws t;
+  read_math_arg t
+
+and read_stepped_round : type a. Cursor.t -> a calc =
+ fun t ->
+  checked_stepped_call t
+    (read_round_call
+       (fun strategy value step -> (Round_n (strategy, value, step) : math_fn))
+       read_math_arg_ws t)
+
+and read_stepped_binary : type a.
+    string -> (math_arg -> math_arg -> math_fn) -> Cursor.t -> a calc =
+ fun name mk t ->
+  checked_stepped_call t (read_binary_call name mk read_math_arg_ws t)
 
 and read_numeric_list_call : type a.
     string -> (float -> float -> float) -> float -> Cursor.t -> a calc =

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -313,11 +313,17 @@ val normalize_percentage : ?ctx:calc_ctx -> percentage -> percentage
     keeping any [var()]. *)
 
 val normalize_duration :
-  ?ctx:calc_ctx -> ?canonicalize_ms:bool -> duration -> duration
+  ?ctx:calc_ctx ->
+  ?canonicalize_ms:bool ->
+  ?non_negative:bool ->
+  duration ->
+  duration
 (** [normalize_duration d] folds the value-independent parts of a [<time>]
     [calc()] ([calc(var(--d) * 1)] becomes [calc(var(--d))]), keeping any
     [var()]. It chooses the shorter seconds spelling by default;
-    [canonicalize_ms:false] preserves millisecond units. *)
+    [canonicalize_ms:false] preserves millisecond units. [non_negative] says the
+    property refuses a negative literal, so a call folding to one keeps its
+    wrapper rather than becoming CSS the reader drops. *)
 
 val normalize_color :
   ?lossless:bool -> ?exact_srgb:bool -> ?resolve_missing:bool -> color -> color
@@ -613,9 +619,12 @@ val read_angle_unit_required : Cursor.t -> angle
 val read_duration : Cursor.t -> duration
 (** [read_duration t] parses a CSS duration. *)
 
-val read_duration_preserve_ms : Cursor.t -> duration
+val read_duration_preserve_ms : ?allow_negative:bool -> Cursor.t -> duration
 (** [read_duration_preserve_ms t] parses a CSS duration without canonicalizing
-    milliseconds to seconds. *)
+    milliseconds to seconds. [allow_negative] lifts the [0s,inf] range the
+    literal grammar carries, for the caller reading a math function: CSS Values
+    4 sec. 10.12 checks that range on the value the call resolves to, at
+    computed-value time, and clamps rather than invalidating. *)
 
 val read_time : Cursor.t -> duration
 (** [read_time t] parses a CSS time value (can be negative). *)

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -77,6 +77,11 @@ and math_fn =
   | Hypot of math_arg list
   | Sign_n of math_arg
   | Abs_n of math_arg
+  | Round_n of string * math_arg * math_arg
+      (** Sec. 10.9 [round(<rounding-strategy>?, A, B)]. The strategy is a
+          keyword rather than an operand; the default is [nearest]. *)
+  | Mod_n of math_arg * math_arg
+  | Rem_n of math_arg * math_arg
 
 (** [sin] / [cos] / [tan] accept an [<angle>] or unitless [<number>] expression
     (treated as radians). Arithmetic over angles ([22deg + 23deg]) and

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1909,6 +1909,38 @@ let spec_math_result_type () =
   decl_optimizes ~prop:"opacity" ~into:".5" "calc(abs(-.5))";
   decl_optimizes ~prop:"width" ~into:"1px" "calc(abs(-1px))"
 
+(* CSS Values 4 (ED) sec. 10.9 spells the arguments of [round()], [mod()] and
+   [rem()] as [<calc-sum>], so a dimension is one of them, and sec. 10.2 gives
+   the call the type its arguments have. The stepped-value functions therefore
+   stand wherever sec. 10.5 [hypot()] does, at a [<line-width>] as at a
+   [<length>], and answer the [<number>] slot the same way it does. *)
+let spec_stepped_value_dimensions () =
+  let module P = Css.Properties in
+  decl_optimizes ~prop:"border-top-width" ~into:"2px" "round(1.5px,1px)";
+  decl_optimizes ~prop:"border-top-width" ~into:"1px" "mod(5px,2px)";
+  decl_optimizes ~prop:"border-top-width" ~into:"1px" "rem(5px,2px)";
+  decl_optimizes ~prop:"outline-width" ~into:"2px" "round(1.5px,1px)";
+  decl_optimizes ~prop:"column-rule-width" ~into:"1px" "mod(5px,2px)";
+  decl_optimizes ~prop:"-webkit-text-stroke-width" ~into:"1px" "rem(5px,2px)";
+  (* Sec. 10.1 puts [calc()] among the math functions rather than above them, so
+     the wrapped spelling lands the same way the bare one does. *)
+  decl_optimizes ~prop:"border-top-width" ~into:"2px" "calc(round(1.5px,1px))";
+  decl_optimizes ~prop:"border-top-width" ~into:"1px" "calc(mod(5px,2px))";
+  decl_optimizes ~prop:"border-top-width" ~into:"1px" "calc(rem(5px,2px))";
+  (* A [<number>] argument keeps answering a [<number>], which is what the
+     [<line-width>] slot refuses and an [<opacity-value>] takes. *)
+  decl_optimizes ~prop:"opacity" ~into:"2" "round(1.5,1)";
+  decl_optimizes ~prop:"opacity" ~into:"1" "mod(5,2)";
+  decl_optimizes ~prop:"opacity" ~into:"1" "rem(5,2)";
+  neg_cursor P.read_opacity "round(1.5px,1px)";
+  neg_cursor P.read_opacity "mod(5px,2px)";
+  neg_cursor P.read_opacity "rem(5px,2px)";
+  neg_cursor P.read_border_width "round(1.5,1)";
+  (* Sec. 10.2 requires the arguments to have a consistent type, so a step in
+     one type and a value in another is no calculation at all. *)
+  neg_cursor P.read_border_width "round(1.5px,1)";
+  neg_cursor P.read_border_width "mod(5px,2)"
+
 let test_attr_syntax () =
   check_attr_syntax "<length>";
   check_attr_syntax "<length-percentage>";
@@ -2092,6 +2124,8 @@ let value_tests =
     test_case "spec math operand range" `Quick spec_math_operand_range;
     test_case "spec bare math functions" `Quick spec_bare_math_functions;
     test_case "spec math result type" `Quick spec_math_result_type;
+    test_case "spec stepped value dimensions" `Quick
+      spec_stepped_value_dimensions;
   ]
 
 let suite = ("values", value_tests)

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1941,6 +1941,79 @@ let spec_stepped_value_dimensions () =
   neg_cursor P.read_border_width "round(1.5px,1)";
   neg_cursor P.read_border_width "mod(5px,2)"
 
+(* Sec. 10.1 makes a math function usable wherever a [<number>], [<dimension>]
+   or [<percentage>] is, so a reader that takes a literal there takes a call
+   too, and sec. 10.12 checks the property's range on the value the call
+   resolves to rather than refusing it: a call folding outside the range keeps
+   its wrapper, which is the only spelling the value has left. Chrome 153 reads
+   every row below and computes the call's own value.
+
+   Sec. 10.7.1 keeps [pi] shorter than the coefficient it names, so a call that
+   reduces to the constant keeps it. *)
+let spec_math_at_the_remaining_readers () =
+  let module P = Css.Properties in
+  (* SVG 2 sec. 13.5.3 [stroke-width] is [<length-percentage> | <number>]: the
+     call lands in the branch its own type names, and the [0,inf] range keeps
+     the negative one wrapped. *)
+  decl_optimizes ~prop:"stroke-width" ~into:"1" "calc(1)";
+  decl_optimizes ~prop:"stroke-width" ~into:"calc(pi)" "calc(pi)";
+  decl_optimizes ~prop:"stroke-width" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"stroke-width" ~into:"8" "pow(2,3)";
+  decl_optimizes ~prop:"stroke-width" ~into:"1px" "abs(-1px)";
+  (* SVG 2 sec. 13.5.5 [stroke-miterlimit], [0,inf]. *)
+  decl_optimizes ~prop:"stroke-miterlimit" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"stroke-miterlimit" ~into:"calc(-1)" "sign(-1px)";
+  (* CSS Inline 3 sec. 5.1 [initial-letter], [1,inf] on the size. *)
+  decl_optimizes ~prop:"initial-letter" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"initial-letter" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"initial-letter" ~into:"2 3" "calc(1 + 1) 3";
+  (* CSS Fonts 5 sec. 2.5 [font-size-adjust], [0,inf]. *)
+  decl_optimizes ~prop:"font-size-adjust" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"font-size-adjust" ~into:"calc(-1)" "sign(-1px)";
+  (* SVG 2 sec. 11.3 reads a bare coefficient at [baseline-shift] as a length in
+     user units, so the slot takes a call of either type. *)
+  decl_optimizes ~prop:"baseline-shift" ~into:"calc(2)" "sqrt(4)";
+  decl_optimizes ~prop:"baseline-shift" ~into:"1px" "abs(-1px)";
+  decl_optimizes ~prop:"baseline-shift" ~into:"1px" "min(1px,2px)";
+  (* CSS Transforms 2 sec. 5 [scale] takes any [<number-percentage>], so no
+     range keeps a call wrapped here. *)
+  decl_optimizes ~prop:"scale" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"scale" ~into:"-1" "sign(-1px)";
+  (* The [<integer>] slots of CSS Multicol 2 sec. 4.2 and the [-webkit-line-
+     clamp] alias, all [1,inf]. *)
+  decl_optimizes ~prop:"-webkit-line-clamp" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"-webkit-line-clamp" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"column-count" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"column-count" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"column-count" ~into:"calc(pi)" "calc(pi)";
+  decl_optimizes ~prop:"columns" ~into:"2" "sqrt(4)";
+  decl_optimizes ~prop:"columns" ~into:"calc(-1)" "sign(-1px)";
+  (* The [<percentage>] slots: CSS Fonts 4 sec. 2.3 and CSS Size Adjustment 1
+     sec. 3. The [@font-face] descriptor reads through the same
+     [font-stretch]. *)
+  decl_optimizes ~prop:"font-stretch" ~into:"50%" "calc(50%)";
+  decl_optimizes ~prop:"text-size-adjust" ~into:"50%" "calc(50%)";
+  decl_optimizes ~prop:"-webkit-text-size-adjust" ~into:"50%" "calc(50%)";
+  (* CSS UI 5 sec. 7.2 [interest-delay] is [<time [0s,inf]>], so the negative
+     one Chrome computes as [0s] keeps its wrapper where the literal is
+     dropped. *)
+  decl_optimizes ~prop:"interest-delay" ~into:"calc(-1s)" "calc(-1s)";
+  decl_optimizes ~prop:"interest-delay" ~into:"calc(-2s)" "calc(-1s * 2)";
+  decl_optimizes ~prop:"interest-delay" ~into:"calc(-.5s)" "calc(-1s / 2)";
+  decl_optimizes ~prop:"interest-delay" ~into:"calc(-2s)" "calc(2 * -1s)";
+  decl_optimizes ~prop:"interest-delay" ~into:"1s" "calc(1s)";
+  (* Sec. 10.8 gives a math operand no keyword, and the literal keeps the range
+     the call is exempt from. *)
+  neg_cursor P.read_stroke_width "calc(inherit)";
+  neg_cursor P.read_stroke_width "-1";
+  neg_cursor P.read_column_count "calc(inherit)";
+  neg_cursor P.read_font_size_adjust "-1";
+  neg_cursor P.read_initial_letter "calc(inherit)";
+  neg_cursor P.read_interest_delay "-1s";
+  (* Sec. 10.12 does not lift the range off a neighbouring property: the two
+     durations Chrome refuses whatever the spelling stay refused. *)
+  neg_cursor read_duration "calc(-1s)"
+
 let test_attr_syntax () =
   check_attr_syntax "<length>";
   check_attr_syntax "<length-percentage>";
@@ -2126,6 +2199,8 @@ let value_tests =
     test_case "spec math result type" `Quick spec_math_result_type;
     test_case "spec stepped value dimensions" `Quick
       spec_stepped_value_dimensions;
+    test_case "spec math at the remaining readers" `Quick
+      spec_math_at_the_remaining_readers;
   ]
 
 let suite = ("values", value_tests)


### PR DESCRIPTION
Thirteen property readers spelled their slot with a literal-token reader and no call dispatch beside it, so `stroke-width: sign(-1px)` and `font-stretch: calc(50%)` were dropped. Separately `read_calc_numeric_function` read number-only arguments, so `round()`, `mod()` and `rem()` folded to a coefficient and never carried a unit out to the slot: `border-top-width: round(1.5px, 1px)` was dropped where `width: round(1.5px, 1px)` worked.