### PR TITLE
values: keep the call where a number folds out of range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -452,10 +452,14 @@ to lose a whole rule over one bad piece. Both are gone.
   zero keeps its call on a property whose range starts there, since CSS Values
   4 sec. 10.3 clamps at used-value time: `width: calc(-10px)` computes to `0px`
   where `width: -10px` is dropped, and folding the call away turned a working
-  declaration into one browsers throw out. A sum leads with a positive term
-  where it has one, so `calc(-10px + 100vw)` minifies to `calc(100vw - 10px)`
-  rather than growing a sign into `calc(3px + -2em)` (#350, #354, #362, #367,
-  #676, #731, #967, #1113)
+  declaration into one browsers throw out. That now holds for a `<number>` as
+  well as a length, so `aspect-ratio: sign(-1px)` keeps `calc(-1)` where it
+  wrote `-1`, output its own reader then refused, at eleven properties among
+  them `flex-grow`, `line-height`, `tab-size`, `stroke-width` and
+  `border-radius`. A sum leads with a positive term where it has one, so
+  `calc(-10px + 100vw)` minifies to `calc(100vw - 10px)` rather than growing a
+  sign into `calc(3px + -2em)` (#350, #354, #362, #367, #676, #731, #967,
+  #1113, #1149)
 - `--minify` folds a value's spelling before two rules are compared, so a hex
   colour, a NaN, an unreduced `min()`, a same-unit `calc()`, a shorthand
   component at its longhand's initial, a repeated `font-family` entry, a

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -33,13 +33,16 @@ let normalize_animation_range : animation_range -> animation_range =
              option_map_preserve normalize_animation_range_item b ))
   | other -> other
 
-(* Sec. 3.4 gives the count a plain [<number>], so a static math function on it
-   folds like any other. *)
+(* Sec. 3.4 gives the count a [0,inf] [<number>], so a static math function on
+   it folds like any other, and one folding below the range keeps its wrapper
+   rather than becoming a literal the reader refuses. *)
 let rec normalize_animation_iteration_count ~ctx :
     animation_iteration_count -> animation_iteration_count =
  fun value ->
   match value with
-  | Count n -> preserve_if_equal value (Count (Values.normalize_number ~ctx n))
+  | Count n ->
+      preserve_if_equal value
+        (Count (Values.normalize_number ~ctx ~non_negative:true n))
   | Counts counts ->
       preserve_if_equal value
         (Counts (map_preserve (normalize_animation_iteration_count ~ctx) counts))

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1994,26 +1994,33 @@ let pp_animation_shorthand : animation_shorthand Pp.t =
   if ambiguous_name_last then
     pp_animation_name_slot ctx state ~quote_ambiguous_name anim
 
-(* The animation reader fills every slot with its longhand initial, so only the
-   easing needs canonicalising here: its keyword and curve spellings are the
-   same node question [normalize_timing_function] answers. *)
-let normalize_animation_shorthand (a : animation_shorthand) :
+(* The animation reader fills every slot with its longhand initial, so each slot
+   answers here the question its own longhand answers: the easing's keyword and
+   curve spellings are one node, and the count carries the [0,inf] range that
+   keeps a call wrapped. A slot left out folds only on a second pass over the
+   output, which is a pass too late for output that is input. *)
+let normalize_animation_shorthand ~ctx (a : animation_shorthand) :
     animation_shorthand =
-  let duration = option_map_preserve Values.normalize_duration a.duration in
-  let delay = option_map_preserve Values.normalize_duration a.delay in
-  let timing_function =
+  let duration = option_map_preserve (Values.normalize_duration ~ctx) a.duration
+  and delay = option_map_preserve (Values.normalize_duration ~ctx) a.delay
+  and timing_function =
     option_map_preserve normalize_timing_function a.timing_function
+  and iteration_count =
+    option_map_preserve
+      (normalize_animation_iteration_count ~ctx)
+      a.iteration_count
   in
   if
     option_is_phys_same duration a.duration
     && option_is_phys_same delay a.delay
     && option_is_phys_same timing_function a.timing_function
