### PR TITLE
declaration: trim a custom property value to its tokens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -580,6 +580,9 @@ to lose a whole rule over one bad piece. Both are gone.
 - `--minify` keeps the quotes on a `<string>` written to a custom property whose
   `@property` syntax accepts only an ident, and the space between the
   repetitions of a `<type>+` initial value (#626, #704)
+- A custom property whose value is only whitespace holds the empty value, so
+  `--x: ` minifies to `--x:` rather than growing a space on every formatting
+  pass, and `Css.Declaration.custom_property` trims to match (#1157)
 - `Css.resolve_theme` accounts for the declarations `@keyframes`, `@page`,
   `@position-try` and a `@supports` condition carry, builds each
   `theme_defaults` binding with `parse_custom_property` rather than reparsing

--- a/fuzz/fuzz_declaration.ml
+++ b/fuzz/fuzz_declaration.ml
@@ -384,8 +384,12 @@ let test_custom_prop_empty_edges _buf =
         if serialized <> expected then
           failf "%s custom property changed: %S -> %S" label input serialized
   in
-  assert_serializes "browser-compatible empty value" "--x:" "--x:";
-  assert_serializes "spec whitespace-token value" "--x: " "--x: "
+  (* CSS Syntax 3 sec. 5.5.6 discards whitespace before a declaration value and
+     removes it from the end, so the two spellings name one value: the empty
+     value CSS Custom Properties 1 sec. 2 grants the [--*] family through
+     [<declaration-value>?]. Both therefore write back the same way. *)
+  assert_serializes "empty value" "--x:" "--x:";
+  assert_serializes "whitespace-only value" "--x: " "--x:"
 
 let suite =
   ( "declaration",

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -115,6 +115,17 @@ let is_declaration_value value =
 let refuse name detail =
   failwith (String.concat "" [ "custom_property: "; name; ": "; detail ])
 
+(* CSS Syntax 3 (ED) sec. 5.5.6 discards whitespace before a declaration's value
+   and again from its end, so a stream built from text carries neither. Only the
+   ends go: sec. 4.1 of CSS Custom Properties 1 (ED) forbids normalizing what is
+   between them. *)
+let trim_declaration_value components =
+  let rec drop_leading = function
+    | cv :: rest when Component.is_whitespace cv -> drop_leading rest
+    | kept -> kept
+  in
+  components |> drop_leading |> List.rev |> drop_leading |> List.rev
+
 (* Helper for raw custom properties - primarily for internal use *)
 
 let custom_property ?layer name value =
@@ -132,7 +143,9 @@ let custom_property ?layer name value =
   (* Parse the value into a CSS Syntax 3 component stream so the declaration
      never carries a raw author string; the printer can then re-serialise with
      the active [Pp] context (handles minification). *)
-  let components = Cursor.remaining (Cursor.of_string value) in
+  let components =
+    trim_declaration_value (Cursor.remaining (Cursor.of_string value))
+  in
   v (Custom_property name)
     (Custom_value { value = Tokens components; layer; meta = None })
 
@@ -2217,39 +2230,24 @@ let read_custom_property_payload name value_str =
       read_custom_property_value ~font_family:true (Cursor.of_string value_str)
   else read_custom_property_value (Cursor.of_string value_str)
 
-let whitespace_only_custom_property_value =
-  Tokens [ Component.Preserved (Token.synthetic (Token.Whitespace " ")) ]
-
-(* Keep a single space when the raw declaration value was whitespace-only - that
-   one space is the spec-required token sequence (CSS Custom Properties for
-   Cascading Variables 1 sec. 2.1). *)
-let read_custom_value name ~raw_is_whitespace_only value_str =
-  let value_str =
-    if value_str = "" && raw_is_whitespace_only then " " else value_str
-  in
-  if value_str = " " && raw_is_whitespace_only then
-    whitespace_only_custom_property_value
-  else read_custom_property_payload name value_str
-
 (* The [name] declaration formed over the value at [t]; split from
    [read_custom_property_declaration] for a caller that already holds the
    name. *)
 let read_custom_value_declaration t name : declaration =
-  (* CSS Custom Properties 1 sec. 2.1: [<declaration-value>] matches "any
-     sequence of one or more tokens", so the whitespace after [:] IS the value
-     when nothing else follows ([--foo: ;]). Don't skip it before
-     [consume_until_semicolon], or the token count becomes input-dependent. *)
+  (* CSS Syntax 3 (ED) sec. 5.5.6 discards whitespace before a declaration's
+     value and again from its end, so [--foo: ;] carries no token at all. CSS
+     Custom Properties 1 (ED) sec. 2 writes the [--*] family's value
+     [<declaration-value>?] and sec. 2.2 calls that empty value valid, which is
+     what is left. Read the raw text untrimmed all the same: the trim belongs to
+     [split_important], which needs the [!] and the flag word together. *)
   reject_custom_bad_string t;
   let raw_value = Cursor.consume_until_semicolon ~trim:false t in
-  let raw_is_whitespace_only = raw_value <> "" && String.trim raw_value = "" in
   let value_str, is_important = split_important raw_value in
   if not (is_optional_declaration_value value_str) then
     Cursor.err_invalid t "custom property value is no <declaration-value>";
   (* custom_property may raise Failure for invalid names like "--" *)
   try
-    let custom_value =
-      read_custom_value name ~raw_is_whitespace_only value_str
-    in
+    let custom_value = read_custom_property_payload name value_str in
     let decl =
       v (Custom_property name)
         (Custom_value { value = custom_value; layer = None; meta = None })

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -552,6 +552,16 @@ let normalize_expected ~category ~id expected =
          [#000] is the shortest spelling. *)
       fixture ~category ~id ~upstream:"a{--brand-color: rgb(0 0 0)}"
         ~cascade:"a{--brand-color:#000}" upstream
+  | "values", "0058" ->
+      (* The upstream oracle keeps the space after the colon, which every
+         minifier in the corpus does. CSS Syntax 3 sec. 5.5.6 discards
+         whitespace before a declaration value and removes it from the end, so
+         nothing of a whitespace-only value survives, and CSS Custom Properties
+         1 sec. 2 writes the [--*] family's value [<declaration-value>?], whose
+         [?] is the empty value sec. 2 calls valid. The space is therefore a
+         separator the emitter may drop rather than a token the value holds. *)
+      fixture ~category ~id ~upstream:"a{--foo: ;color:var(--foo,red)}"
+        ~cascade:"a{--foo:;color:var(--foo,red)}" upstream
   | "whitespace", "0012" ->
       (* The upstream fixture is scoped to whitespace around multiplication in
          calc() and keeps the calc() wrapper. Exact constant math may fold:

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -280,6 +280,13 @@ let custom_properties_basic () =
   check_declaration ~minify:false ~expected:"--x: a  b" "--x:a  b";
   check_declaration ~minify:false ~expected:"--sp: a" "--sp:  a  ";
   check_declaration ~minify:false ~expected:"--c: a b" "--c:a/**/b";
+  (* Trimming the ends is that same step with nothing left between them: CSS
+     Custom Properties 1 (ED) sec. 2 gives the [--*] family [Value:
+     <declaration-value>?], and sec. 2.2 calls an empty value written into a
+     custom property valid, so a whitespace-only value is the empty value and
+     not a one-token stream. *)
+  check_declaration ~expected:"--e:" "--e: ";
+  check_declaration ~expected:"--e:" "--e:";
   (* Section 9.1 serializes an ident by escaping only what must be, so an escape
      the author wrote otherwise does not come back. A custom property's value is
      not a reserialized stream, so its tokens keep the text they were read
@@ -4386,7 +4393,10 @@ let parse_custom_property_guard () =
       ("\"a;b\"", "--x:\"a;b\"");
       ("{a:b;}", "--x:{a:b;}");
       ("red/*", "--x:red");
-      (" ", "--x: ");
+      (* Sec. 5.5.6 discards whitespace at both ends of a declaration value, so
+         a whitespace-only one is the empty value sec. 2.2 of CSS Custom
+         Properties 1 (ED) calls valid. *)
+      (" ", "--x:");
       (* CSS Syntax 3 (ED) sec. 4.3.5 ends a string at EOF as the string it
          read, so this is one declaration value and writes back closed. *)
       ("\"abc", "--x:\"abc\"");

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8566,11 +8566,15 @@ let customprops13_declaration () =
   Alcotest.(check string)
     "--x: red blue preserved" ".x{--x:red blue}"
     (normalize ".x { --x: red blue }");
+  (* CSS Syntax 3 (ED) sec. 5.5.6 discards whitespace before a declaration's
+     value and again from its end, and CSS Custom Properties 1 (ED) sec. 2
+     writes the [--*] family's value [<declaration-value>?], so what is left of
+     a whitespace-only value is the empty value sec. 2.2 calls valid. *)
   Alcotest.(check string)
-    "--x: before block close preserves whitespace-token value" ".x{--x: }"
+    "--x: before block close is the empty value" ".x{--x:}"
     (normalize ".x { --x: }");
   Alcotest.(check string)
-    "--x: ; preserves the whitespace-token value" ".x{--x: }"
+    "--x: ; is the empty value" ".x{--x:}"
     (normalize ".x { --x: ; }")
 
 let customprops13_color_keyword_case_fold () =


### PR DESCRIPTION
`a{--x: }` grew a space on every formatting pass: the value carried one whitespace token and `fmt` wrote its own `: ` separator in front of it. CSS Syntax 3 sec. 5.5.6 discards whitespace before a declaration value and removes it from the end, so a whitespace-only value is the empty value `<declaration-value>?` grants the `--*` family, and `--minify` now writes `--x:`.

That is shorter than the `--foo: ;` every minifier in the imported css-minify-tests corpus emits, so values/0058 carries a Cascade oracle rather than a rewritten fixture.