### PR TITLE
values: drop a length's authored spelling once the round-trip is over

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -517,6 +517,11 @@ to lose a whole rule over one bad piece. Both are gone.
 - Computed-value evaluation resolves a direct `inherit`, `initial`, `unset`,
   `revert` or `revert-layer` for every typed property, and whether a property
   inherits is decided in one place from the typed property (#763, #764)
+- A length reaching one minified text through two nodes is one node, so
+  `a{width:1.0px}b{width:1px}` merges in the pass that minifies it rather than
+  the one after. `Declaration.hash` keys the structural value and short-circuits
+  `Declaration.same_minified`, and the reader kept an authored spelling the
+  printer already discards, so one text arrived through two nodes (#1150)
 - `--minify` and `cascade diff` are faster on a large stylesheet, for
   byte-identical output. The slowest corpus stylesheet drops sharply, a long run
   of rules sharing one selector no longer allocates quadratically, a 4,000

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1959,6 +1959,24 @@ let length_of_unit unit n =
 let length_of_calc_unit (unit : length_unit) n : length =
   match unit with Px -> Px n | _ -> length_of_unit unit n
 
+(* CSS Syntax 3 (ED) sec. 4.3.12 builds a number's value from its sign, digits,
+   fraction and exponent, so [1.0px], [+1px], [01px] and [1e3px] name lengths
+   the constructors above already hold. The reader keeps such a spelling in a
+   [Dimension] for the unminified round-trip, and the printer drops it under
+   [--minify]: two spellings then reach one minified text through two nodes,
+   which anything keyed on the node reads as two values. Fold back to the
+   constructor once the round-trip no longer needs the spelling. Only a unit the
+   constructor prints back verbatim folds, so no byte moves; a zero is left to
+   [strip_zero_length], whose unit strip is a type change this is not. *)
+let canonical_dimension (l : length) : length =
+  match l with
+  | Dimension { value; unit; _ }
+    when value <> 0. && String.equal (String.lowercase_ascii unit) unit -> (
+      match unit_of_string unit with
+      | Some unit -> length_of_unit unit value
+      | None -> l)
+  | _ -> l
+
 type linear_term = {
   unit : length_unit;
   value : float;
@@ -3882,7 +3900,7 @@ let rec normalize_length ?(strip = true) ?(non_negative = false)
           |> eval_length_calc ~ctx
         with
         | folded -> Calc_size (basis, folded))
-    | _ -> l
+    | _ -> canonical_dimension l
   in
   (* CSS Values 4 sec. 10.12 clamps a math function whose value falls outside
      the property's range at computed-value time and keeps the declaration, so

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6971,6 +6971,69 @@ let hex_spellings_have_one_node () =
   distinct_value "#fff vs #fff8" short_lower
     (sole_declaration ".e{color:#FFF8}")
 
+(* CSS Syntax 3 (ED) sec. 4.3.12 builds a <number-token>'s value from an
+   optional sign, a digit run, an optional fraction and an optional exponent, so
+   [1px], [1.0px], [+1px], [01px] and [1e0px] are one length, as [1e3px] and
+   [1000px] are. The AST keeps the authored spelling for the unminified
+   round-trip only; once optimisation has canonicalised it away the spellings
+   are one declaration, they hash alike, and the rules holding them merge in the
+   single pass the optimizer's fixpoint promises. *)
+let number_spellings_have_one_node () =
+  let canonical = sole_declaration ".a{width:1px}" in
+  List.iter
+    (fun spelling ->
+      let d =
+        sole_declaration (String.concat "" [ ".b{width:"; spelling; "}" ])
+      in
+      Alcotest.(check string)
+        (spelling ^ ": the fold spells 1px")
+        "width:1px"
+        (Css.Declaration.to_string ~minify:true d);
+      same_text_same_hash (spelling ^ " vs 1px") d canonical)
+    [ "1.0px"; "1.00px"; "+1px"; "01px"; "1e0px"; "1E0px" ];
+  (* An exponent the printer does not keep names the number it stands for. *)
+  same_text_same_hash "1e3px vs 1000px"
+    (sole_declaration ".a{width:1e3px}")
+    (sole_declaration ".b{width:1000px}");
+  Alcotest.(check string)
+    "the spellings merge in one pass" ".a,.b{width:1px}"
+    (minified ".a{width:1.0px}.b{width:1px}");
+  Alcotest.(check string)
+    "an exponent merges in one pass" ".a,.b{width:1000px}"
+    (minified ".a{width:1e3px}.b{width:1000px}");
+  (* The same node feeds the box contraction: a side spelled differently held
+     the shorthand open until a second pass re-read it. *)
+  Alcotest.(check string)
+    "the box contracts in one pass" ".a{padding:1px}"
+    (minified ".a{padding:1px;padding-bottom:1E0px}")
+
+(* What the fold above must not reach. A unit or a type carries a value the
+   number alone does not, and CSS Variables 1 sec. 4.1 forbids normalizing a
+   custom property at all, so its authored spelling stays a value of its own. *)
+let number_spellings_keep_their_value () =
+  let px = sole_declaration ".a{width:1px}" in
+  distinct_value "1px vs 1pt" px (sole_declaration ".b{width:1pt}");
+  distinct_value "1px vs 1%" px (sole_declaration ".c{width:1%}");
+  distinct_value "1px vs 2px" px (sole_declaration ".d{width:2px}");
+  (* Sec. 6 of CSS Values 4 drops a zero length's unit, so these two already
+     were one declaration. *)
+  same_text_same_hash "0 vs 0px"
+    (sole_declaration ".a{width:0}")
+    (sole_declaration ".b{width:0px}");
+  (* CSS Color 4 sec. 5.2: the hex and the name are one colour, and already
+     were. *)
+  same_text_same_hash "red vs #f00"
+    (sole_declaration ".a{color:red}")
+    (sole_declaration ".b{color:#f00}");
+  (* A custom property holds the token stream the author wrote, so its two
+     spellings stay two declarations even where the printer gives them one
+     text. *)
+  let custom = sole_declaration ".a{--x:1.0px}" in
+  let custom' = sole_declaration ".b{--x:1px}" in
+  Alcotest.(check bool)
+    "a custom property is not folded" false
+    (Css.Declaration.equal_declaration custom custom')
+
 (* Cascade keeps no raw-token sidecar, so a printed declaration is rebuilt from
    its typed values alone: reading the print back has to land on the node that
    printed it, not merely on the same text. *)
@@ -7137,6 +7200,10 @@ let declaration_tests =
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;
+    test_case "number spellings have one node" `Quick
+      number_spellings_have_one_node;
+    test_case "number spellings keep their value" `Quick
+      number_spellings_keep_their_value;
     test_case "parse_declaration" `Quick parse_declaration_case;
     (* Parsing basics *)
     test_case "simple" `Quick simple;


### PR DESCRIPTION
Two declarations that render to the same minified text did not compare equal, so `a{width:1.0px}b{width:1px}` needed a second `--minify` pass to merge. `Declaration.hash` keys the structural value and short-circuits `same_minified`, and the reader kept an authored spelling that the printer already discards under `--minify`, so one text arrived through two nodes. Folding the node back to its constructor moves hash and equality together; no minified byte can change, since the fold fires only where the constructor prints the same unit back.