+    && option_is_phys_same iteration_count a.iteration_count
   then a
-  else { a with duration; timing_function; delay }
+  else { a with duration; timing_function; delay; iteration_count }
 
-let normalize_animation : animation -> animation = function
+let normalize_animation ~ctx : animation -> animation = function
   | Shorthand a as value ->
-      let a' = normalize_animation_shorthand a in
+      let a' = normalize_animation_shorthand ~ctx a in
       if a' == a then value else Shorthand a'
   | value -> value
 

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -239,9 +239,11 @@ let rec pp_border_radius : border_radius Pp.t =
    horizontal one says what omitting it says. *)
 let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
  fun value ->
+  (* Sec. 4.1 gives each radius a [0,inf] range, and the shorthand carries what
+     its longhands carry: a call folding below it keeps its wrapper. *)
   let group =
     normalize_box_shorthand ~is_substitution:is_lp_substitution
-      (Values.normalize_length_percentage ~strip)
+      (Values.normalize_length_percentage ~strip ~non_negative:true)
   in
   match value with
   | Radius { horizontal; vertical } ->

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -250,17 +250,17 @@ let aspect_ratio_of_numbers ~auto (a : number) (b : number) : aspect_ratio =
   | false, a, b -> Ratio_calc (a, b)
   | true, a, b -> Auto_ratio_calc (a, b)
 
+(* CSS Sizing 4 sec. 5 spells the value [<ratio>], whose CSS Values 4 sec. 6.5
+   numbers carry a [0,inf] range, so a call folding below it keeps its wrapper:
+   the literal underneath is one [read_aspect_ratio_number] refuses. *)
 let normalize_aspect_ratio : aspect_ratio -> aspect_ratio =
  fun value ->
+  let number = Values.normalize_number ~non_negative:true in
   match value with
   | Auto_ratio_calc (a, b) ->
-      aspect_ratio_of_numbers ~auto:true
-        (Values.normalize_number a)
-        (Values.normalize_number b)
+      aspect_ratio_of_numbers ~auto:true (number a) (number b)
   | Ratio_calc (a, b) ->
-      aspect_ratio_of_numbers ~auto:false
-        (Values.normalize_number a)
-        (Values.normalize_number b)
+      aspect_ratio_of_numbers ~auto:false (number a) (number b)
   | other -> other
 
 let rec pp_display : display Pp.t =
@@ -731,9 +731,11 @@ let rec pp_table_layout : table_layout Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* Sec. 6.5 refuses a negative ratio number written on its own, so the fold
+   comes off only where its result is a ratio number by itself. *)
 let pp_aspect_ratio_number ctx value =
   match (Pp.minified ctx, eval_number_value value) with
-  | true, Some value -> Pp.float ctx value
+  | true, Some value when value >= 0. -> Pp.float ctx value
   | _ -> pp_number ctx value
 
 let pp_aspect_ratio_pair ctx a b =

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -41,11 +41,14 @@ let rec numeric_flex_factor_calc_leaves : flex_factor calc -> flex_factor calc =
           numeric_flex_factor_calc_leaves right )
   | other -> other
 
+(* Sec. 7.2 gives both factors a [0,inf] [<number>], and CSS Values 4 sec. 10.12
+   clamps a math function past that range at computed-value time: unwrapping a
+   negative one would write CSS a browser drops. *)
 let rec normalize_flex_factor (value : flex_factor) : flex_factor =
   match value with
   | Calc c -> (
       match eval_calc (numeric_flex_factor_calc_leaves c) with
-      | Num f -> Number f
+      | Num f when f >= 0. -> Number f
       | Val v -> normalize_flex_factor v
       | folded -> if folded == c then value else Calc folded)
   | _ -> value
@@ -198,7 +201,14 @@ let rec pp_flex_factor : flex_factor Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_flex_factor ctx v
   | Number value -> Pp.float ctx value
