### PR TITLE
image: fold the gradient interpolation keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -354,11 +354,12 @@ to lose a whole rule over one bad piece. Both are gone.
 - Keyword, at-rule and function names match without regard to case, so
   `grid-column: SPAN 2`, `@MEDIA`, `RGB()`, `VAR(--x)`, `:dir(LTR)`,
   `touch-action: NONE`, `display: LIST-ITEM FLOW-ROOT`, `align-items: FIRST
-  BASELINE`, `grid-template-columns: REPEAT(3, 1FR)` and `color: COLOR(DISPLAY-P3
-  1 0 0)` read, while an author-defined name keeps the case it was written in.
+  BASELINE`, `grid-template-columns: REPEAT(3, 1FR)`, `color: COLOR(DISPLAY-P3
+  1 0 0)` and `linear-gradient(IN OKLAB, red, blue)` read, while an
+  author-defined name keeps the case it was written in.
   An escaped name reads as the name it spells: `@supports (--x\3b y: red)` is
   read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer `b`
-  of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141)
+  of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141, #1162)
 - Cascade reads back everything it writes. Minified `@scope to (...)`, `rotate`
   with a negative axis, a relative colour's channels, a `-webkit-gradient`
   `color-stop()` and `center` point, `text-decoration: none solid`,

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -45,10 +45,13 @@ let rec pp_color_interpolation : color_interpolation Pp.t =
    [<hue-interpolation-method>] followed by [hue]. *)
 let read_hue_interpolation_method t =
   let snap = Cursor.save t in
-  match Cursor.ident_opt t with
+  let keyword t =
+    Option.map String.lowercase_ascii_preserve (Cursor.ident_opt t)
+  in
+  match keyword t with
   | Some (("shorter" | "longer" | "increasing" | "decreasing") as kw) -> (
       Cursor.ws t;
-      match Cursor.ident_opt t with
+      match keyword t with
       | Some "hue" ->
           Some
             (match kw with
@@ -70,7 +73,7 @@ let read_color_interpolation (t : Cursor.t) : color_interpolation =
       (* At the component-value level, [in oklab] lexes as two separate idents;
          [inoklab] lexes as a single ident and would fail [expect_string "in"]
          above, so no extra whitespace check is needed here. *)
-      let space = Cursor.ident t in
+      let space = String.lowercase_ascii_preserve (Cursor.ident t) in
       let hue () =
         Cursor.ws t;
         read_hue_interpolation_method t

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -2190,6 +2190,18 @@ let spec_keyword_case_insensitive () =
   agrees "gradient position var()"
     ~upper:".a{background:linear-gradient(VAR(--dir),red,blue)}"
     ~lower:".a{background:linear-gradient(var(--dir),red,blue)}";
+  (* CSS Color 5 sec. 9 spells one [<color-interpolation-method>] for every
+     place it appears, so the colour space and the hue keyword fold in a
+     gradient exactly as [color-mix()]'s own reader already folds them. *)
+  agrees "gradient interpolation colour space"
+    ~upper:".a{background:linear-gradient(to right IN OKLAB,red,blue)}"
+    ~lower:".a{background:linear-gradient(to right in oklab,red,blue)}";
+  agrees "gradient interpolation hue method"
+    ~upper:".a{background:linear-gradient(IN OKLCH SHORTER HUE,red,blue)}"
+    ~lower:".a{background:linear-gradient(in oklch shorter hue,red,blue)}";
+  agrees "color-mix interpolation colour space"
+    ~upper:".a{color:color-mix(IN OKLAB,red,blue)}"
+    ~lower:".a{color:color-mix(in oklab,red,blue)}";
   (* [shape-outside] is a [string property]: a valid value is handed back as
      the raw source text, uppercase var() included, so there is no folded
      form to agree on here. Only the empty-var() rejection below is a shared


### PR DESCRIPTION
`linear-gradient(in OKLAB, red, blue)` used to be dropped: the gradient matched the colour space and the hue method against lower-case literals, while `color-mix()` reads the same `<color-interpolation-method>` through `Values.read_color_space` and takes it either way.