### PR TITLE
values: type the math at a percentage slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,11 @@ entry points both moved.
   Values 4 sec. 10.9 fails the whole calculation when adding the types of a
   `+` or `-` fails; an angle-valued call still adds to an angle, so
   `rotate: calc(atan(1) + 10deg)` reads (#1151)
+- A percentage slot refuses a length-valued math call, so `scale: abs(-1px)`,
+  `font-stretch: hypot(3px, 4px)` and `text-size-adjust: round(1.5px, 1px)` are
+  dropped, and `font-stretch: calc(inherit)` no longer prints a live `inherit`.
+  A keyword is not a `<calc-value>` there either, so `calc(normal)` and
+  `calc(none)` are dropped (#1153)
 - A math function reads wherever the grammar allows its type, with no `calc()`
   wrapper needed, so `font-weight: calc(400)`, `zoom: calc(.5)`,
   `grid-row-start: calc(2) center`, `width: abs(-1px)`, `opacity: pow(2, 3)`

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -2016,42 +2016,54 @@ let rec read_font t : font =
         in
         Shorthand body
 
-let rec read_font_stretch t : font_stretch =
+let rec read_font_stretch_with ~keywords t : font_stretch =
   let read_percentage t : font_stretch =
     let n = Cursor.pct t in
     (* CSS Fonts 4 sec. 2.3: font-stretch percentage is non-negative. *)
     if n < 0. then err_invalid_value t "font-stretch" (string_of_float n);
     Pct n
   in
-  (* CSS Values 4 sec. 10.1 puts a math function wherever the [<percentage>]
-     stands, [calc()] being one of them rather than the gate to the rest, and
-     sec. 10.12 checks the [0,inf] range on the value it resolves to: the call
-     keeps out of [read_percentage], which is the literal's range check. *)
+  (* Sec. 10.1 puts a math function wherever the [<percentage>] stands, [calc()]
+     being one of them rather than the gate to the rest, and sec. 10.12 checks
+     the [0,inf] range on the value it resolves to: the call keeps out of
+     [read_percentage], which is the literal's range check. Sec. 2.3.1 spells
+     the width a [<percentage>] with no [<number>] beside it, so a call
+     answering a [<length>] or a bare coefficient is none of its types. Sec.
+     10.8 gives an operand no keyword, so [calc(inherit)] and [calc(condensed)]
+     fail the way the browser drops them rather than surviving as a [Calc] the
+     printer unwraps into a live value. *)
   let read_math t : font_stretch =
-    Calc (read_calc ~result_type:`Value read_font_stretch t)
+    Calc
+      (read_calc ~result_type:`Percentage
+         (read_font_stretch_with ~keywords:false)
+         t)
   in
   Cursor.enum_or_calls "font-stretch"
-    [
-      ("ultra-condensed", Ultra_condensed);
-      ("extra-condensed", Extra_condensed);
-      ("condensed", Condensed);
-      ("semi-condensed", Semi_condensed);
-      ("normal", Normal);
-      ("semi-expanded", Semi_expanded);
-      ("expanded", Expanded);
-      ("extra-expanded", Extra_expanded);
-      ("ultra-expanded", Ultra_expanded);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
+    (if keywords then
+       [
+         ("ultra-condensed", (Ultra_condensed : font_stretch));
+         ("extra-condensed", Extra_condensed);
+         ("condensed", Condensed);
+         ("semi-condensed", Semi_condensed);
+         ("normal", Normal);
+         ("semi-expanded", Semi_expanded);
+         ("expanded", Expanded);
+         ("extra-expanded", Extra_expanded);
+         ("ultra-expanded", Ultra_expanded);
+         ("inherit", Inherit);
+         ("initial", Initial);
+         ("unset", Unset);
+         ("revert", Revert);
+         ("revert-layer", Revert_layer);
+       ]
+     else [])
     ~calls:
-      (("var", fun t -> Var (read_var read_font_stretch t))
+      (("var", fun t -> Var (read_var (read_font_stretch_with ~keywords) t))
       :: ("calc", read_math)
       :: Values.math_function_calls read_math)
     ~default:read_percentage t
+
+let read_font_stretch t : font_stretch = read_font_stretch_with ~keywords:true t
 
 let rec read_font_display t : font_display =
   Cursor.enum_or_var "font-display"

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -2105,7 +2105,7 @@ let rec read_hyphens t : hyphens =
     ~var:(fun t -> Var (Values.read_var read_hyphens t))
     t
 
-let rec read_text_size_adjust t : text_size_adjust =
+let rec read_text_size_adjust_with ~keywords t : text_size_adjust =
   Cursor.ws t;
   match Cursor.percentage_opt t with
   | Some n ->
@@ -2113,27 +2113,43 @@ let rec read_text_size_adjust t : text_size_adjust =
         Cursor.err t "text-size-adjust percentages cannot be negative"
       else Pct n
   | _ ->
-      (* CSS Values 4 sec. 10.1 puts a math function wherever the [<percentage>]
-         stands, [calc()] being one of them rather than the gate to the rest,
-         and sec. 10.12 checks the [0,inf] range on the value it resolves to. *)
+      (* Sec. 10.1 puts a math function wherever the [<percentage>] stands,
+         [calc()] being one of them rather than the gate to the rest, and sec.
+         10.12 checks the [0,inf] range on the value it resolves to. CSS Size
+         Adjustment 1 sec. 3 spells the adjustment a [<percentage>] with no
+         [<number>] beside it, so a call answering a [<length>] or a bare
+         coefficient is none of its types. Sec. 10.8 gives an operand no
+         keyword, so [calc(inherit)] and [calc(2 * auto)] fail the way the
+         browser drops them rather than surviving as a [Calc] the printer
+         unwraps into a live value. *)
       let read_math t : text_size_adjust =
-        Calc (Values.read_calc ~result_type:`Value read_text_size_adjust t)
+        Calc
+          (Values.read_calc ~result_type:`Percentage
+             (read_text_size_adjust_with ~keywords:false)
+             t)
       in
       Cursor.enum_or_calls "text-size-adjust"
-        [
-          ("none", (None : text_size_adjust));
-          ("auto", Auto);
-          ("inherit", Inherit);
-          ("initial", Initial);
-          ("unset", Unset);
-          ("revert", Revert);
-          ("revert-layer", Revert_layer);
-        ]
+        (if keywords then
+           [
+             ("none", (None : text_size_adjust));
+             ("auto", Auto);
+             ("inherit", Inherit);
+             ("initial", Initial);
+             ("unset", Unset);
+             ("revert", Revert);
+             ("revert-layer", Revert_layer);
+           ]
+         else [])
         ~calls:
-          (("var", fun t -> Var (Values.read_var read_text_size_adjust t))
+          (( "var",
+             fun t ->
+               Var (Values.read_var (read_text_size_adjust_with ~keywords) t) )
           :: ("calc", read_math)
           :: Values.math_function_calls read_math)
         t
+
+let read_text_size_adjust t : text_size_adjust =
+  read_text_size_adjust_with ~keywords:true t
 
 let rec read_tab_size (t : Cursor.t) : tab_size =
   let checked t (n : number) : tab_size =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5867,14 +5867,19 @@ let validate_calc_type t result_type calc =
     | _, Deferred -> true
     (* A call answering its arguments' type stands where that type stands: at a
        [<number>] slot it does not, and at an [<opacity-value>] only the
-       [<percentage>] the slot resolves against its number does. *)
+       [<percentage>] the slot resolves against its number does. [`Value] is the
+       slot whose contextual dimension the leaf reader already vouched for, so
+       the unit is that one; a [<percentage>] slot names its own. *)
     | `Number, Result_unit _ -> false
-    | `Number_or_percentage, Result_unit unit -> String.equal unit "%"
+    | (`Number_or_percentage | `Percentage), Result_unit unit ->
+        String.equal unit "%"
     | (`Value | `Number_or_value), Result_unit _ -> true
-    | `Number, Dimension 0 | `Value, Dimension 1 -> true
+    | `Number, Dimension 0 -> true
+    | (`Value | `Percentage), Dimension 1 -> true
     | (`Number_or_value | `Number_or_percentage), (Dimension 0 | Dimension 1) ->
         true
-    | ( (`Number | `Value | `Number_or_value | `Number_or_percentage),
+    | ( ( `Number | `Value | `Number_or_value | `Number_or_percentage
+        | `Percentage ),
         (Invalid | Dimension _) ) ->
         false
   in
@@ -5923,7 +5928,12 @@ let typed_math_function_calls read =
   List.map (fun n -> (n, read)) typed_math_function_names
 
 let read_calc : type a.
-    ?result_type:[ `Number | `Number_or_percentage | `Number_or_value | `Value ] ->
+    ?result_type:
+      [ `Number
+      | `Number_or_percentage
+      | `Number_or_value
+      | `Percentage
+      | `Value ] ->
     (Cursor.t -> a) ->
     Cursor.t ->
     a calc =
@@ -7815,9 +7825,11 @@ let rec read_number_percentage t : number_percentage =
     (* CSS Values 4 sec. 10.1 puts every math function where [calc()] stands,
        and sec. 10.12 checks the property's range on what the call resolves to,
        so the call is held rather than folded to a literal the reader would then
-       refuse. *)
+       refuse. Sec. 10.9 admits only what the slot's two types name: a call
+       answering a [<length>] is neither. *)
     Calc
-      (read_calc ~result_type:`Number_or_value read_number_percentage_dim_only t)
+      (read_calc ~result_type:`Number_or_percentage
+         read_number_percentage_dim_only t)
   else
     (* Try to read as percentage or number *)
     Cursor.one_of

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -652,7 +652,8 @@ val read_number_percentage : Cursor.t -> number_percentage
 (** [read_number_percentage t] parses a CSS number or percentage. *)
 
 val read_calc :
-  ?result_type:[ `Number | `Number_or_percentage | `Number_or_value | `Value ] ->
+  ?result_type:
+    [ `Number | `Number_or_percentage | `Number_or_value | `Percentage | `Value ] ->
   (Cursor.t -> 'a) ->
   Cursor.t ->
   'a calc
@@ -664,7 +665,11 @@ val read_calc :
 
     [`Number_or_percentage] is the [<number> | <percentage>] slot of an
     [<opacity-value>]: it parts with [`Number_or_value] on a math function
-    answering its arguments' type, which stands there only as a percentage. *)
+    answering its arguments' type, which stands there only as a percentage.
+    [`Percentage] is the slot that spells a [<percentage>] and no [<number>]
+    beside it, so it parts with [`Value] on the same call: [`Value] takes
+    whatever unit its leaf reader vouched for, and a [<percentage>] slot takes
+    only [%]. *)
 
 val looking_at_math_function : Cursor.t -> bool
 (** [looking_at_math_function t] is [true] on a call to a math function other
@@ -702,7 +707,7 @@ val read_calc_expr : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
 
 val validate_calc_type :
   Cursor.t ->
-  [ `Number | `Number_or_percentage | `Number_or_value | `Value ] ->
+  [ `Number | `Number_or_percentage | `Number_or_value | `Percentage | `Value ] ->
   'a calc ->
   unit
 (** [validate_calc_type t result_type calc] raises unless [calc] infers to

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -2058,6 +2058,58 @@ let spec_math_at_the_remaining_readers () =
      durations Chrome refuses whatever the spelling stay refused. *)
   neg_cursor read_duration "calc(-1s)"
 
+(* Sec. 10.9 types a calculation and sec. 10.1 admits it only where that type
+   stands, so a call answering its arguments' type reaches a [<number>] or
+   [<percentage>] slot only when those arguments were numbers or percentages:
+   sec. 10.5 [hypot()], sec. 10.6 [abs()] and the sec. 10.2 stepped functions
+   over lengths name a [<length>] and belong to none of the slots below. Sec.
+   10.8 spells a [<calc-value>] as a number, a dimension, a percentage, a
+   [<calc-keyword>] or a parenthesised sum, so no keyword of the property's own
+   grammar is an operand either. Chrome 153 drops every row here. *)
+let spec_math_type_at_the_number_percentage_readers () =
+  let module P = Css.Properties in
+  (* CSS Transforms 2 sec. 5 [scale] is [none | [ <number> | <percentage>
+     ]{1,3}] and names no length. *)
+  neg_cursor P.read_scale "abs(-1px)";
+  neg_cursor P.read_scale "hypot(3px,4px)";
+  neg_cursor P.read_scale "mod(5px,2px)";
+  neg_cursor P.read_scale "round(1.5px,1px)";
+  neg_cursor P.read_scale "calc(abs(-1px))";
+  (* CSS Fonts 4 sec. 2.3.1 [font-stretch] is the [font-width] alias, [normal |
+     <percentage [0,inf]> | <keyword>], and names no length. *)
+  neg_cursor P.read_font_stretch "abs(-1px)";
+  neg_cursor P.read_font_stretch "hypot(3px,4px)";
+  neg_cursor P.read_font_stretch "mod(5px,2px)";
+  neg_cursor P.read_font_stretch "round(1.5px,1px)";
+  neg_cursor P.read_font_stretch "calc(abs(-1px))";
+  (* CSS Size Adjustment 1 sec. 3 [text-size-adjust] is [none | auto |
+     <percentage [0,inf]>], and names no length. The [-webkit-] twin reads
+     through the same reader. *)
+  neg_cursor P.read_text_size_adjust "abs(-1px)";
+  neg_cursor P.read_text_size_adjust "hypot(3px,4px)";
+  neg_cursor P.read_text_size_adjust "mod(5px,2px)";
+  neg_cursor P.read_text_size_adjust "round(1.5px,1px)";
+  neg_cursor P.read_text_size_adjust "calc(abs(-1px))";
+  (* A keyword operand is no [<calc-value>]. Unwrapping one wrote back a live
+     [inherit] where the browser had dropped the declaration outright. *)
+  neg_cursor P.read_font_stretch "calc(inherit)";
+  neg_cursor P.read_font_stretch "calc(normal)";
+  neg_cursor P.read_font_stretch "calc(condensed)";
+  neg_cursor P.read_text_size_adjust "calc(inherit)";
+  neg_cursor P.read_text_size_adjust "calc(none)";
+  neg_cursor P.read_text_size_adjust "calc(2 * auto)";
+  neg_cursor P.read_text_size_adjust "calc(auto * 2)";
+  (* The types each slot does take. A percentage-typed call stands at all three,
+     and the [<number>] one only where the grammar spells a [<number>]. *)
+  decl_optimizes ~prop:"scale" ~into:"2" "calc(2)";
+  decl_optimizes ~prop:"scale" ~into:"1%" "abs(-1%)";
+  decl_optimizes ~prop:"font-stretch" ~into:"50%" "calc(50%)";
+  decl_optimizes ~prop:"font-stretch" ~into:"calc(abs(-1%))" "abs(-1%)";
+  decl_optimizes ~prop:"text-size-adjust" ~into:"50%" "calc(50%)";
+  decl_optimizes ~prop:"text-size-adjust" ~into:"calc(abs(-1%))" "abs(-1%)";
+  neg_cursor P.read_font_stretch "calc(2)";
+  neg_cursor P.read_text_size_adjust "calc(2)"
+
 (* Sec. 9.1 is explicit that "width: -5px is not equivalent to width:
    calc(-5px)", because "out-of-range values specified literally are invalid at
    parse-time", and sec. 10.13 drops the wrapper only "of a computed value or
@@ -2376,6 +2428,8 @@ let value_tests =
       spec_stepped_value_dimensions;
     test_case "spec math at the remaining readers" `Quick
       spec_math_at_the_remaining_readers;
+    test_case "spec math type at the number percentage readers" `Quick
+      spec_math_type_at_the_number_percentage_readers;
     test_case "spec math range keeps the call" `Quick
       spec_math_range_keeps_the_call;
     test_case "spec minified output reads back" `Quick


### PR DESCRIPTION
A regression from #1148. It wired thirteen readers to the math grammar without the type discipline the neighbouring PRs established, so a length-valued call reached `<percentage>` slots and `font-stretch: calc(inherit)` printed a live `inherit`, which is the miscompile #1139 fixed for `width`. `\`Value`\` means "the contextual dimension the leaf reader vouched for" and cannot tell which unit that is, so it admits every length at a percentage slot; this adds a `\`Percentage`\` result type instead.