-  | Calc c -> pp_calc pp_flex_factor ctx c
+  (* Sec. 7.2 refuses a negative factor written on its own, so the wrapper comes
+     off only around a leaf that is a factor by itself. *)
+  | Calc c ->
+      pp_calc
+        ~unwrap_num:(match c with Num f -> f >= 0. | _ -> true)
+        ~unwrap:(fun (v : flex_factor) ->
+          match v with Number f -> f >= 0. | _ -> true)
+        pp_flex_factor ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1391,6 +1391,7 @@ let rec pp_line_height : line_height Pp.t =
   | Var v -> pp_var pp_line_height ctx v
   | Calc c ->
       pp_calc
+        ~unwrap_num:(match c with Num f -> f >= 0. | _ -> true)
         ~unwrap:(fun v -> not (negative_line_height v))
         pp_line_height ctx c
 
@@ -2457,7 +2458,10 @@ let normalize_line_height ?(lossless = false) (lh : line_height) : line_height =
         if lossless || calc_has_computed_input c then Option.None
         else Option.map (Pp.round_sig 6) (Values.eval_numeric_calc c)
       with
-      | Option.Some f -> Num f
+      (* The [0,inf] range is checked on what the call resolves to, so the
+         six-figure result takes the same guard the exact fold below takes. *)
+      | Option.Some f when f >= 0. -> Num f
+      | Option.Some f -> Calc (Num f)
       | Option.None -> (
           match Values.eval_calc c with
           | Values.Num f when f >= 0. -> Num f

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -72,7 +72,7 @@ let rec numeric_stroke_width_calc_leaves :
 let rec normalize_stroke_width ~ctx (value : stroke_width) : stroke_width =
   match value with
   | Length lp ->
-      let lp' = Values.normalize_length_percentage ~ctx lp in
+      let lp' = Values.normalize_length_percentage ~ctx ~non_negative:true lp in
       if lp' == lp then value else Length lp'
   (* Sec. 13.5.3 calls a negative width invalid, and CSS Values 4 sec. 10.12
      clamps a math function past that range at computed-value time: unwrapping a

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -84,13 +84,15 @@ let rec normalize_stroke_width ~ctx (value : stroke_width) : stroke_width =
       | folded -> if folded == c then value else Calc folded)
   | _ -> value
 
+(* Sec. 13.5.4 calls a negative dash length an error, so the [0,inf] range holds
+   whichever branch of the production the value took. *)
 let normalize_dash_length ~ctx (value : dash_length) : dash_length =
   match value with
   | Number n ->
-      let n' = Values.normalize_number ~ctx n in
+      let n' = Values.normalize_number ~ctx ~non_negative:true n in
       if n' == n then value else Number n'
   | Length lp ->
-      let lp' = Values.normalize_length_percentage ~ctx lp in
+      let lp' = Values.normalize_length_percentage ~ctx ~non_negative:true lp in
       if lp' == lp then value else Length lp'
 
 let normalize_stroke_dashoffset ~ctx (value : stroke_dashoffset) :

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -779,8 +779,10 @@ let normalize_hyphenate_limit_chars_item ~ctx :
  fun item ->
   match item with
   | Auto -> item
+  (* Sec. 6.2 counts characters, so each slot is a [1,inf] [<integer>] and a
+     call folding below it keeps its wrapper. *)
   | Chars n ->
-      let n' = Values.normalize_number ~ctx n in
+      let n' = Values.normalize_number ~ctx ~non_negative:true n in
       if n' == n then item else Chars n'
 
 let normalize_hyphenate_limit_chars ~ctx :
@@ -874,11 +876,13 @@ let normalize_text_shadow ?(lossless = false) : text_shadow -> text_shadow =
            })
   | other -> other
 
+(* Sec. 4.2 gives the number a [0,inf] range, so a call folding below it keeps
+   its wrapper rather than becoming a literal the reader refuses. *)
 let normalize_tab_size ~ctx : tab_size -> tab_size =
  fun value ->
   match value with
   | Number n ->
