### PR TITLE
optimize: synthesise the compatibility prefixes inside the pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -422,6 +422,11 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Minification
 
+- `--minify` runs the compatibility-prefix synthesis inside its own pipeline
+  rather than after it, so a sheet no longer minifies smaller the second time it
+  is run: the prefixed declarations are a rule's shared subset for the factoring
+  like any other, and `a{user-select:all}b{-webkit-user-select:ALL}` reached its
+  factored form only on a caller's next pass (#1158)
 - `--minify` contracts every shorthand family from the longhands that name it.
   This release adds the four-sided box families (`border-width`, `border-style`,
   `border-color`, `scroll-margin`, `scroll-padding`), the eight border sides and

--- a/lib/dune
+++ b/lib/dune
@@ -38,6 +38,7 @@
   loop
   rule_candidate
   rule_rewrite
+  webkit_fallback
   factor_safe
   gzip_size
   index

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -645,266 +645,17 @@ let flatten_nesting = Flatten.block
 
 (** {1 Stylesheet Optimization} *)
 
-type webkit_fallback =
-  | User_select_fallback
-  | Backdrop_filter_fallback
-  | Hyphens_fallback
-  | Text_decoration_color_fallback
-  | Mask_fallback
-  | Mask_image_fallback
-  | Mask_position_fallback
-  | Mask_size_fallback
-  | Mask_repeat_fallback
-  | Mask_clip_fallback
-  | Mask_origin_fallback
-
-(* A target that cannot read the standard property at all needs the fallback for
-   every value of it. A target that reads both spellings needs it only where the
-   value is not settled at parse time. *)
-type fallback_condition = Any_value | Unresolved_value
-
-type webkit_fallback_spec =
-  | Typed_fallback : {
-      kind : webkit_fallback;
-      property : 'a Properties.property;
-      webkit_property : 'b Properties.property;
-      convert : 'a -> 'b option;
-      name : string;
-      webkit_name : string;
-      condition : fallback_condition;
-    }
-      -> webkit_fallback_spec
-  | Mask_fallback_spec of { name : string; webkit_name : string }
-
-let typed_fallback ?(condition = Any_value) kind property webkit_property name
-    webkit_name =
-  Typed_fallback
-    {
-      kind;
-      property;
-      webkit_property;
-      convert = Option.some;
-      name;
-      webkit_name;
-      condition;
-    }
-
-(* The same, where the prefixed property does not take the standard one's
-   vocabulary and a value outside the overlap gets no fallback. *)
-let converted_fallback ?(condition = Any_value) ~convert kind property
-    webkit_property name webkit_name =
-  Typed_fallback
-    { kind; property; webkit_property; convert; name; webkit_name; condition }
-
-(* The prefixed mask box properties take WebKit's older vocabulary, which meets
-   the [<coord-box>] of CSS Masking 1 sec. 6.4 and 6.5 on the three CSS box
-   names alone. A value with no prefixed spelling gets no fallback rather than
-   one the browser drops. *)
-let rec prefixed_mask_box :
-    Properties.mask_box -> Properties.webkit_mask_box option = function
-  | Border_box -> Some Border_box
-  | Content_box -> Some Content_box
-  | Padding_box -> Some Padding_box
-  | Inherit -> Some Inherit
-  | Initial -> Some Initial
-  | Unset -> Some Unset
-  | Revert -> Some Revert
-  | Revert_layer -> Some Revert_layer
-  | Layers layers ->
-      (* One layer outside the overlap costs the whole fallback: the prefixed
-         property reads the list or none of it. *)
-      let mapped = List.filter_map prefixed_mask_box layers in
-      if List.length mapped = List.length layers then
-        Some (Layers mapped : Properties.webkit_mask_box)
-      else None
-  | Fill_box | Stroke_box | View_box | No_clip | Var _ -> None
-
-let webkit_fallback_specs =
-  [
-    typed_fallback User_select_fallback User_select Webkit_user_select
-      "user-select" "-webkit-user-select";
-    typed_fallback Backdrop_filter_fallback Backdrop_filter
-      Webkit_backdrop_filter "backdrop-filter" "-webkit-backdrop-filter";
-    typed_fallback Hyphens_fallback Hyphens Webkit_hyphens "hyphens"
-      "-webkit-hyphens";
-    typed_fallback ~condition:Unresolved_value Text_decoration_color_fallback
-      Text_decoration_color Webkit_text_decoration_color "text-decoration-color"
-      "-webkit-text-decoration-color";
-    Mask_fallback_spec { name = "mask"; webkit_name = "-webkit-mask" };
-    typed_fallback Mask_image_fallback Mask_image Webkit_mask_image "mask-image"
-      "-webkit-mask-image";
-    typed_fallback Mask_position_fallback Mask_position Webkit_mask_position
-      "mask-position" "-webkit-mask-position";
-    typed_fallback Mask_size_fallback Mask_size Webkit_mask_size "mask-size"
-      "-webkit-mask-size";
-    typed_fallback Mask_repeat_fallback Mask_repeat Webkit_mask_repeat
-      "mask-repeat" "-webkit-mask-repeat";
-    converted_fallback ~convert:prefixed_mask_box Mask_clip_fallback Mask_clip
-      Webkit_mask_clip "mask-clip" "-webkit-mask-clip";
-    converted_fallback ~convert:prefixed_mask_box Mask_origin_fallback
-      Mask_origin Webkit_mask_origin "mask-origin" "-webkit-mask-origin";
-  ]
-
-let fallback_spec_kind = function
-  | Typed_fallback { kind; _ } -> kind
-  | Mask_fallback_spec _ -> Mask_fallback
-
-let fallback_spec_condition = function
-  | Typed_fallback { condition; _ } -> condition
-  | Mask_fallback_spec _ -> Any_value
-
-let fallback_spec_names = function
-  | Typed_fallback { name; webkit_name; _ } -> (name, webkit_name)
-  | Mask_fallback_spec { name; webkit_name } -> (name, webkit_name)
-
-let fallback_spec_by_kind kind =
-  List.find_opt
-    (fun spec -> fallback_spec_kind spec = kind)
-    webkit_fallback_specs
-
-let fallback_spec_by_name select_name name =
-  List.find_opt
-    (fun spec -> String.equal (select_name (fallback_spec_names spec)) name)
-    webkit_fallback_specs
-
-let fallback_spec_by_standard_name = fallback_spec_by_name fst
-
-(* The target contract is deliberately owned here rather than by the printer:
-   adding a fallback changes the AST and must therefore be explicit to API
-   callers. Which of these the targets read unprefixed is a fact about browsers,
-   so {!Support} answers it from the generated web-features table and a browser
-   that catches up moves the answer at the next regeneration. [mask-mode] and
-   [mask-composite] are excluded because their prefixed forms have different
-   grammars. *)
-let required_fallback kind targets =
-  let lacks key = Support.unimplemented_by targets key in
-  match kind with
-  | User_select_fallback -> lacks "css.properties.user-select"
-  | Backdrop_filter_fallback -> lacks "css.properties.backdrop-filter"
-  | Hyphens_fallback -> lacks "css.properties.hyphens"
-  | Text_decoration_color_fallback ->
-      (* Not a support gap: Safari/iOS answer the standard property under both
-         spellings through 26.1, which no dataset records, so this stays a
-         measured boundary. It pairs with [Unresolved_value], since a settled
-         colour is served by the standard longhand on every declared target. *)
-      let at_most (major, minor) (target_major, target_minor) =
-        target_major < major || (target_major = major && target_minor <= minor)
-      in
-      at_most (26, 1) targets.safari || at_most (26, 1) targets.ios_safari
-  | Mask_fallback -> lacks "css.properties.mask"
-  | Mask_image_fallback -> lacks "css.properties.mask-image"
-  | Mask_position_fallback -> lacks "css.properties.mask-position"
-  | Mask_size_fallback -> lacks "css.properties.mask-size"
-  | Mask_repeat_fallback -> lacks "css.properties.mask-repeat"
-  | Mask_clip_fallback -> lacks "css.properties.mask-clip"
-  | Mask_origin_fallback -> lacks "css.properties.mask-origin"
-
-let webkit_compatible_mask : Properties.mask -> Properties.mask =
-  let strip_layer (layer : Properties.mask_layer) =
-    { layer with mode = Option.none; composite = Option.none }
-  in
-  function
-  | Layer layer -> Layer (strip_layer layer)
-  | Layers layers -> Layers (List.map strip_layer layers)
-  | value -> value
-
-let webkit_fallback_of_declaration targets decl : Declaration.declaration option
-    =
-  let fallback : type a.
-      webkit_fallback ->
-      a Properties.property ->
-      a ->
-      bool ->
-      Declaration.declaration option =
-   fun kind property value important ->
-    if required_fallback kind targets then
-      Some (Declaration.v ~important property value)
-    else None
-  in
-  let opaque_fallback kind property source important =
-    if required_fallback kind targets then
-      match
-        Declaration.parse_opaque_declaration property
-          (Declaration.string_of_value ~minify:true source)
-      with
-      | Some prefixed ->
-          Some (if important then Declaration.important prefixed else prefixed)
-      | None -> None
-    else None
-  in
-  let condition_holds spec =
-    match fallback_spec_condition spec with
-    | Any_value -> true
-    | Unresolved_value -> Variables.declaration_uses_var decl
-  in
-  let fallback_from_spec spec =
-    match (spec, decl) with
-    | ( Typed_fallback { kind; property; webkit_property; convert; _ },
-        Declaration { property = actual; value; important; _ } ) -> (
-        match Properties.eq_property actual property with
-        | Some Equal -> (
-            match convert value with
-            | Some value -> fallback kind webkit_property value important
-            | None -> None)
-        | None -> None)
-    | ( Mask_fallback_spec { webkit_name; _ },
-        Declaration { property = Mask; value; important; _ } ) ->
-        let source = Declaration.v Mask (webkit_compatible_mask value) in
-        opaque_fallback Mask_fallback webkit_name source important
-    | _, (Theme_guarded _ | Declaration _) -> None
-  in
-  match decl with
-  | Theme_guarded _ -> None
-  | Declaration
-      { property = Unknown_property name; value = components; important; _ }
-    -> (
-      match fallback_spec_by_standard_name name with
-      | Some (Mask_fallback_spec { webkit_name; _ }) -> (
-          let source = Declaration.v (Unknown_property name) components in
-          let rendered = Declaration.string_of_value ~minify:false source in
-          match Declaration.parse_declaration "mask" rendered with
-          | Some (Declaration { property = Mask; value; _ }) ->
-              let source = Declaration.v Mask (webkit_compatible_mask value) in
-              opaque_fallback Mask_fallback webkit_name source important
-          | Some _ | None ->
-              fallback Mask_fallback (Unknown_property webkit_name) components
-                important)
-      | Some spec when condition_holds spec ->
-          let kind = fallback_spec_kind spec in
-          let _, webkit_name = fallback_spec_names spec in
-          fallback kind (Unknown_property webkit_name) components important
-      | Some _ | None -> None)
-  | Declaration _ -> (
-      match fallback_spec_by_standard_name (Declaration.property_name decl) with
-      | Some spec when condition_holds spec -> fallback_from_spec spec
-      | Some _ | None -> None)
-
-let is_webkit_fallback kind decl =
-  match (fallback_spec_by_kind kind, decl) with
-  | Some spec, Declaration _ ->
-      let _, webkit_name = fallback_spec_names spec in
-      String.equal (Declaration.property_name decl) webkit_name
-  | None, Declaration _ -> false
-  | (None | Some _), Theme_guarded _ -> false
-
-let fallback_kind decl : webkit_fallback option =
-  match decl with
-  | Theme_guarded _ -> None
-  | Declaration _ ->
-      Option.map fallback_spec_kind
-        (fallback_spec_by_standard_name (Declaration.property_name decl))
-
 (* Once an author supplied a prefix for a property, that spelling is theirs:
    synthesising another value could change what WebKit sees. Otherwise mirror
    every standard declaration so source-order fallback semantics stay intact. *)
 let add_declaration_prefixes ~targets decls =
