### PR TITLE
values: type a scalar-folding math call at a calc sum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,13 @@ entry points both moved.
 
 ### Breaking
 
+- A calculation whose sum has no consistent type is dropped, so
+  `width: calc(sqrt(4) - 1px)`, `border-width: abs(-1)` and
+  `width: calc(sign(-1px))` are refused where they were written back as
+  `calc(2 - 1px)` and the like, which cascade's own reader also refuses. CSS
+  Values 4 sec. 10.9 fails the whole calculation when adding the types of a
+  `+` or `-` fails; an angle-valued call still adds to an angle, so
+  `rotate: calc(atan(1) + 10deg)` reads (#1151)
 - A math function reads wherever the grammar allows its type, with no `calc()`
   wrapper needed, so `font-weight: calc(400)`, `zoom: calc(.5)`,
   `grid-row-start: calc(2) center`, `width: abs(-1px)`, `opacity: pow(2, 3)`

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5808,6 +5808,17 @@ type inferred_calc_type =
   | Deferred
   | Invalid
 
+(* The type a call folding to a bare coefficient answers. Sec. 10.4 gives the
+   inverse trigonometric functions an [<angle>] that [math_fn_result] carries as
+   a bare degree count, so the coefficient names no type to check and they stay
+   deferred. Every other function here is [<number>] out, so sec. 10.9 types the
+   sum it sits in. *)
+let math_fn_scalar_type = function
+  | Asin _ | Acos _ | Atan _ | Atan2 _ -> Deferred
+  | Sin _ | Cos _ | Tan _ | Sqrt _ | Exp _ | Log _ | Pow _ | Hypot _ | Sign_n _
+  | Abs_n _ | Round_n _ | Mod_n _ | Rem_n _ ->
+      Dimension 0
+
 (* Inside an operand tree a call that answers its arguments' type is the
    contextual dimension: the leaf reader beside it has already vouched for the
    unit. Only a whole calculation keeps the unit for the slot to judge. *)
@@ -5826,7 +5837,9 @@ and infer_calc_type : type a. a calc -> inferred_calc_type = function
   | Math_fn fn -> (
       match math_fn_result fn with
       | Some (United (_, unit)) -> Result_unit unit
-      | Some (Scalar _) | None -> Deferred)
+      | Some (Scalar _) -> math_fn_scalar_type fn
+      (* A call that does not fold keeps no type to check against. *)
+      | None -> Deferred)
   | Nested inner | Parens inner -> infer_calc_type inner
   | Expr (left, (Add | Sub), right) -> (
       match (infer_calc_operand left, infer_calc_operand right) with

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1909,6 +1909,50 @@ let spec_math_result_type () =
   decl_optimizes ~prop:"opacity" ~into:".5" "calc(abs(-.5))";
   decl_optimizes ~prop:"width" ~into:"1px" "calc(abs(-1px))"
 
+(* CSS Values 4 (ED) sec. 10.9 Type Checking: at a [+] or [-] sub-expression the
+   two argument types are added, and "if this returns failure, the entire
+   calculation's type is failure". A call answering a [<number>] therefore fails
+   the whole sum beside a dimension, and stands nowhere a [<number>] does not.
+   Chrome 153 rejects every row here, cascade's own [calc(2 - 1px)] among
+   them. *)
+let spec_math_sum_type_check () =
+  let module P = Css.Properties in
+  (* A [<number>] call on either side of a [<length>] sum fails the sum. *)
+  neg_cursor read_length "calc(sqrt(4) - 1px)";
+  neg_cursor read_length "calc(1px - sqrt(4))";
+  neg_cursor read_length "calc(sqrt(4) + 1px)";
+  neg_cursor read_length "calc(sign(-1px) - 1px)";
+  (* The failure is the sum's, not the call's: the same call multiplied by a
+     dimension is the dimension sec. 10.9 gives a product. *)
+  check_length ~minify:false "calc(sqrt(4) * 1px)";
+  check_length ~minify:false ~expected:"calc(sqrt(4) * 1px)" "calc(sqrt(4)*1px)";
+  (* A [<number>] call standing alone at a [<length>] slot fails the same way,
+     wrapped in [calc()] or not. *)
+  neg_cursor read_length "abs(-1)";
+  neg_cursor read_length "calc(abs(-1))";
+  neg_cursor read_length "calc(sign(-1px))";
+  neg_cursor P.read_border_width "abs(-1)";
+  neg_cursor P.read_border_width "calc(sign(-1px))";
+  (* Sec. 10.4 gives the inverse trigonometric functions an [<angle>], so they
+     are the one scalar-folding family that is not a [<number>]: the sum they
+     sit in keeps them where the [<number>] families fail it. *)
+  decl_optimizes ~prop:"rotate" ~into:"55deg" "calc(atan(1) + 10deg)";
+  decl_optimizes ~prop:"rotate" ~into:"40deg" "calc(atan2(1,1) - 5deg)";
+  decl_optimizes ~prop:"rotate" ~into:"45deg" "atan(1)";
+  (* Sec. 10.4 [sin()], [cos()] and [tan()] answer a [<number>] whatever went
+     in, so they fail the [<angle>] sum the inverse family holds. *)
+  neg_cursor read_angle "calc(sin(0) + 10deg)";
+  neg_cursor read_angle "calc(sqrt(4) + 10deg)";
+  (* Sec. 10.9 checks a [<time>] sum the same way. *)
+  neg_cursor read_duration "calc(sqrt(4) + 1s)";
+  check_duration ~minify:false "calc(sqrt(4) * 1s)";
+  (* A [<number>] sum stays a [<number>] and lands where one lands. *)
+  decl_optimizes ~prop:"opacity" ~into:"1" "calc(sqrt(4) - 1)";
+  decl_optimizes ~prop:"z-index" ~into:"2" "calc(2)";
+  (* A dimension sum is untouched by the check. *)
+  decl_optimizes ~prop:"width" ~into:"3px" "calc(1px + 2px)";
+  decl_optimizes ~prop:"width" ~into:"calc(100% - 10px)" "calc(100% - 10px)"
+
 (* CSS Values 4 (ED) sec. 10.9 spells the arguments of [round()], [mod()] and
    [rem()] as [<calc-sum>], so a dimension is one of them, and sec. 10.2 gives
    the call the type its arguments have. The stepped-value functions therefore
@@ -2242,7 +2286,12 @@ let test_calc_operator_whitespace () =
   check_length ~minify:false "calc((1px) - (2px))";
   check_length ~minify:false "calc((1px + 2px) - 3px)";
   check_length ~minify:false "calc(min(1px, 2px) - 3px)";
-  check_length ~minify:false "calc(sqrt(4) - 1px)";
+  (* [calc(sqrt(4) - 1px)] is the one rejection above whose spaced spelling does
+     not come back: sec. 10.9 Type Checking adds the types at a [-], and a
+     [<number>] beside a [<length>] returns failure, which is the whole
+     calculation's type. The whitespace rule keeps its math-function operand in
+     the [min(1px, 2px)] row above. *)
+  neg_cursor read_length "calc(sqrt(4) - 1px)";
   check_length ~minify:false "calc(sqrt(4 - 1) * 1px)";
   check_length ~minify:false "calc(1px * 2 - 1px)";
   check_length ~minify:false ~expected:"calc(100% - 10px)"
@@ -2322,6 +2371,7 @@ let value_tests =
     test_case "spec math operand range" `Quick spec_math_operand_range;
     test_case "spec bare math functions" `Quick spec_bare_math_functions;
     test_case "spec math result type" `Quick spec_math_result_type;
+    test_case "spec math sum type check" `Quick spec_math_sum_type_check;
     test_case "spec stepped value dimensions" `Quick
       spec_stepped_value_dimensions;
     test_case "spec math at the remaining readers" `Quick


### PR DESCRIPTION
A `<number>`-typed math call was never type-checked inside a dimensioned sum, so `width: calc(sqrt(4) - 1px)` was written back as `calc(2 - 1px)`, which Chrome drops and which cascade's own reader also refuses. CSS Values 4 sec. 10.9 fails the whole calculation when adding the operand types fails. The inverse trigonometric functions stay deferred rather than scalar, so an angle-valued call still adds to an angle.