-      let n' = Values.normalize_number ~ctx n in
+      let n' = Values.normalize_number ~ctx ~non_negative:true n in
       if n' == n then value else Number n'
   | other -> other
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4511,9 +4511,9 @@ let normalize_property_value : type a.
   | O_transition -> map_preserve normalize_transition value
   | List_style -> normalize_list_style value
   | Transition_timing_function -> normalize_timing_function value
-  | Animation -> map_preserve normalize_animation value
-  | Webkit_animation -> map_preserve normalize_animation value
-  | Moz_animation -> map_preserve normalize_animation value
+  | Animation -> map_preserve (normalize_animation ~ctx) value
+  | Webkit_animation -> map_preserve (normalize_animation ~ctx) value
+  | Moz_animation -> map_preserve (normalize_animation ~ctx) value
   | Animation_timing_function -> normalize_timing_function value
   | Padding_left -> Values.normalize_length ~non_negative:true ~ctx value
   | Padding_right -> Values.normalize_length ~non_negative:true ~ctx value

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3911,44 +3911,62 @@ let normalize_length_percentage ?(strip = true) ?(non_negative = false)
       if l' == l then lp else Length l'
   | _ -> lp
 
+(* The [<number>] counterpart of [negative_length]: a number a property whose
+   range starts at [0] refuses when it is written as a literal. *)
+let negative_number : number -> bool = function Num f -> f < 0. | _ -> false
+
 (* Evaluate the static CSS math functions on [<number>] (the folds the printer
    used to do under minify), so the printer stays a pure serialiser. Recurses so
    nested calls fold ([abs(hypot(3, 4))] -> [5]); a non-static operand keeps the
    call. *)
-let rec normalize_number ?(ctx = default_calc_ctx) (n : number) : number =
+let rec normalize_number ?(ctx = default_calc_ctx) ?(non_negative = false)
+    (n : number) : number =
+  (* CSS Values 4 sec. 10.12 checks the property's range on the value the whole
+     calculation resolves to rather than on each operand, so the operand fold
+     drops [non_negative]. *)
   let nf = normalize_number ~ctx in
