### PR TITLE
background: read a leading var() as a layer slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -365,9 +365,10 @@ to lose a whole rule over one bad piece. Both are gone.
   `transition: none 1s`, an unterminated string, a quoted `animation-name`, a
   keyword-shaped keyframe name, an at-rule body ending on a backslash, a `u+a`
   selector outside `unicode-range`, an explicit `animation: spin 0s`, a `url(`
-  at end of input and a repeating gradient built from a `var()` each survive
-  the round trip (#558, #656, #875, #876, #894, #896, #898, #899, #900, #901,
-  #902, #903, #910, #911, #912, #913)
+  at end of input and a `background` layer whose `var()` stands ahead of another
+  slot each survive the round trip
+  (#558, #656, #875, #876, #894, #896, #898, #899, #900, #901, #902, #903,
+  #910, #911, #912, #913, #1155)
 - A colour is read as the closed production CSS Color 5 sec. 3 defines. A
   relative colour's channel expressions are type-checked, so
   `rgb(from red calc(r + 10%) g b)` is dropped as every browser drops it while

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2079,12 +2079,6 @@ let read_background_vars read_self t =
   in
   loop []
 
-let read_background_var_call read_self t : background =
-  let first = read_var read_self t in
-  match read_background_vars read_self t with
-  | [] -> Var first
-  | rest -> Vars (first :: rest)
-
 let read_background_var_sequence read_self t : background =
   let snap = Cursor.save t in
   match read_background_vars read_self t with
@@ -2108,6 +2102,20 @@ let background_value_boundary t =
 let read_background_shorthand_from t snap : background =
   Cursor.restore t snap;
   Shorthand (read_background_shorthand t)
+
+(* CSS Backgrounds 3 (ED) sec. 2.1 orders a layer's slots rather than the
+   author's words, so pp writes the image before the colour and [background: red
+   var(--x)] comes out as [var(--x)red]. A leading var() therefore only stands
+   for the whole value when it reaches the value boundary; with a slot behind it
+   the layer is what was written, and reading it as the whole value would leave
+   pp's own emission unreadable. *)
+let read_background_var_call read_self t : background =
+  let snap = Cursor.save t in
+  let first = read_var read_self t in
+  let rest = read_background_vars read_self t in
+  if not (background_value_boundary t) then
+    read_background_shorthand_from t snap
+  else match rest with [] -> Var first | rest -> Vars (first :: rest)
 
 let read_background_keyword_or_shorthand t : background =
   let snap = Cursor.save t in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1510,6 +1510,27 @@ let background_initial_slots () =
   check_declaration ~expected:"background:url(a.png)red"
     ~optimized:"background:url(a.png)red" "background: url(a.png) red"
 
+(* CSS Backgrounds 3 (ED) sec. 2.1 orders a layer's slots, not the author's
+   words, so pp writes the image before the colour whichever way round they were
+   read. [background: red var(--x)] therefore prints [var(--x)red], and that
+   emission is only readable as the layer it came from if a leading [var()] with
+   more behind it fills the image slot rather than standing for the whole
+   value. *)
+let background_leading_var_slot () =
+  check_declaration ~expected:"background:var(--x)red"
+    "background: red var(--x)";
+  check_declaration ~expected:"background:var(--x)red"
+    "background: var(--x) red";
+  check_declaration ~expected:"background:var(--x)no-repeat"
+    "background: no-repeat var(--x)";
+  check_declaration ~expected:"background:var(--x)no-repeat"
+    "background: var(--x) no-repeat";
+  (* Controls: a [var()] that reaches the value boundary is still the whole
+     value, and a run of them is still the run. *)
+  check_declaration ~expected:"background:var(--x)" "background: var(--x)";
+  check_declaration ~expected:"background:var(--a) var(--b)"
+    "background: var(--a) var(--b)"
+
 (* CSS Backgrounds 3 (ED) sec. 2.6 gives background-position the initial value
    [0% 0%], which [0 0] and [left top] both name, so the slot drops with the
    rest. It also reads a lone value as "the second value is assumed to be
@@ -7268,6 +7289,7 @@ let declaration_tests =
     test_case "border line-width" `Quick border_line_width;
     test_case "border line-style" `Quick border_line_style;
     test_case "background initial slots" `Quick background_initial_slots;
+    test_case "background leading var slot" `Quick background_leading_var_slot;
     test_case "background position slot" `Quick background_position_slot;
     test_case "background box slots" `Quick background_box_slots;
     test_case "mask-border mode slot" `Quick mask_border_mode_slot;


### PR DESCRIPTION
A background layer prints its image slot before its colour, so `background: red var(--x)` comes out as `background:var(--x)red`. Reading that emission back treated the leading `var()` as the whole value, so `--minify` and `--diff=canonical` did not agree with themselves over cascade's own output.