### PR TITLE
values: fold an authored spelling wherever a length is kept

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -422,6 +422,11 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Minification
 
+- `--minify` merges two rules whose values were written with different spellings
+  of one number, so `a{tab-size:2e0ch}b{tab-size:2ch}` groups on the first pass
+  rather than the second. `line-height`, `overflow-clip-margin`, the grid track
+  breadths, the `contain-intrinsic-*` family and `columns` each kept the
+  authored spelling past the fold that `width` already had (#1159)
 - `--minify` runs the compatibility-prefix synthesis inside its own pipeline
   rather than after it, so a sheet no longer minifies smaller the second time it
   is run: the prefixed declarations are a rule's shared subset for the factoring

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -591,6 +591,17 @@ let pp_overflow_clip_box : overflow_clip_box Pp.t =
   | Padding_box -> Pp.string ctx "padding-box"
   | Border_box -> Pp.string ctx "border-box"
 
+(* The clip distance keeps the spelling the author wrote for the unminified
+   round-trip, and [pp_length] drops it under [--minify]. Fold it, or two
+   spellings of one distance reach one minified text through two nodes and
+   anything keyed on the node reads them as two values. *)
+let normalize_overflow_clip_margin :
+    overflow_clip_margin -> overflow_clip_margin = function
+  | Clip_margin (box, Some length) as value ->
+      let length' = Values.canonical_dimension length in
+      if length' == length then value else Clip_margin (box, Some length')
+  | value -> value
+
 let rec pp_overflow_clip_margin : overflow_clip_margin Pp.t =
  fun ctx -> function
   | Clip_margin (Some box, Some length) ->

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -2479,6 +2479,18 @@ let normalize_line_height ?(lossless = false) (lh : line_height) : line_height =
           | Values.Num f when f >= 0. -> Num f
           | Values.Val v when not (negative_line_height v) -> v
           | folded -> Calc folded))
+  (* The reader keeps [+120%] and [12.0px] in [Number] so an unminified print
+     gives the bytes back, and [pp_line_height] writes the constructor's own
+     spelling under [--minify]. Fold onto the constructor where there is one, or
+     the two spellings reach one minified text through two nodes. *)
+  | Number { value; unit; _ } -> (
+      match unit with
+      | Option.None -> Num value
+      | Option.Some "%" -> Pct value
+      | Option.Some "px" -> Px value
+      | Option.Some "rem" -> Rem value
+      | Option.Some "em" -> Em value
+      | Option.Some _ -> lh)
   | _ -> lh
 
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -338,6 +338,25 @@ let rec normalize_grid_template (value : grid_template) : grid_template =
           tracks
       in
       if tracks' == tracks then value else Named_tracks tracks'
+  (* A track breadth keeps the spelling the author wrote for the unminified
+     round-trip and the printer drops it under [--minify], so the two reach one
+     minified text through two nodes unless the spelling folds here. Folding it
+     is two steps rather than one: [Length] is where a breadth the eight
+     unit-specific arms above cannot hold goes, so a spelling of one they CAN
+     hold has to come back out of it, or [100.0px] settles at [Length (Px 100.)]
+     beside the [Px 100.] that [100px] reads as. [canonical_dimension] leaves a
+     zero alone, so nothing lands here that the [Zero] arms above want. *)
+  | Length length -> (
+      match Values.canonical_dimension length with
+      | Px f -> Px f
+      | Rem f -> Rem f
+      | Em f -> Em f
+      | Pct f -> Pct f
+      | Vw f -> Vw f
+      | Vh f -> Vh f
+      | Vmin f -> Vmin f
+      | Vmax f -> Vmax f
+      | length' -> if length' == length then value else Length length')
   | _ -> value
 
 let grid_area_row_ws = function

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -274,6 +274,36 @@ let rec pp_contain_intrinsic_size : contain_intrinsic_size Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* The same fold as everywhere else a length carries its authored spelling: the
+   reader keeps it for the unminified round-trip and the printer drops it under
+   [--minify], so it has to go before anything keyed on the node compares two
+   spellings of one size. *)
+let normalize_contain_intrinsic_size_item :
+    contain_intrinsic_size_item -> contain_intrinsic_size_item = function
+  | Length length as value ->
+      let length' = Values.canonical_dimension length in
+      if length' == length then value else Length length'
+  | Auto length as value ->
+      let length' = Values.canonical_dimension length in
+      if length' == length then value else Auto length'
+  | value -> value
+
+let normalize_contain_intrinsic_longhand :
+    contain_intrinsic_longhand -> contain_intrinsic_longhand = function
+  | Size size as value ->
+      let size' = normalize_contain_intrinsic_size_item size in
+      if size' == size then value else Size size'
+  | value -> value
+
+let normalize_contain_intrinsic_size :
+    contain_intrinsic_size -> contain_intrinsic_size = function
+  | Intrinsic (first, second) as value ->
+      let first' = normalize_contain_intrinsic_size_item first in
+      let second' = Option.map normalize_contain_intrinsic_size_item second in
+      if first' == first && second' == second then value
+      else Intrinsic (first', second')
+  | value -> value
+
 let rec pp_contain_intrinsic_longhand : contain_intrinsic_longhand Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_contain_intrinsic_longhand ctx v

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -143,6 +143,15 @@ let normalize_columns_value : columns_value -> columns_value =
       match eval_calc (numeric_columns_calc_leaves c) with
       | Num n when Float.is_integer n && n >= 1. -> Count (int_of_float n)
       | folded -> if folded == c then value else Count_calc folded)