-  match n with
-  | Calc c -> (
-      match eval_calc ~ctx c with
-      | Num f -> Num f
-      | Val v -> nf v
-      | folded -> Calc folded)
-  | Round (strategy, a, b) -> (
-      match (nf a, nf b) with
-      | Num value, Num step when step <> 0. ->
-          Num (round_to_step strategy value step)
-      | a, b -> Round (strategy, a, b))
-  | Mod (a, b) -> (
-      match (nf a, nf b) with
-      | Num a, Num b when b <> 0. -> Num (mod_value a b)
-      | a, b -> Mod (a, b))
-  | Rem (a, b) -> (
-      match (nf a, nf b) with
-      | Num a, Num b when b <> 0. -> Num (Float.rem a b)
-      | a, b -> Rem (a, b))
-  | Hypot (a, b) -> (
-      match (nf a, nf b) with
-      | Num a, Num b -> Num (Float.sqrt ((a *. a) +. (b *. b)))
-      | a, b -> Hypot (a, b))
-  | Pow (a, b) -> (
-      match (nf a, nf b) with
-      | Num a, Num b -> Num (Float.pow a b)
-      | a, b -> Pow (a, b))
-  | Sqrt v -> (
-      match nf v with Num a when a >= 0. -> Num (Float.sqrt a) | v -> Sqrt v)
-  | Abs v -> ( match nf v with Num a -> Num (Float.abs a) | v -> Abs v)
-  | Sign v -> Sign (nf v)
-  | Sin _ | Num _ | Var _ -> n
+  let result =
+    match n with
+    | Calc c -> (
+        match eval_calc ~ctx c with
+        | Num f -> Num f
+        | Val v -> nf v
+        | folded -> Calc folded)
+    | Round (strategy, a, b) -> (
+        match (nf a, nf b) with
+        | Num value, Num step when step <> 0. ->
+            Num (round_to_step strategy value step)
+        | a, b -> Round (strategy, a, b))
+    | Mod (a, b) -> (
+        match (nf a, nf b) with
+        | Num a, Num b when b <> 0. -> Num (mod_value a b)
+        | a, b -> Mod (a, b))
+    | Rem (a, b) -> (
+        match (nf a, nf b) with
+        | Num a, Num b when b <> 0. -> Num (Float.rem a b)
+        | a, b -> Rem (a, b))
+    | Hypot (a, b) -> (
+        match (nf a, nf b) with
+        | Num a, Num b -> Num (Float.sqrt ((a *. a) +. (b *. b)))
+        | a, b -> Hypot (a, b))
+    | Pow (a, b) -> (
+        match (nf a, nf b) with
+        | Num a, Num b -> Num (Float.pow a b)
+        | a, b -> Pow (a, b))
+    | Sqrt v -> (
+        match nf v with Num a when a >= 0. -> Num (Float.sqrt a) | v -> Sqrt v)
+    | Abs v -> ( match nf v with Num a -> Num (Float.abs a) | v -> Abs v)
+    | Sign v -> Sign (nf v)
+    | Sin _ | Num _ | Var _ -> n
+  in
+  (* Sec. 10.12 clamps a math function past the property's range at
+     computed-value time and keeps the declaration, so folding one to a literal
+     the reader then refuses would drop it: the arithmetic still folds, and the
+     call stays around the result. A literal that was already negative is the
+     reader's business, not this fold's. *)
+  match result with
+  | Num f when non_negative && f < 0. && not (negative_number n) -> Calc (Num f)
+  | _ -> result
 
 (* Fold the value-independent parts of a [<percentage>] [calc()] ([calc(1 / 2 *
    100%)] -> [calc(.5*100%)]), keeping any [var()]. Replaces the numeric /
@@ -5012,7 +5030,15 @@ let rec pp_number : number Pp.t =
   | Num f ->
       Pp.string ctx (Pp.string_of_float ~drop_leading_zero:(Pp.minified ctx) f)
   | Var v -> pp_var pp_number ctx v
-  | Calc c -> pp_calc_with pp_number ctx c
+  (* A negative number has no spelling at a property whose range starts at [0],
+     and which properties those are is not knowable here, so the wrapper stays
+     on a leaf that reads back differently without it. [normalize_number] has
+     already unwrapped the rest, where the property is in hand. *)
+  | Calc c ->
+      pp_calc_with
+        ~unwrap_num:(match c with Num f -> f >= 0. | _ -> true)
+        ~unwrap:(fun v -> not (negative_number v))
+        pp_number ctx c
   | Round (strategy, value, step) ->
       Pp.call "round"
         (fun ctx (strategy, value, step) ->

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -302,10 +302,12 @@ val normalize_number_percentage :
     stay opaque - inside a [calc()], the two spellings are not interchangeable.
 *)
 
-val normalize_number : ?ctx:calc_ctx -> number -> number
+val normalize_number : ?ctx:calc_ctx -> ?non_negative:bool -> number -> number
 (** [normalize_number n] evaluates the static CSS math functions on a [<number>]
     ([hypot(3, 4)] becomes [5], [calc(1 + 2)] becomes [3]), recursing into
-    nested calls; an operand with a [var()] keeps the call. *)
+    nested calls; an operand with a [var()] keeps the call. [non_negative] says
+    the property refuses a negative literal, so a call folding to one keeps its
+    wrapper rather than becoming CSS the reader drops. *)
 
 val normalize_percentage : ?ctx:calc_ctx -> percentage -> percentage
 (** [normalize_percentage p] folds the value-independent parts of a

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -2076,6 +2076,10 @@ let spec_math_range_keeps_the_call () =
   decl_optimizes ~prop:"stroke-dasharray" ~into:"calc(-1px)" "calc(-1px)";
   decl_optimizes ~prop:"stroke-dasharray" ~into:"calc(-1)" "sign(-1px)";
   decl_optimizes ~prop:"stroke-dasharray" ~into:"1px" "calc(1px)";
+  (* SVG 2 sec. 13.5.3 calls a negative [stroke-width] invalid, and the number
+     branch already kept its call: the length branch carries the same range. *)
+  decl_optimizes ~prop:"stroke-width" ~into:"calc(-1px)" "calc(-1px)";
+  decl_optimizes ~prop:"stroke-width" ~into:"calc(2px - 3px)" "calc(2px - 3px)";
   (* CSS Text 4 sec. 6.2 gives the three [hyphenate-limit-chars] counts a
      [1,inf] [<integer>]. *)
   decl_optimizes ~prop:"hyphenate-limit-chars" ~into:"calc(-1)" "sign(-1px)";
@@ -2128,6 +2132,7 @@ let spec_minified_output_reads_back () =
     [ "sign(-1px)"; "calc(-1)"; "sign(-1px),2" ];
   reads_back "animation" [ "sign(-1px)"; "calc(-1)"; "2s linear calc(1 + 2)" ];
   reads_back "stroke-dasharray" [ "calc(-1px)"; "sign(-1px)"; "calc(1px)" ];
+  reads_back "stroke-width" [ "calc(-1px)"; "calc(2px - 3px)"; "sign(-1px)" ];
   reads_back "hyphenate-limit-chars" [ "sign(-1px)"; "calc(-1)"; "calc(4)" ];
   (* The durations the sibling range guard already keeps, pinned here so the
      fixed-point half of the property covers them too. *)

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -2066,6 +2066,10 @@ let spec_math_range_keeps_the_call () =
   decl_optimizes ~prop:"animation-iteration-count" ~into:"calc(-1),2"
     "sign(-1px),2";
   decl_optimizes ~prop:"animation-iteration-count" ~into:"2" "calc(2)";
+  (* The shorthand normalises the slots it holds, so the count folds where the
+     longhand folds instead of waiting for a second pass over the output. *)
+  decl_optimizes ~prop:"animation" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"animation" ~into:"2s linear 3" "2s linear calc(1 + 2)";
   (* SVG 2 sec. 13.5.4 makes a negative dash length an error, so each item
      carries the range whichever branch of [<length-percentage> | <number>] it
      took. *)
@@ -2122,6 +2126,7 @@ let spec_minified_output_reads_back () =
   reads_back "tab-size" [ "sign(-1px)"; "calc(-1)"; "round(-3,2)" ];
   reads_back "animation-iteration-count"
     [ "sign(-1px)"; "calc(-1)"; "sign(-1px),2" ];
+  reads_back "animation" [ "sign(-1px)"; "calc(-1)"; "2s linear calc(1 + 2)" ];
   reads_back "stroke-dasharray" [ "calc(-1px)"; "sign(-1px)"; "calc(1px)" ];
   reads_back "hyphenate-limit-chars" [ "sign(-1px)"; "calc(-1)"; "calc(4)" ];
   (* The durations the sibling range guard already keeps, pinned here so the

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -2014,6 +2014,121 @@ let spec_math_at_the_remaining_readers () =
      durations Chrome refuses whatever the spelling stay refused. *)
   neg_cursor read_duration "calc(-1s)"
 
+(* Sec. 9.1 is explicit that "width: -5px is not equivalent to width:
+   calc(-5px)", because "out-of-range values specified literally are invalid at
+   parse-time", and sec. 10.13 drops the wrapper only "of a computed value or
+   later". A minifier serialises specified values, so a call folding outside the
+   property's [0,inf] range keeps its wrapper: the literal underneath is a
+   spelling the property's own grammar refuses. The arithmetic still folds, so
+   what is kept is the shortest call, not the authored one. Chrome 153 reads
+   every wrapped row below and drops every unwrapped one. *)
+let spec_math_range_keeps_the_call () =
+  (* CSS Sizing 4 sec. 5 gives [<ratio>] the [0,inf] numbers of sec. 6.5. *)
+  decl_optimizes ~prop:"aspect-ratio" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"aspect-ratio" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"aspect-ratio" ~into:"calc(-4)" "round(-3,2)";
+  decl_optimizes ~prop:"aspect-ratio" ~into:"1" "calc(1)";
+  decl_optimizes ~prop:"aspect-ratio" ~into:"1" "1";
+  (* CSS Backgrounds 3 sec. 4.1 gives each radius a [0,inf]
+     [<length-percentage>]; the shorthand carries the range its longhands
+     carry. *)
+  decl_optimizes ~prop:"border-radius" ~into:"calc(-1px)" "calc(-1px)";
+  (* The [<length>] guard keeps the call as authored rather than the folded one
+     ([width: calc(-5px - 5px)] is the same shape), so the arithmetic under a
+     kept wrapper stays where the author put it. *)
+  decl_optimizes ~prop:"border-radius" ~into:"calc(-1px*2)" "calc(-1px * 2)";
+  decl_optimizes ~prop:"border-radius" ~into:"1px" "calc(1px)";
+  (* CSS Flexbox 1 sec. 7.2 gives both factors a [0,inf] [<number>], through the
+     shorthand and the two longhands alike. *)
+  decl_optimizes ~prop:"flex" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"flex" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"flex" ~into:"1" "calc(1)";
+  decl_optimizes ~prop:"flex-grow" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"flex-grow" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"flex-grow" ~into:"calc(-4)" "round(-3,2)";
+  decl_optimizes ~prop:"flex-grow" ~into:"2" "calc(2)";
+  decl_optimizes ~prop:"flex-shrink" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"flex-shrink" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"flex-shrink" ~into:"2" "calc(2)";
+  (* CSS Inline 3 sec. 2.2 gives [line-height] a [0,inf] number and length. *)
+  decl_optimizes ~prop:"line-height" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"line-height" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"line-height" ~into:"1.5" "calc(1.5)";
+  (* CSS Text 4 sec. 4.2 [tab-size], [0,inf]. *)
+  decl_optimizes ~prop:"tab-size" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"tab-size" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"tab-size" ~into:"calc(-4)" "round(-3,2)";
+  decl_optimizes ~prop:"tab-size" ~into:"4" "calc(4)";
+  (* CSS Animations 1 sec. 3.4 [animation-iteration-count], [0,inf], and the
+     shorthand slot that reads through it. *)
+  decl_optimizes ~prop:"animation-iteration-count" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"animation-iteration-count" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"animation-iteration-count" ~into:"calc(-1),2"
+    "sign(-1px),2";
+  decl_optimizes ~prop:"animation-iteration-count" ~into:"2" "calc(2)";
+  (* SVG 2 sec. 13.5.4 makes a negative dash length an error, so each item
+     carries the range whichever branch of [<length-percentage> | <number>] it
+     took. *)
+  decl_optimizes ~prop:"stroke-dasharray" ~into:"calc(-1px)" "calc(-1px)";
+  decl_optimizes ~prop:"stroke-dasharray" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"stroke-dasharray" ~into:"1px" "calc(1px)";
+  (* CSS Text 4 sec. 6.2 gives the three [hyphenate-limit-chars] counts a
+     [1,inf] [<integer>]. *)
+  decl_optimizes ~prop:"hyphenate-limit-chars" ~into:"calc(-1)" "sign(-1px)";
+  decl_optimizes ~prop:"hyphenate-limit-chars" ~into:"calc(-1)" "calc(-1)";
+  decl_optimizes ~prop:"hyphenate-limit-chars" ~into:"4" "calc(4)";
+  (* The folds that stay folds: a call landing inside the range has no reason to
+     keep a wrapper, and a property with no lower bound never grows one. *)
+  decl_optimizes ~prop:"width" ~into:"3px" "calc(1px + 2px)";
+  decl_optimizes ~prop:"opacity" ~into:".5" "calc(.5)";
+  decl_optimizes ~prop:"width" ~into:"3.14159px" "calc(pi * 1px)";
+  decl_optimizes ~prop:"z-index" ~into:"2" "calc(2)";
+  decl_optimizes ~prop:"width" ~into:"calc(-10px)" "calc(-10px)";
+  decl_optimizes ~prop:"border-width" ~into:"calc(-1px)" "calc(-1px)";
+  decl_optimizes ~prop:"width" ~into:"1px" "abs(-1px)";
+  decl_optimizes ~prop:"margin" ~into:"-10px" "calc(-10px)";
+  decl_optimizes ~prop:"scale" ~into:"-1" "sign(-1px)"
+
+(* Minified output is input: every declaration Cascade writes has to read back
+   through Cascade's own grammar, with no warning and no second fold. The ten
+   properties below each folded a math function to a literal their own reader
+   refuses, so each one wrote CSS it could not read. *)
+let decl_reads_back ~prop input =
+  let wrap v = String.concat "" [ ".x{"; prop; ":"; v; "}" ] in
+  let minify p = Css.to_string ~minify:true (Css.optimize p) |> String.trim in
+  match Css.of_string ~strict:false (wrap input) with
+  | Error _ -> Alcotest.failf "parse failed: %s" (wrap input)
+  | Ok p -> (
+      let out = minify p.stylesheet in
+      match Css.of_string ~strict:true out with
+      | Error e ->
+          Alcotest.failf "%s wrote %S, which it refuses to read: %s"
+            (wrap input) out (Error.to_string e)
+      | Ok back ->
+          (* A second pass must not move: a value that folds again was never
+             minified, it was only half-folded. *)
+          Alcotest.(check string)
+            (String.concat "" [ wrap input; " is a fixed point" ])
+            out (minify back.stylesheet))
+
+let spec_minified_output_reads_back () =
+  let reads_back prop = List.iter (decl_reads_back ~prop) in
+  reads_back "aspect-ratio" [ "sign(-1px)"; "calc(-1)"; "round(-3,2)"; "1" ];
+  reads_back "border-radius" [ "calc(-1px)"; "calc(-1px * 2)"; "1px" ];
+  reads_back "flex" [ "sign(-1px)"; "calc(-1)"; "calc(1)" ];
+  reads_back "flex-grow" [ "sign(-1px)"; "calc(-1)"; "round(-3,2)" ];
+  reads_back "flex-shrink" [ "sign(-1px)"; "calc(-1)"; "calc(2)" ];
+  reads_back "line-height" [ "sign(-1px)"; "calc(-1)"; "calc(1.5)" ];
+  reads_back "tab-size" [ "sign(-1px)"; "calc(-1)"; "round(-3,2)" ];
+  reads_back "animation-iteration-count"
+    [ "sign(-1px)"; "calc(-1)"; "sign(-1px),2" ];
+  reads_back "stroke-dasharray" [ "calc(-1px)"; "sign(-1px)"; "calc(1px)" ];
+  reads_back "hyphenate-limit-chars" [ "sign(-1px)"; "calc(-1)"; "calc(4)" ];
+  (* The durations the sibling range guard already keeps, pinned here so the
+     fixed-point half of the property covers them too. *)
+  reads_back "transition-duration" [ "calc(120ms)"; "calc(1s + 200ms)" ];
+  reads_back "interest-delay" [ "calc(-1s)" ]
+
 let test_attr_syntax () =
   check_attr_syntax "<length>";
   check_attr_syntax "<length-percentage>";
@@ -2201,6 +2316,10 @@ let value_tests =
       spec_stepped_value_dimensions;
     test_case "spec math at the remaining readers" `Quick
       spec_math_at_the_remaining_readers;
+    test_case "spec math range keeps the call" `Quick
+      spec_math_range_keeps_the_call;
+    test_case "spec minified output reads back" `Quick
+      spec_minified_output_reads_back;
   ]
 
 let suite = ("values", value_tests)


### PR DESCRIPTION
The range guard was built for lengths and times and never for numbers, so a property whose `<number>` is `[0,inf]` folded a math call straight to a literal its own reader rejects: `aspect-ratio: sign(-1px)` wrote `aspect-ratio: -1`, which cascade then refused to read and which Chrome drops while accepting the input. CSS Values 4 sec. 9.1 makes an out-of-range literal invalid at parse time where the call is not. Eleven properties, plus the `animation` shorthand which never folded its own count slot and so needed a second pass.