### PR TITLE
values: print an unwrapped calc leaf as the leaf it became

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -422,6 +422,10 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Minification
 
+- `--minify` writes a `calc()` it unwraps as the leaf it became, so
+  `transition-duration: calc(120ms)` is `.12s` and not the `120ms` an operand is
+  spelled, and `animation: calc(1)` is the `none` the bare `1` already gave.
+  Both used to need a second pass to settle (#1160)
 - `--minify` merges two rules whose values were written with different spellings
   of one number, so `a{tab-size:2e0ch}b{tab-size:2ch}` groups on the first pass
   rather than the second. `line-height`, `overflow-clip-margin`, the grid track

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -10025,12 +10025,17 @@ val pp_transform : transform Pp.t
 (** [pp_transform] is the pretty printer for transform values. *)
 
 val pp_calc :
-  ?unwrap_num:bool -> ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
-(** [pp_calc ?unwrap_num ?unwrap pp_value] is the pretty printer for calc
-    expressions. Minified output drops the call around a single leaf, and
-    [unwrap] says which leaves that is safe for. [unwrap_num] is the same
-    question for a bare number leaf, which a property taking an [<integer>]
-    answers no to. *)
+  ?unwrap_num:bool ->
+  ?unwrap:('a -> bool) ->
+  ?pp_unwrapped:'a Pp.t ->
+  'a Pp.t ->
+  'a calc Pp.t
+(** [pp_calc ?unwrap_num ?unwrap ?pp_unwrapped pp_value] is the pretty printer
+    for calc expressions. [pp_unwrapped] writes the one leaf that comes out of
+    the call, which is no longer an operand; it defaults to [pp_value]. Minified
+    output drops the call around a single leaf, and [unwrap] says which leaves
+    that is safe for. [unwrap_num] is the same question for a bare number leaf,
+    which a property taking an [<integer>] answers no to. *)
 
 val pp_font_style : font_style Pp.t
 (** [pp_font_style] is the pretty printer for font-style values. *)

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1755,9 +1755,18 @@ module Animation = struct
     | Some Ease | None -> false
     | Some tf -> not (is_default_timing tf)
 
+  (* [calc(1)] is the initial count written the long way, and CSS Values 4 sec.
+     10.12 gives it the same computed value, so the slot answers for it as it
+     already answers for the bare [1] the shorthand drops. Reading it as a value
+     of its own left [animation: calc(1)] emitting [animation: 1], which is
+     every slot at its initial and so reads back as [animation: none]. *)
+  let is_default_count : animation_iteration_count -> bool = function
+    | Count (Num 1.) | Count (Calc (Num 1.)) -> true
+    | _ -> false
+
   let is_iteration : animation_iteration_count option -> bool = function
-    | Some (Count (Num 1.)) | None -> false
-    | Some _ -> true
+    | Some c -> not (is_default_count c)
+    | None -> false
 
   let is_direction : animation_direction option -> bool = function
     | Some Normal | None -> false
@@ -1833,8 +1842,10 @@ module Animation = struct
   let iteration ?(quote_name = false) (anim : animation_shorthand) :
       animation_iteration_count option =
     match (anim.iteration_count, effective_ambiguous_kind ~quote_name anim) with
-    | (Some (Count (Num 1.)) | None), Some Iteration -> Some (Count (Num 1.))
-    | Some (Count (Num 1.)), _ | None, _ -> None
+    | Some c, Some Iteration when is_default_count c -> Some (Count (Num 1.))
+    | None, Some Iteration -> Some (Count (Num 1.))
+    | Some c, _ when is_default_count c -> None
+    | None, _ -> None
     | Some c, _ -> Some c
 
   let direction ?(quote_name = false) (anim : animation_shorthand) :

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1407,8 +1407,13 @@ let negative_length : length -> bool = function
   | _ -> false
 
 let pp_calc_with : type a.
-    ?unwrap_num:bool -> ?unwrap:(a -> bool) -> a Pp.t -> a calc Pp.t =
- fun ?(unwrap_num = true) ?(unwrap = fun _ -> true) pp_value ctx calc ->
+    ?unwrap_num:bool ->
+    ?unwrap:(a -> bool) ->
+    ?pp_unwrapped:a Pp.t ->
+    a Pp.t ->
+    a calc Pp.t =
+ fun ?(unwrap_num = true) ?(unwrap = fun _ -> true) ?pp_unwrapped pp_value ctx
+     calc ->
   match calc with
   (* CSS Values 4 sec. 10.10: a [var()] inside [calc()] is a runtime
      substitution boundary - the substituted tokens go through calc's typed
@@ -1421,14 +1426,21 @@ let pp_calc_with : type a.
      those are is not knowable here, so the wrapper stays on a value that reads
      back differently without it; [Declaration.normalize] unwraps the rest,
      where the property is in hand. *)
-  | Val v when Pp.minified ctx && unwrap v -> pp_value ctx v
+  (* A leaf that comes out of the call is no longer an operand, so it is written
+     the way a leaf on its own is written. [pp_value] is the operand printer,
+     which a caller whose two spellings differ passes [pp_unwrapped] beside: a
+     duration operand keeps [ms] so two unequal calls do not print alike, while
+     [120ms] on its own is [.12s], and printing the operand spelling here left
+     an emission the next reader shortened. *)
+  | Val v when Pp.minified ctx && unwrap v ->
+      Option.value pp_unwrapped ~default:pp_value ctx v
   | Num n when Pp.minified ctx && unwrap_num -> Pp.float ctx n
   | _ ->
       let ctx = { ctx with in_calc = true } in
       Pp.call "calc" (pp_calc_contents pp_value) ctx calc
 
-let pp_calc ?unwrap_num ?unwrap pp_value ctx calc =
-  pp_calc_with ?unwrap_num ?unwrap pp_value ctx calc
+let pp_calc ?unwrap_num ?unwrap ?pp_unwrapped pp_value ctx calc =
+  pp_calc_with ?unwrap_num ?unwrap ?pp_unwrapped pp_value ctx calc
 
 (* Small helpers *)
 
@@ -5036,6 +5048,7 @@ let rec pp_duration_with ~shorten_ms : duration Pp.t =
   | Calc c ->
       pp_calc_with ~unwrap_num:false
         ~unwrap:(fun d -> not (negative_duration d))
+        ~pp_unwrapped:(pp_duration_with ~shorten_ms)
         (pp_duration_with ~shorten_ms:false)
         ctx c
 

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -366,15 +366,22 @@ val pp_number_percentage : ?always:bool -> number_percentage Pp.t
     When [always] is true, always includes units even for 0. *)
 
 val pp_calc :
-  ?unwrap_num:bool -> ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
-(** [pp_calc ?unwrap_num ?unwrap pp] pretty-prints [calc] expressions using [pp]
-    for leaf values. Minified output drops the call around a single leaf;
-    [unwrap] says which leaves that is safe for, and defaults to all of them. A
-    leaf outside the property's range is not one: CSS Values 4 sec. 10.12 keeps
-    the call valid there and clamps at used-value time, where the bare value is
-    dropped instead. [unwrap_num] is the same question for a bare number leaf,
-    which a property taking an [<integer>] answers no to: sec. 10.12 rounds the
-    call and drops the fraction written on its own. *)
+  ?unwrap_num:bool ->
+  ?unwrap:('a -> bool) ->
+  ?pp_unwrapped:'a Pp.t ->
+  'a Pp.t ->
+  'a calc Pp.t
+(** [pp_calc ?unwrap_num ?unwrap ?pp_unwrapped pp] pretty-prints [calc]
+    expressions using [pp] for leaf values, and [pp_unwrapped] for the one leaf
+    that comes out of the call, which is no longer an operand and takes the
+    spelling a leaf on its own takes; it defaults to [pp]. Minified output drops
+    the call around a single leaf; [unwrap] says which leaves that is safe for,
+    and defaults to all of them. A leaf outside the property's range is not one:
+    CSS Values 4 sec. 10.12 keeps the call valid there and clamps at used-value
+    time, where the bare value is dropped instead. [unwrap_num] is the same
+    question for a bare number leaf, which a property taking an [<integer>]
+    answers no to: sec. 10.12 rounds the call and drops the fraction written on
+    its own. *)
 
 val pp_color_name : color_name Pp.t
 (** [pp_color_name] pretty-prints {!type-color_name} values. *)

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2212,6 +2212,19 @@ let test_authored_dimension_reaches_fixpoint () =
       "a{columns:+12em}b{columns:12em}";
     ]
 
+let test_unwrapped_calc_leaf_reaches_fixpoint () =
+  (* [pp_min] prints without running a pass, which is the mode that asks whether
+     the printer is a serialiser. Dropping a [calc()] wrapper there leaves a
+     leaf that is no longer a calc operand, so the next reader gives it the
+     spelling a leaf takes on its own, and for [animation] the unwrapped [1] is
+     the slot's initial and the whole shorthand collapses. *)
+  assert_emission_is_a_fixed_point ~emit:pp_min "pp minify"
+    [
+      "a{transition-duration:calc(120ms)}";
+      "a{animation-duration:calc(120ms)}";
+      "a{animation:calc(1)}";
+    ]
+
 let test_no_factor_across_conflict () =
   (* CSS Cascade 6.1: the two .x rules conflict on color, so they merge (last
      wins). The later .y carries the first .x's value, but grouping it with that
@@ -5568,6 +5581,9 @@ let selector_merging_tests =
     ( "authored dimension reaches fixpoint in one pass",
       `Quick,
       test_authored_dimension_reaches_fixpoint );
+    ( "unwrapped calc leaf reaches fixpoint in one pass",
+      `Quick,
+      test_unwrapped_calc_leaf_reaches_fixpoint );
     ("no factor across conflict", `Quick, test_no_factor_across_conflict);
     ( "zero box side covered by shorthand",
       `Quick,


### PR DESCRIPTION
`a{transition-duration:calc(120ms)}` minified to `120ms` and then to `.12s` on the pass after: a leaf that comes out of a `calc()` is no longer an operand, but it was still written by the operand printer, which keeps `ms` so that two unequal calls do not print alike. The `animation` shorthand had the same shape one level up, where `calc(1)` is the initial count written the long way.

The readback sweep goes from 6 unstable emissions over 2 causes to 3 over 1. The remaining cause is the `mask-image` contraction, which is a different mechanism.