### PR TITLE
values: read a comparison function at a percentage slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,7 +50,7 @@ entry points both moved.
   `interest-delay`. `Cascade.Properties.font_weight`,
   `webkit_line_clamp`, `zoom`, `border_image_slice_item` and
   `shape_image_threshold` gain `Calc`, and `grid_line` gains `Calc_name`
-  (#1072, #1086, #1124, #1125, #1126, #1145, #1148)
+  (#1072, #1086, #1124, #1125, #1126, #1145, #1148, #1161)
 - A math function takes only the operands CSS Values 4 sec. 10.8 grants, so
   `width: calc(inherit)`, `height: calc(auto)`, `border-width: calc(medium)`,
   `width: calc(fit-content(20rem))` and `width: min(unset, 1px)` are dropped

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -2017,12 +2017,14 @@ let rec read_font t : font =
         Shorthand body
 
 let rec read_font_stretch_with ~keywords t : font_stretch =
-  let read_percentage t : font_stretch =
-    let n = Cursor.pct t in
-    (* CSS Fonts 4 sec. 2.3: font-stretch percentage is non-negative. *)
+  (* CSS Fonts 4 sec. 2.3: font-stretch percentage is non-negative. Sec. 10.12
+     puts the range on the value a math function resolves to, so a folded
+     comparison answers to it the way a literal does. *)
+  let checked t n : font_stretch =
     if n < 0. then err_invalid_value t "font-stretch" (string_of_float n);
     Pct n
   in
+  let read_percentage t : font_stretch = checked t (Cursor.pct t) in
   (* Sec. 10.1 puts a math function wherever the [<percentage>] stands, [calc()]
      being one of them rather than the gate to the rest, and sec. 10.12 checks
      the [0,inf] range on the value it resolves to: the call keeps out of
@@ -2060,7 +2062,7 @@ let rec read_font_stretch_with ~keywords t : font_stretch =
     ~calls:
       (("var", fun t -> Var (read_var (read_font_stretch_with ~keywords) t))
       :: ("calc", read_math)
-      :: Values.math_function_calls read_math)
+      :: Values.percentage_math_function_calls ~pct:checked read_math)
     ~default:read_percentage t
 
 let read_font_stretch t : font_stretch = read_font_stretch_with ~keywords:true t

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -2134,6 +2134,13 @@ let rec read_text_size_adjust_with ~keywords t : text_size_adjust =
              (read_text_size_adjust_with ~keywords:false)
              t)
       in
+      (* Sec. 10.12 puts the [0,inf] range on the value a math function resolves
+         to, so a folded comparison answers to it the way a literal does. *)
+      let checked t n : text_size_adjust =
+        if n < 0.0 then
+          Cursor.err t "text-size-adjust percentages cannot be negative"
+        else Pct n
+      in
       Cursor.enum_or_calls "text-size-adjust"
         (if keywords then
            [
@@ -2151,7 +2158,7 @@ let rec read_text_size_adjust_with ~keywords t : text_size_adjust =
              fun t ->
                Var (Values.read_var (read_text_size_adjust_with ~keywords) t) )
           :: ("calc", read_math)
-          :: Values.math_function_calls read_math)
+          :: Values.percentage_math_function_calls ~pct:checked read_math)
         t
 
 let read_text_size_adjust t : text_size_adjust =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5898,11 +5898,21 @@ let validate_calc_type t result_type calc =
   in
   if not accepted then Cursor.err_invalid t "incompatible calc types"
 
-(* CSS Values 4 sec. 10.2 comparison and stepped-value functions, sec. 10.5
-   [hypot()] and sec. 10.6 [abs()]: each answers the type of its arguments, so a
-   [<length>] slot takes them as readily as a [<number>] one. *)
+(* CSS Values 4 sec. 10.2 comparison functions. Their answer is one of their
+   arguments, so a slot spelling the arguments' type already has a leaf for the
+   result and the call folds to it rather than standing as a calculation. *)
+let comparison_math_function_names = [ "min"; "max"; "clamp" ]
+
+(* Sec. 10.9 stepped-value functions, sec. 10.5 [hypot()] and sec. 10.6 [abs()]:
+   each answers the type of its arguments too, and each computes a value none of
+   them spelled, so the call stays in the calculation. *)
+let computed_typed_math_function_names =
+  [ "round"; "mod"; "rem"; "hypot"; "abs" ]
+
+(* Together they are the functions a [<length>] slot takes as readily as a
+   [<number>] one. *)
 let typed_math_function_names =