-  let author_owns kind = List.exists (is_webkit_fallback kind) decls in
+  let author_owns kind = List.exists (Webkit_fallback.is_prefixed kind) decls in
   let rec loop changed acc = function
     | [] -> if changed then List.rev acc else decls
     | decl :: rest -> (
-        match fallback_kind decl with
+        match Webkit_fallback.kind_of decl with
         | Some kind when not (author_owns kind) -> (
-            match webkit_fallback_of_declaration targets decl with
+            match Webkit_fallback.of_declaration targets decl with
             | Some prefixed -> loop true (decl :: prefixed :: acc) rest
             | None -> loop changed (decl :: acc) rest)
         | Some _ | None -> loop changed (decl :: acc) rest)
@@ -913,7 +664,7 @@ let add_declaration_prefixes ~targets decls =
 
 let rec condition_has_webkit kind = function
   | Supports.Property (Supports.Declaration (_, decl)) ->
-      is_webkit_fallback kind decl
+      Webkit_fallback.is_prefixed kind decl
   | Supports.Property _ | Supports.Function _ | Supports.General_enclosed _ ->
       false
   | Supports.Not condition -> condition_has_webkit kind condition
@@ -924,9 +675,9 @@ let add_condition_prefixes ~targets condition =
   let author_owns kind = condition_has_webkit kind condition in
   let rec map = function
     | Supports.Property (Supports.Declaration (_, decl)) as original -> (
-        match fallback_kind decl with
+        match Webkit_fallback.kind_of decl with
         | Some kind when not (author_owns kind) -> (
-            match webkit_fallback_of_declaration targets decl with
+            match Webkit_fallback.of_declaration targets decl with
             | Some prefixed ->
                 (* Cascade writes this one, so it carries no authored
                    spelling. *)
@@ -1292,7 +1043,7 @@ let rec statement_rule_count = function
 let stylesheet_rule_count stmts =
   List.fold_left (fun count stmt -> count + statement_rule_count stmt) 0 stmts
 
-let run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet =
+let run_pipeline ~ctx ~targets ~enforce_spec ~aggressive stylesheet =
   (* Re-run the top-level pipeline until the AST stops changing or a small cap
      fires. A pass may shrink the input again because an earlier one
      (vendor-alias drop, shorthand composition, media/support merging) exposed a
@@ -1304,10 +1055,25 @@ let run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet =
     else 5
   in
   let factor_cache = Factor.cache () in
+  (* Inside the loop, not after it: a synthesised prefix is a declaration the
+     rest of the pipeline decides about. It is a rule's shared subset for the
+     factoring and a longhand for the shorthand contraction, and a pass that
+     runs once the loop has settled leaves both to the next caller, whose
+     emission then differs from this one.
+
+     It runs last in the body because the vendor-alias drop reads {!Baseline}
+     where this reads [targets]. The two disagree wherever a target trails
+     Baseline, and a prefix synthesised into the next pass's input would be
+     dropped there as dead. *)
+  let prefixes stmts =
+    if enforce_spec then stmts else add_compatibility_prefixes ~targets stmts
+  in
   let rec loop n stmts =
     if n <= 0 then stmts
     else
-      let next = statements_top_level ~factor_cache ~ctx ~enforce_spec stmts in
+      let next =
+        prefixes (statements_top_level ~factor_cache ~ctx ~enforce_spec stmts)
+      in
       if next == stmts || Stylesheet.equal next stmts then stmts
       else loop (n - 1) next
   in
@@ -1385,14 +1151,11 @@ let stylesheet ?scope ?(targets = evergreen_targets) ?(flatten_nesting = false)
   let result =
     run_pipeline
       ~ctx:(Ctx.with_extend_lists true ctx)
-      ~enforce_spec ~aggressive stylesheet
+      ~targets ~enforce_spec ~aggressive stylesheet
   in
   let result =
     if prune_unused_custom_props then drop_unused_custom_props result
     else result
-  in
-  let result =
-    if enforce_spec then result else add_compatibility_prefixes ~targets result
   in
   let result = if flatten_nesting then Flatten.block result else result in
   Log.debug (fun m ->

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -346,8 +346,53 @@ let live_rules g =
 let rules_with_ids g ids =
   List.map (fun id -> (id, Rule_graph.node_rule g id)) ids
 
+(* Each declaration of [r] paired with a later one that is the other half of a
+   compatibility fallback. Almost every rule has none, and the scan below only
+   reaches the produced rules for a rule that has one. *)
+let fallback_pairs (r : rule) =
+  let rec walk acc = function
+    | [] -> acc
+    | decl :: rest ->
+        let acc =
+          List.fold_left
+            (fun acc other ->
+              if Webkit_fallback.is_pair decl other then (decl, other) :: acc
+              else acc)
+            acc rest
+        in
+        walk acc rest
+  in
+  if Webkit_fallback.holds_a_prefixed_spelling r.declarations then
+    walk [] r.declarations
+  else []
+
+(* The prefix synthesis reads one rule at a time and asks only whether THAT rule
+   already carries the prefixed spelling. So a rewrite that leaves the two
+   halves of a pair in two rules has the missing half written back beside the
+   one it kept, even though the group rule above already serves it: the element
+   ends up carrying the prefixed declaration twice and the emission is longer
+   than the rules the rewrite replaced. Keep the pair in one rule or leave it
+   alone. *)
+let splits_a_fallback_pair g ~consume ~produce =
+  let together (a, b) =
+    let holds decl (r : rule) = List.exists (same_decl decl) r.declarations in
+    (* A rewrite that keeps neither half has not separated them: the shorthand
+       contraction writes both as their shorthands, which is one pair again
+       under two other names. Only a half that outlives its partner is a
+       split. *)
+    (not (List.exists (holds a) produce || List.exists (holds b) produce))
+    || List.exists (fun r -> holds a r && holds b r) produce
+  in
+  List.exists
+    (fun id ->
+      List.exists
+        (fun pair -> not (together pair))
+        (fallback_pairs (Rule_graph.node_rule g id)))
+    consume
+
 let candidate ?size_cache ~kind ~finalize g ~consume ~produce =
-  Rule_rewrite.v ?size_cache ~kind ~finalize g ~consume ~produce
+  if splits_a_fallback_pair g ~consume ~produce then Option.None
+  else Rule_rewrite.v ?size_cache ~kind ~finalize g ~consume ~produce
 
 let selector_size (r : rule) = Pp.size ~minify:true Selector.pp r.selector
 let decls_inline_cost decls = decls_size decls + List.length decls

--- a/lib/webkit_fallback.ml
+++ b/lib/webkit_fallback.ml
@@ -1,0 +1,309 @@
+(** The WebKit compatibility fallbacks: which standard property has a prefixed
+    spelling, what the prefixed declaration for a value is, and whether a set of
+    targets still needs one.
+
+    This sits apart from {!Optimize} because two passes have to agree about it.
+    The prefix synthesis reads it to write a declaration, and the rule factoring
+    reads it to refuse a rewrite that would separate the two halves of a pair it
+    wrote. A second table spelling the same relation is how they came to
+    disagree: the factoring used to ask {!Shorthand.vendor_alias_pair}, which
+    has no [mask-*] arm, so the two halves were split and the synthesis wrote
+    the missing one back into a rule the group above it already served. *)
+
+open Declaration
+
+(** The families with a prefixed spelling. Sealed: a property that grows one
+    stops every site that decides about the set from compiling. *)
+type t =
+  | User_select_fallback
+  | Backdrop_filter_fallback
+  | Hyphens_fallback
+  | Text_decoration_color_fallback
+  | Mask_fallback
+  | Mask_image_fallback
+  | Mask_position_fallback
+  | Mask_size_fallback
+  | Mask_repeat_fallback
+  | Mask_clip_fallback
+  | Mask_origin_fallback
+
+(* A target that cannot read the standard property at all needs the fallback for
+   every value of it. A target that reads both spellings needs it only where the
+   value is not settled at parse time. *)
+type fallback_condition = Any_value | Unresolved_value
+
+type spec =
+  | Typed_fallback : {
+      kind : t;
+      property : 'a Properties.property;
+      webkit_property : 'b Properties.property;
+      convert : 'a -> 'b option;
+      name : string;
+      webkit_name : string;
+      condition : fallback_condition;
+    }
+      -> spec
+  | Mask_fallback_spec of { name : string; webkit_name : string }
+
+let typed_fallback ?(condition = Any_value) kind property webkit_property name
+    webkit_name =
+  Typed_fallback
+    {
+      kind;
+      property;
+      webkit_property;
+      convert = Option.some;
+      name;
+      webkit_name;
+      condition;
+    }
+
+(* The same, where the prefixed property does not take the standard one's
+   vocabulary and a value outside the overlap gets no fallback. *)
+let converted_fallback ?(condition = Any_value) ~convert kind property
+    webkit_property name webkit_name =
+  Typed_fallback
+    { kind; property; webkit_property; convert; name; webkit_name; condition }
+
+(* The prefixed mask box properties take WebKit's older vocabulary, which meets
+   the [<coord-box>] of CSS Masking 1 sec. 6.4 and 6.5 on the three CSS box
+   names alone. A value with no prefixed spelling gets no fallback rather than
+   one the browser drops. *)
+let rec prefixed_mask_box :
+    Properties.mask_box -> Properties.webkit_mask_box option = function
+  | Border_box -> Some Border_box
+  | Content_box -> Some Content_box
+  | Padding_box -> Some Padding_box
+  | Inherit -> Some Inherit
+  | Initial -> Some Initial
+  | Unset -> Some Unset
+  | Revert -> Some Revert
+  | Revert_layer -> Some Revert_layer
+  | Layers layers ->
+      (* One layer outside the overlap costs the whole fallback: the prefixed
+         property reads the list or none of it. *)
+      let mapped = List.filter_map prefixed_mask_box layers in
+      if List.length mapped = List.length layers then
+        Some (Layers mapped : Properties.webkit_mask_box)
+      else None
+  | Fill_box | Stroke_box | View_box | No_clip | Var _ -> None
+
+let specs =
+  [
+    typed_fallback User_select_fallback User_select Webkit_user_select
+      "user-select" "-webkit-user-select";
+    typed_fallback Backdrop_filter_fallback Backdrop_filter
+      Webkit_backdrop_filter "backdrop-filter" "-webkit-backdrop-filter";
+    typed_fallback Hyphens_fallback Hyphens Webkit_hyphens "hyphens"
+      "-webkit-hyphens";
+    typed_fallback ~condition:Unresolved_value Text_decoration_color_fallback
+      Text_decoration_color Webkit_text_decoration_color "text-decoration-color"
+      "-webkit-text-decoration-color";
+    Mask_fallback_spec { name = "mask"; webkit_name = "-webkit-mask" };
+    typed_fallback Mask_image_fallback Mask_image Webkit_mask_image "mask-image"
+      "-webkit-mask-image";
+    typed_fallback Mask_position_fallback Mask_position Webkit_mask_position
+      "mask-position" "-webkit-mask-position";
+    typed_fallback Mask_size_fallback Mask_size Webkit_mask_size "mask-size"
+      "-webkit-mask-size";
+    typed_fallback Mask_repeat_fallback Mask_repeat Webkit_mask_repeat
+      "mask-repeat" "-webkit-mask-repeat";
+    converted_fallback ~convert:prefixed_mask_box Mask_clip_fallback Mask_clip
+      Webkit_mask_clip "mask-clip" "-webkit-mask-clip";
+    converted_fallback ~convert:prefixed_mask_box Mask_origin_fallback
+      Mask_origin Webkit_mask_origin "mask-origin" "-webkit-mask-origin";
+  ]
+
+let fallback_spec_kind = function
+  | Typed_fallback { kind; _ } -> kind
+  | Mask_fallback_spec _ -> Mask_fallback
+
+let fallback_spec_condition = function
+  | Typed_fallback { condition; _ } -> condition
+  | Mask_fallback_spec _ -> Any_value
+
+let fallback_spec_names = function
+  | Typed_fallback { name; webkit_name; _ } -> (name, webkit_name)
+  | Mask_fallback_spec { name; webkit_name } -> (name, webkit_name)
+
+let fallback_spec_by_kind kind =
+  List.find_opt (fun spec -> fallback_spec_kind spec = kind) specs
+
+let fallback_spec_by_name select_name name =
+  List.find_opt
+    (fun spec -> String.equal (select_name (fallback_spec_names spec)) name)
+    specs
+
+let fallback_spec_by_standard_name = fallback_spec_by_name fst
+
+(* The target contract is deliberately owned here rather than by the printer:
+   adding a fallback changes the AST and must therefore be explicit to API
+   callers. Which of these the targets read unprefixed is a fact about browsers,
+   so {!Support} answers it from the generated web-features table and a browser
+   that catches up moves the answer at the next regeneration. [mask-mode] and
+   [mask-composite] are excluded because their prefixed forms have different
+   grammars. *)
+let required_fallback kind targets =
+  let lacks key = Support.unimplemented_by targets key in
+  match kind with
+  | User_select_fallback -> lacks "css.properties.user-select"
+  | Backdrop_filter_fallback -> lacks "css.properties.backdrop-filter"
+  | Hyphens_fallback -> lacks "css.properties.hyphens"
+  | Text_decoration_color_fallback ->
+      (* Not a support gap: Safari/iOS answer the standard property under both
+         spellings through 26.1, which no dataset records, so this stays a
+         measured boundary. It pairs with [Unresolved_value], since a settled
+         colour is served by the standard longhand on every declared target. *)
+      let at_most (major, minor) (target_major, target_minor) =
+        target_major < major || (target_major = major && target_minor <= minor)
+      in
+      at_most (26, 1) targets.safari || at_most (26, 1) targets.ios_safari
+  | Mask_fallback -> lacks "css.properties.mask"
+  | Mask_image_fallback -> lacks "css.properties.mask-image"
+  | Mask_position_fallback -> lacks "css.properties.mask-position"
+  | Mask_size_fallback -> lacks "css.properties.mask-size"
+  | Mask_repeat_fallback -> lacks "css.properties.mask-repeat"
+  | Mask_clip_fallback -> lacks "css.properties.mask-clip"
+  | Mask_origin_fallback -> lacks "css.properties.mask-origin"
+
+let webkit_compatible_mask : Properties.mask -> Properties.mask =
+  let strip_layer (layer : Properties.mask_layer) =
+    { layer with mode = Option.none; composite = Option.none }
+  in
+  function
+  | Layer layer -> Layer (strip_layer layer)
+  | Layers layers -> Layers (List.map strip_layer layers)
+  | value -> value
+
+let of_declaration targets decl : Declaration.declaration option =
+  let fallback : type a.
+      t -> a Properties.property -> a -> bool -> Declaration.declaration option
+      =
+   fun kind property value important ->
+    if required_fallback kind targets then
+      Some (Declaration.v ~important property value)
+    else None
+  in
+  let opaque_fallback kind property source important =
+    if required_fallback kind targets then
+      match
+        Declaration.parse_opaque_declaration property
+          (Declaration.string_of_value ~minify:true source)
+      with
+      | Some prefixed ->
+          Some (if important then Declaration.important prefixed else prefixed)
+      | None -> None
+    else None
+  in
+  let condition_holds spec =
+    match fallback_spec_condition spec with
+    | Any_value -> true
+    | Unresolved_value -> Variables.declaration_uses_var decl
+  in
+  let fallback_from_spec spec =
+    match (spec, decl) with
+    | ( Typed_fallback { kind; property; webkit_property; convert; _ },
+        Declaration { property = actual; value; important; _ } ) -> (
+        match Properties.eq_property actual property with
+        | Some Equal -> (
+            match convert value with
+            | Some value -> fallback kind webkit_property value important
+            | None -> None)
+        | None -> None)
+    | ( Mask_fallback_spec { webkit_name; _ },
+        Declaration { property = Mask; value; important; _ } ) ->
+        let source = Declaration.v Mask (webkit_compatible_mask value) in
+        opaque_fallback Mask_fallback webkit_name source important
+    | _, (Theme_guarded _ | Declaration _) -> None
+  in
+  match decl with
+  | Theme_guarded _ -> None
+  | Declaration
+      { property = Unknown_property name; value = components; important; _ }
+    -> (
+      match fallback_spec_by_standard_name name with
+      | Some (Mask_fallback_spec { webkit_name; _ }) -> (
+          let source = Declaration.v (Unknown_property name) components in
+          let rendered = Declaration.string_of_value ~minify:false source in
+          match Declaration.parse_declaration "mask" rendered with
+          | Some (Declaration { property = Mask; value; _ }) ->
+              let source = Declaration.v Mask (webkit_compatible_mask value) in
+              opaque_fallback Mask_fallback webkit_name source important
+          | Some _ | None ->
+              fallback Mask_fallback (Unknown_property webkit_name) components
+                important)
+      | Some spec when condition_holds spec ->
+          let kind = fallback_spec_kind spec in
+          let _, webkit_name = fallback_spec_names spec in
+          fallback kind (Unknown_property webkit_name) components important
+      | Some _ | None -> None)
+  | Declaration _ -> (
+      match fallback_spec_by_standard_name (Declaration.property_name decl) with
+      | Some spec when condition_holds spec -> fallback_from_spec spec
+      | Some _ | None -> None)
+
+let is_prefixed kind decl =
+  match (fallback_spec_by_kind kind, decl) with
+  | Some spec, Declaration _ ->
+      let _, webkit_name = fallback_spec_names spec in
+      String.equal (Declaration.property_name decl) webkit_name
+  | None, Declaration _ -> false
+  | (None | Some _), Theme_guarded _ -> false
+
+(* The (standard, prefixed) names of the family [decl]'s property heads, or none
+   where the property has no prefixed spelling. *)
+let fallback_spec_names_of_declaration decl =
+  match decl with
+  | Theme_guarded _ -> None
+  | Declaration _ ->
+      Option.map fallback_spec_names
+        (fallback_spec_by_standard_name (Declaration.property_name decl))
+
+(* The standard property name is what names a family everywhere else, so it is
+   what a log line or a test failure should show. *)
+let pp ctx kind =
+  match fallback_spec_by_kind kind with
+  | Some spec -> Pp.string ctx (fst (fallback_spec_names spec))
+  | None -> Pp.string ctx "unknown"
+
+let kind_of decl : t option =
+  match decl with
+  | Theme_guarded _ -> None
+  | Declaration _ ->
+      Option.map fallback_spec_kind
+        (fallback_spec_by_standard_name (Declaration.property_name decl))
+
+(* The relation with neither side named the prefixed one, and with no [targets]
+   to consult: a caller asking whether two declarations are the two halves of
+   one fallback pair does not know which order they arrived in, and by the time
+   it asks the synthesis has already decided the targets needed the pair.
+
+   Same value is asked of the minified text rather than of the values
+   themselves. The two sides are two property types wherever a prefixed
+   spelling takes WebKit's older vocabulary, so nothing compares them directly,
+   and the text is what the pair was written to make a browser read. *)
+(* Every prefixed spelling in the table above is a [-webkit-] name, so a
+   declaration list holding none of those holds no pair. The scan below is
+   quadratic in a rule's declarations and runs on every rewrite candidate, so it
+   is worth answering the cheap question first. *)
+let holds_a_prefixed_spelling decls =
+  List.exists
+    (fun decl ->
+      String.starts_with ~prefix:"-webkit-" (Declaration.property_name decl))
+    decls
+
+let is_pair a b =
+  let names decl = fallback_spec_names_of_declaration decl in
+  let paired standard prefixed =
+    match names standard with
+    | Some (_, webkit_name) ->
+        String.equal (Declaration.property_name prefixed) webkit_name
+        && Bool.equal
+             (Declaration.is_important standard)
+             (Declaration.is_important prefixed)
+        && String.equal
+             (Declaration.string_of_value ~minify:true standard)
+             (Declaration.string_of_value ~minify:true prefixed)
+    | None -> false
+  in
+  paired a b || paired b a

--- a/lib/webkit_fallback.mli
+++ b/lib/webkit_fallback.mli
@@ -1,0 +1,54 @@
+(** The WebKit compatibility fallbacks: which standard property has a prefixed
+    spelling, what the prefixed declaration for a value is, and whether a set of
+    targets still needs one.
+
+    This sits apart from {!Optimize} because two passes have to agree about it.
+    The prefix synthesis reads it to write a declaration, and the rule factoring
+    reads it to refuse a rewrite that would separate the two halves of a pair it
+    wrote. A second table spelling the same relation is how they came to
+    disagree. *)
+
+(** The families with a prefixed spelling. Sealed: a property that grows one
+    stops every site that decides about the set from compiling. *)
+type t =
+  | User_select_fallback
+  | Backdrop_filter_fallback
+  | Hyphens_fallback
+  | Text_decoration_color_fallback
+  | Mask_fallback
+  | Mask_image_fallback
+  | Mask_position_fallback
+  | Mask_size_fallback
+  | Mask_repeat_fallback
+  | Mask_clip_fallback
+  | Mask_origin_fallback
+
+val pp : t Pp.t
+(** [pp] writes the family's standard property name, which is what names it in a
+    log line or a test failure. *)
+
+val kind_of : Declaration.declaration -> t option
+(** [kind_of decl] is the family [decl] heads, or [None] where its property has
+    no prefixed spelling. Asked of the standard spelling. *)
+
+val is_prefixed : t -> Declaration.declaration -> bool
+(** [is_prefixed kind decl] is whether [decl] is the prefixed spelling of
+    [kind], whatever value it carries. *)
+
+val of_declaration :
+  Support.targets -> Declaration.declaration -> Declaration.declaration option
+(** [of_declaration targets decl] is the prefixed declaration [decl] needs for
+    [targets], or [None] where the targets read the standard spelling, the value
+    has no prefixed spelling, or [decl] heads no family. *)
+
+val holds_a_prefixed_spelling : Declaration.declaration list -> bool
+(** [holds_a_prefixed_spelling decls] is whether any of [decls] is spelled with
+    a [-webkit-] prefix. Every prefixed half of a pair is, so a list this
+    refuses holds no pair: it is the cheap filter in front of {!is_pair}, not
+    the relation itself. *)
+
+val is_pair : Declaration.declaration -> Declaration.declaration -> bool
+(** [is_pair a b] is whether the two are the two halves of one fallback pair,
+    carrying the same value and importance, in either order. It takes no
+    targets: by the time a caller asks, the synthesis has already decided the
+    targets needed the pair, and separating the halves is what breaks it. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -19,6 +19,7 @@ let () =
       Test_css.suite;
       Test_baseline.suite;
       Test_support.suite;
+      Test_webkit_fallback.suite;
       Test_loc.suite;
       Test_token.suite;
       Test_lexer.suite;

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2159,6 +2159,35 @@ let test_large_stylesheet_factoring_reaches_fixpoint () =
     "large-sheet factoring converges in one scheduler run" once
     (minify_str once)
 
+(* A second pass that moves is a first pass that stopped early, so each vector
+   is checked by re-emitting what the first pass wrote. [emit] is the mode's own
+   emitter, and the name carries the vector so a failure says which one
+   moved. *)
+let assert_emission_is_a_fixed_point ~emit label vectors =
+  List.iter
+    (fun css ->
+      let once = emit css in
+      Alcotest.(check string)
+        (String.concat "" [ label; " is a fixed point on "; css ])
+        once (emit once))
+    vectors
+
+let test_prefix_synthesis_reaches_fixpoint () =
+  (* The compatibility-prefix pass writes declarations the rest of the pipeline
+     decides about: a prefixed twin is a rule's shared subset for the factoring,
+     and a prefixed longhand run is a shorthand for the contraction. Synthesised
+     after the pipeline settled, neither pass ever sees it. *)
+  assert_emission_is_a_fixed_point ~emit:minify_str "minify"
+    [
+      "a{user-select:all}b{-webkit-user-select:ALL}";
+      "a{-webkit-user-select:all}b{user-select:ALL}";
+      "a{mask-size:auto}b{-webkit-mask-size:AUTO}";
+      "a{mask-clip:content-box}b{-webkit-mask-clip:CONTENT-BOX}";
+      "a{mask-position:10% 20%}b{-webkit-mask-position:10%\t20%}";
+      "a{backdrop-filter:blur(max(0px, \
+       1em))}b{-webkit-backdrop-filter:blur(max(0px,1em))}";
+    ]
+
 let test_no_factor_across_conflict () =
   (* CSS Cascade 6.1: the two .x rules conflict on color, so they merge (last
      wins). The later .y carries the first .x's value, but grouping it with that
@@ -5509,6 +5538,9 @@ let selector_merging_tests =
     ( "large stylesheet factoring reaches fixpoint",
       `Quick,
       test_large_stylesheet_factoring_reaches_fixpoint );
+    ( "prefix synthesis reaches fixpoint in one pass",
+      `Quick,
+      test_prefix_synthesis_reaches_fixpoint );
     ("no factor across conflict", `Quick, test_no_factor_across_conflict);
     ( "zero box side covered by shorthand",
       `Quick,

--- a/test/test_webkit_fallback.ml
+++ b/test/test_webkit_fallback.ml
@@ -1,0 +1,72 @@
+(** The compatibility-prefix pairs, pinned through the emission.
+
+    {!Cascade.Optimize} synthesises a prefixed declaration beside a standard one
+    the targets cannot read, and the rule factoring has to recognise the same
+    pairs or it separates the two halves. Both sides read one table; these ask
+    the observable question that table settles, for a family from each of the
+    two relations that used to answer it apart. *)
+
+open Cascade
+
+let minify css =
+  match Css.of_string ~strict:false css with
+  | Ok { Css.stylesheet; _ } ->
+      String.trim (Css.to_string ~minify:true (Css.optimize stylesheet))
+  | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+
+let emits input expected = Alcotest.(check string) input expected (minify input)
+
+(* The synthesis writes the prefixed half in front of the standard one, so a
+   WebKit that reads only the prefixed spelling still loses to a later standard
+   declaration in the cascade. *)
+let test_synthesis_writes_the_pair () =
+  emits "a{user-select:all}" "a{-webkit-user-select:all;user-select:all}";
+  emits "a{mask-size:auto}" "a{-webkit-mask-size:auto;mask-size:auto}";
+  emits "a{hyphens:auto}" "a{-webkit-hyphens:auto;hyphens:auto}"
+
+(* An authored prefix is the author's, so nothing is synthesised beside it and
+   there is no pair to keep together. *)
+let test_authored_prefix_is_left_alone () =
+  emits "a{-webkit-user-select:all}" "a{-webkit-user-select:all}";
+  emits "a{-webkit-mask-size:auto}" "a{-webkit-mask-size:auto}"
+
+(* The factoring may not take one half into a shared rule and leave the other
+   behind: the synthesis reads one rule at a time, so it would write the missing
+   half back beside the half that stayed and the element would carry it twice.
+
+   [user-select] was answered by Shorthand's hand-written vendor twins and
+   [mask-size] by nothing, which is how the second used to come out longer than
+   the rules the rewrite replaced. Both are asked here, and in both orders,
+   since neither half knows which arrived first. *)
+let test_factoring_keeps_a_pair_together () =
+  emits "a{user-select:all}b{-webkit-user-select:ALL}"
+    "a{-webkit-user-select:all;user-select:all}b{-webkit-user-select:all}";
+  emits "a{-webkit-user-select:all}b{user-select:ALL}"
+    "a{-webkit-user-select:all}b{-webkit-user-select:all;user-select:all}";
+  emits "a{mask-size:auto}b{-webkit-mask-size:AUTO}"
+    "a{-webkit-mask-size:auto;mask-size:auto}b{-webkit-mask-size:auto}";
+  emits "a{-webkit-mask-size:auto}b{mask-size:AUTO}"
+    "a{-webkit-mask-size:auto}b{-webkit-mask-size:auto;mask-size:auto}"
+
+(* Two declarations of one family that carry different values, or disagree about
+   [!important], are not a pair, so nothing stops the factoring reaching them.
+   Without this the guard would be a rule against grouping [-webkit-] anything,
+   which is not what the synthesis needs. *)
+let test_a_differing_value_is_not_a_pair () =
+  emits "a{-webkit-mask-size:cover}b{-webkit-mask-size:cover}"
+    "a,b{-webkit-mask-size:cover}";
+  emits "a{-webkit-user-select:none}b{-webkit-user-select:none}"
+    "a,b{-webkit-user-select:none}"
+
+let suite =
+  ( "webkit_fallback",
+    [
+      Alcotest.test_case "synthesis writes the pair" `Quick
+        test_synthesis_writes_the_pair;
+      Alcotest.test_case "an authored prefix is left alone" `Quick
+        test_authored_prefix_is_left_alone;
+      Alcotest.test_case "factoring keeps a pair together" `Quick
+        test_factoring_keeps_a_pair_together;
+      Alcotest.test_case "a differing value is not a pair" `Quick
+        test_a_differing_value_is_not_a_pair;
+    ] )

--- a/test/test_webkit_fallback.mli
+++ b/test/test_webkit_fallback.mli
@@ -1,0 +1,6 @@
+(** Test suite module. *)
+
+val suite : string * unit Alcotest.test_case list
+(** [suite] pins the compatibility-prefix pairs through the emission, which is
+    where the relation is observable: the module itself is an optimizer
+    implementation detail. *)


### PR DESCRIPTION
The prefix pass ran once the pipeline had settled, so a declaration it wrote was never a rule's shared subset for the factoring: `a{user-select:all}b{-webkit-user-select:ALL}` still had a factoring left in it and reached its factored form only when a caller minified the output again. The readback sweep goes from 76 unstable emissions over 5 causes to 40 over 3.

Running the synthesis in the loop needs the factoring to know which pairs it must not separate, and that relation now has one home rather than two: `Shorthand`'s hand-written vendor twins have no `mask-*` arm, so asking there answered for `user-select` and not for `mask-size`. `cascade fmt --minify` over the netflix and reddit corpus sheets is unchanged (14.5s and 48.2s against 17.8s and 49.9s).