### PR TITLE
support: measure two productions Chrome ships past the grammar

### DIFF
--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3817,8 +3817,8 @@ type image_resolution =
   | Revert_layer
   | Var of image_resolution var
 
-(** CSS Sizing 4 sec. 6 spells one slot [auto? [ none | <length [0,inf]> ]], so
-    the keyword takes the [auto] prefix as a length does. *)
+(** CSS Sizing 4 sec. 5.2 spells one slot [auto? [ none | <length [0,inf]> ]],
+    so the keyword takes the [auto] prefix as a length does. *)
 type contain_intrinsic_size_item =
   | None
   | Length of length

--- a/lib/support.ml
+++ b/lib/support.ml
@@ -695,6 +695,38 @@ let measured =
       measured = "Chrome 153";
     };
     {
+      key = "css.properties.font-family.inherit";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Values 4 sec. 4.2 excludes the CSS-wide keywords from \
+         <custom-ident> itself, so no word of a family sequence is one \
+         wherever it stands. Chrome reads inherit as a family name once \
+         another word stands beside it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.contain-intrinsic-size.auto_none_auto";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 (ED) sec. 5.2 spells contain-intrinsic-size [ auto? [ \
+         none | <length [0,inf]> ] ]{1,2}, so auto none is one whole slot and \
+         the auto after it is no slot at all. Chrome takes the trailing bare \
+         auto";
+      measured = "Chrome 153";
+    };
+    {
       key = "css.properties.break-before.all";
       support =
         {

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5084,7 +5084,7 @@ let spec_generated_box_layout_edges () =
   check_contain_intrinsic_longhand "auto 10px";
   check_contain_intrinsic_size "auto 10px 20px";
   check_contain_intrinsic_size_item "auto 10px";
-  (* CSS Sizing 4 sec. 6 spells a slot [auto? [ none | <length [0,inf]> ]], so
+  (* CSS Sizing 4 sec. 5.2 spells a slot [auto? [ none | <length [0,inf]> ]], so
      [none] is one of the two things the optional [auto] may precede and it sits
      in a slot rather than standing for the whole value. Chrome 153 takes each
      of these. *)

--- a/test/test_support.ml
+++ b/test/test_support.ml
@@ -72,9 +72,42 @@ let test_unknown_is_not_a_gap () =
     (Support.unimplemented_by Support.evergreen
        "css.properties.animation.animation-timeline_included")
 
+(* A production Chrome takes and no specification grants: cascade turns the
+   value away, and the browser-backed harness can only tell that apart from a
+   reader gap through a measured key. The pair is the contract, so both halves
+   are asked here.
+
+   CSS Values 4 sec. 4.2 excludes the CSS-wide keywords from [<custom-ident>]
+   itself, so no word of a font family sequence is one. CSS Sizing 4 (ED) sec.
+   5.2 spells [contain-intrinsic-size] as [[ auto? [ none | <length [0,inf]> ] ]
+   {1,2}], so a trailing bare [auto] is no slot. *)
+let test_measured_beyond_the_grammar () =
+  List.iter
+    (fun (key, css) ->
+      Alcotest.(check bool)
+        (key ^ " is measured here")
+        true
+        (Support.self_measured key);
+      answer
+        (key ^ " is what Chrome ships")
+        (Some true)
+        (Support.engine_implements Support.Chrome (153, 0) key);
+      Alcotest.(check bool)
+        (css ^ " is no declaration")
+        true
+        (Result.is_error
+           (Css.of_string ~strict:true (String.concat "" [ "x{"; css; "}" ]))))
+    [
+      ("css.properties.font-family.inherit", "font-family:inherit inherit");
+      ( "css.properties.contain-intrinsic-size.auto_none_auto",
+        "contain-intrinsic-size:auto none auto" );
+    ]
+
 let suite =
   ( "support",
     [
+      Alcotest.test_case "measured beyond the grammar" `Quick
+        test_measured_beyond_the_grammar;
       Alcotest.test_case "known and unknown" `Quick test_known_and_unknown;
       Alcotest.test_case "unimplemented everywhere" `Quick
         test_unimplemented_everywhere;


### PR DESCRIPTION
The accept-set harness reported `font-family: inherit inherit` and `contain-intrinsic-size: auto none auto` as rejects-valid. Cascade is right about both, so each gets a measured key naming the specification text that turns the value away, which is what tells a browser gap from a reader gap.