-  [ "min"; "max"; "clamp"; "round"; "mod"; "rem"; "hypot"; "abs" ]
+  comparison_math_function_names @ computed_typed_math_function_names
 
 (* Sec. 10.5 exponential functions, sec. 10.4 trigonometric ones and sec. 10.6
    [sign()]: all answer a [<number>] whatever went in, so only a [<number>] slot
@@ -5939,6 +5949,48 @@ let math_function_calls read =
 
 let typed_math_function_calls read =
   List.map (fun n -> (n, read)) typed_math_function_names
+
+(* Sec. 10.2 requires a comparison function's arguments to have a consistent
+   type and answers with that type, so at a [<percentage>] slot every argument
+   is a [<calc-sum>] resolving to a percentage: a bare coefficient is a
+   [<number>] the slot does not spell, and a length is a type of its own. *)
+let read_percentage_argument t =
+  let arg = read_math_arg t in
+  match math_arg_result arg with
+  | Some (United (v, unit)) when String.equal unit "%" -> v
+  | Some (Scalar _ | United _) | None -> Cursor.err_expected t "percentage"
+
+let read_percentage_list_call name pick initial t =
+  Cursor.call name t (fun inner ->
+      let args =
+        Cursor.list ~sep:Cursor.comma ~at_least:1 read_percentage_argument inner
+      in
+      Cursor.ws inner;
+      Cursor.expect_eof inner;
+      List.fold_left pick initial args)
+
+let read_percentage_clamp t =
+  Cursor.call "clamp" t (fun inner ->
+      let low = read_percentage_argument inner in
+      Cursor.ws inner;
+      Cursor.comma inner;
+      let value = read_percentage_argument inner in
+      Cursor.ws inner;
+      Cursor.comma inner;
+      let high = read_percentage_argument inner in
+      Cursor.ws inner;
+      Cursor.expect_eof inner;
+      Float.max low (Float.min value high))
+
+let percentage_math_function_calls ~pct read =
+  ("min", fun t -> pct t (read_percentage_list_call "min" Float.min infinity t))
+  :: ( "max",
+       fun t -> pct t (read_percentage_list_call "max" Float.max neg_infinity t)
+     )
+  :: ("clamp", fun t -> pct t (read_percentage_clamp t))
+  :: List.map
+       (fun n -> (n, read))
+       (computed_typed_math_function_names @ number_math_function_names)
 
 let read_calc : type a.
     ?result_type:

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -708,6 +708,18 @@ val typed_math_function_calls :
     functions that answer the type of their arguments, for a slot that takes a
     [<length>] or another dimension rather than a [<number>]. *)
 
+val percentage_math_function_calls :
+  pct:(Cursor.t -> float -> 'a) ->
+  (Cursor.t -> 'a) ->
+  (string * (Cursor.t -> 'a)) list
+(** [percentage_math_function_calls ~pct read] is {!math_function_calls} for a
+    slot spelling a [<percentage>] and no [<number>] beside it. CSS Values 4
+    sec. 10.2 answers a comparison with one of its arguments, which is a
+    percentage the slot has a leaf for, so [min()], [max()] and [clamp()] fold
+    to their coefficient and [pct] builds that leaf, applying whatever range the
+    property puts on it. Every other math function keeps [read], which holds the
+    call to the slot's type. *)
+
 val read_integer_calc : string -> Cursor.t -> [ `Int of int | `Calc of 'a calc ]
 (** [read_integer_calc name t] parses the math function at an [<integer>]
     position, which CSS Values 4 sec. 10.9 accepts wherever a literal integer

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -2038,6 +2038,19 @@ let spec_math_at_the_remaining_readers () =
   decl_optimizes ~prop:"font-stretch" ~into:"50%" "calc(50%)";
   decl_optimizes ~prop:"text-size-adjust" ~into:"50%" "calc(50%)";
   decl_optimizes ~prop:"-webkit-text-size-adjust" ~into:"50%" "calc(50%)";
+  (* Sec. 10.7 gives [min()], [max()] and [clamp()] [<calc-sum>] arguments and
+     the arguments' own type, exactly as sec. 10.9 does for the stepped
+     functions, so a percentage slot takes them where it takes [calc()]. Chrome
+     153 reads each of these and computes the comparison. *)
+  decl_optimizes ~prop:"font-stretch" ~into:"50%" "min(50%,75%)";
+  decl_optimizes ~prop:"font-stretch" ~into:"75%" "max(50%,75%)";
+  decl_optimizes ~prop:"font-stretch" ~into:"60%" "clamp(50%,60%,75%)";
+  decl_optimizes ~prop:"text-size-adjust" ~into:"50%" "clamp(10%,50%,90%)";
+  decl_optimizes ~prop:"-webkit-text-size-adjust" ~into:"10%" "min(10%,50%)";
+  (* The same call over lengths, which the typed length readers already took, so
+     the two paths agree rather than one admitting what the other refuses. *)
+  decl_optimizes ~prop:"width" ~into:"1px" "min(1px,2px)";
+  decl_optimizes ~prop:"width" ~into:"2px" "max(1px,2px)";
   (* CSS UI 5 sec. 7.2 [interest-delay] is [<time [0s,inf]>], so the negative
      one Chrome computes as [0s] keeps its wrapper where the literal is
      dropped. *)


### PR DESCRIPTION
`font-stretch: min(50%, 75%)` and `text-size-adjust: clamp(10%, 50%, 90%)` used to be dropped; they now read and fold to the percentage the comparison picks, the way they already did at a `<length>` slot. Chrome 153 reads every row.