+  (* The column width keeps the spelling the author wrote for the unminified
+     round-trip, and the printer drops it under [--minify]. Fold it, or two
+     spellings of one width reach one minified text through two nodes. *)
+  | Width len as value ->
+      let len' = Values.canonical_dimension len in
+      if len' == len then value else Width len'
+  | Both (len, count) as value ->
+      let len' = Values.canonical_dimension len in
+      if len' == len then value else Both (len', count)
   | other -> other
 
 let rec pp_columns_value : columns_value Pp.t =

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -884,6 +884,12 @@ let normalize_tab_size ~ctx : tab_size -> tab_size =
   | Number n ->
       let n' = Values.normalize_number ~ctx ~non_negative:true n in
       if n' == n then value else Number n'
+  (* The unit carries the meaning here: CSS Text 4 sec. 6.2 reads a bare number
+     as a count of spaces and a length as a distance, so the spelling folds but
+     no zero strip may reach this. *)
+  | Length len ->
+      let len' = Values.canonical_dimension len in
+      if len' == len then value else Length len'
   | other -> other
 
 let rec pp_tab_size : tab_size Pp.t =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4639,6 +4639,12 @@ let normalize_property_value : type a.
   | Border_block_width -> normalize_logical_border_width value
   | Border_inline_style -> normalize_logical_border_style value
   | Border_block_style -> normalize_logical_border_style value
+  | Overflow_clip_margin -> normalize_overflow_clip_margin value
+  | Contain_intrinsic_size -> normalize_contain_intrinsic_size value
+  | Contain_intrinsic_width -> normalize_contain_intrinsic_longhand value
+  | Contain_intrinsic_height -> normalize_contain_intrinsic_longhand value
+  | Contain_intrinsic_inline_size -> normalize_contain_intrinsic_longhand value
+  | Contain_intrinsic_block_size -> normalize_contain_intrinsic_longhand value
   | Transition_duration -> Values.normalize_duration ~ctx value
   | Transition_delay -> Values.normalize_duration ~ctx value
   | Animation_duration -> Values.normalize_duration ~ctx value

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -262,6 +262,17 @@ val default_calc_ctx : calc_ctx
 (** [default_calc_ctx] knows of no single-valued variables, so every
     context-dependent calc rewrite is a no-op. *)
 
+val canonical_dimension : length -> length
+(** [canonical_dimension l] folds a length written as a spelling of a value the
+    constructors already hold back onto the constructor: [1.0px], [+1px], [01px]
+    and [1e3px] all become [Px]. The reader keeps such a spelling for the
+    unminified round-trip and the printer drops it under [--minify], so two
+    spellings otherwise reach one minified text through two nodes, and anything
+    keyed on the node reads them as two values. Only a unit the constructor
+    prints back verbatim folds, so no byte moves; a zero keeps its unit, whose
+    strip is a separate question. Belongs in a normalize pass, which only the
+    optimizer runs: the unminified round-trip still needs the spelling. *)
+
 val normalize_length_percentage :
   ?strip:bool ->
   ?non_negative:bool ->

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2188,6 +2188,30 @@ let test_prefix_synthesis_reaches_fixpoint () =
        1em))}b{-webkit-backdrop-filter:blur(max(0px,1em))}";
     ]
 
+let test_authored_dimension_reaches_fixpoint () =
+  (* The reader keeps [2e0ch] as a dimension carrying its own text, and the
+     printer drops that text under [--minify]. Two spellings then reach one
+     minified text through two nodes, which the rule merge reads as two values
+     until a second pass re-reads them as one. *)
+  assert_emission_is_a_fixed_point ~emit:minify_str "minify"
+    [
+      "a{tab-size:2e0ch}b{tab-size:2ch}";
+      "a{tab-size:2ch}b{tab-size:2e0ch}";
+      "a{overflow-clip-margin:1E0px}b{overflow-clip-margin:1px}";
+      "a{line-height:+120%}b{line-height:120%}";
+      "a{line-height:12.0px}b{line-height:12px}";
+      "a{grid-auto-rows:100.0px}b{grid-auto-rows:100px}";
+      "a{grid-auto-rows:+100px}b{grid-auto-rows:100px}";
+      "a{grid-auto-columns:00100px}b{grid-auto-columns:100px}";
+      "a{grid-auto-columns:100e0px}b{grid-auto-columns:100px}";
+      "a{contain-intrinsic-width:100.0px}b{contain-intrinsic-width:100px}";
+      "a{contain-intrinsic-height:00100px}b{contain-intrinsic-height:100px}";
+      "a{contain-intrinsic-inline-size:100E0px}b{contain-intrinsic-inline-size:100px}";
+      "a{contain-intrinsic-block-size:00100px}b{contain-intrinsic-block-size:100px}";
+      "a{columns:12E0em}b{columns:12em}";
+      "a{columns:+12em}b{columns:12em}";
+    ]
+
 let test_no_factor_across_conflict () =
   (* CSS Cascade 6.1: the two .x rules conflict on color, so they merge (last
      wins). The later .y carries the first .x's value, but grouping it with that
@@ -5541,6 +5565,9 @@ let selector_merging_tests =
     ( "prefix synthesis reaches fixpoint in one pass",
       `Quick,
       test_prefix_synthesis_reaches_fixpoint );
+    ( "authored dimension reaches fixpoint in one pass",
+      `Quick,
+      test_authored_dimension_reaches_fixpoint );
     ("no factor across conflict", `Quick, test_no_factor_across_conflict);
     ( "zero box side covered by shorthand",
       `Quick,


### PR DESCRIPTION
`a{tab-size:2e0ch}b{tab-size:2ch}` minified to two rules and only grouped when a caller ran the output through again: the reader keeps a number's authored spelling so an unminified print gives the bytes back, the printer drops it under `--minify`, and the rule merge is keyed on the node. Six families never folded it in the normalize pass, where `width` already did.

The readback sweep goes from 40 unstable emissions over 3 causes to 6 over 2, and every instability involving more than one rule is gone.