### PR TITLE
grid: range-check the index a line's math call rounds to

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -221,14 +221,16 @@ to lose a whole rule over one bad piece. Both are gone.
   `padding-bottom: anchor-size(width)`, `translate: auto`,
   `border-top-color: calc(2px - 3px)`, `border-image: none, none`,
   `font-language-override: "default"`, `grid-template-rows: -2px`,
-  `grid-template: 10px`, `quotes:`, `border:` and a `@page size` given a
-  percentage. Ranges, units, sizing functions and the closed `<color>`
-  production are each checked, where the reader carried any dimension or any
-  well-formed token run through, and an empty value is a declaration only for a
-  custom property. This release adds
+  `grid-template: 10px`, `grid-area: calc(1/2/3/4/5)`, `quotes:`, `border:` and
+  a `@page size` given a percentage. Ranges, units, sizing functions and the
+  closed `<color>` production are each checked, where the reader carried any
+  dimension or any well-formed token run through, and a range now answers for
+  the integer a math call rounds to rather than letting the call past, so a
+  line index rounding to zero is no line. An empty value is a declaration only
+  for a custom property. This release adds
   `Cascade.Properties.read_border_image_source`
   (#640, #982, #1000, #1001, #1002, #1003, #1004, #1005, #1006, #1007, #1009,
-  #1010, #1015, #1077, #1078)
+  #1010, #1015, #1077, #1078, #1163)
 - A `<custom-ident>` refuses the names CSS Values 4 sec. 4.2 reserves, in every
   ASCII case permutation, so `animation-name: default`, `counter-reset: DEFAULT`,
   `view-transition-name: default` and a `default` counter-style symbol are

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -778,6 +778,16 @@ let check_grid_line_index t n =
   if n = 0 then Cursor.err_invalid t "grid line index cannot be zero";
   n
 
+(* CSS Values 4 sec. 10.12 rounds a call at an [<integer>] slot to the nearest
+   integer, so the range above answers for the integer it rounds to rather than
+   for the call: [calc(1/2/3/4/5)] is the zero line as surely as [0] is. A call
+   that does not resolve here has no index yet and keeps its wrapper. *)
+let check_grid_line_calc t expr =
+  Option.iter
+    (fun n -> ignore (check_grid_line_index t n))
+    (Values.calc_integer_value expr);
+  expr
+
 let read_grid_line_number t : grid_line =
   let n = check_grid_line_index t (Cursor.int t) in
   Cursor.ws t;
@@ -810,7 +820,7 @@ let read_grid_line_name_value t : grid_line =
           if Cursor.looking_at_calc t || Values.looking_at_math_function t then
             match read_integer_calc "grid-line" t with
             | `Int n -> Num_name (check_grid_line_index t n, name)
-            | `Calc expr -> Calc_name (expr, name)
+            | `Calc expr -> Calc_name (check_grid_line_calc t expr, name)
           else Num_name (check_grid_line_index t (Cursor.int t), name)
         in
         match Cursor.option index t with Some line -> line | None -> Name name)
@@ -819,7 +829,7 @@ let read_grid_line_calc t : grid_line =
   let line =
     match read_integer_calc "grid-line" t with
     | `Int n -> `Int (check_grid_line_index t n)
-    | `Calc expr -> `Calc expr
+    | `Calc expr -> `Calc (check_grid_line_calc t expr)
   in
   Cursor.ws t;
   (* sec. 8.3's [&&] puts the name on either side of the index, so a call in

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6055,6 +6055,18 @@ let read_integer_calc : type a.
   | Some f when Float.is_integer f -> `Int (int_of_float f)
   | Some _ | None -> `Calc expr
 
+(* Sec. 10.12 rounds to the nearest integer with a tie going toward positive
+   infinity, so this is the integer a slot's own range has to answer for: a call
+   that rounds outside the range is as invalid as the literal would be. One
+   holding a [var()] does not resolve here and has no integer yet, and an
+   infinity or a NaN has none at all. *)
+let calc_integer_value : type a. a calc -> int option =
+ fun expr ->
+  match eval_numeric_calc expr with
+  | Some f when Float.is_finite f ->
+      Option.some (int_of_float (Float.floor (f +. 0.5)))
+  | Some _ | None -> Option.none
+
 let read_integer name t =
   if Cursor.looking_at_calc t || looking_at_math_function t then
     match

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -747,6 +747,13 @@ val validate_calc_type :
     it per argument, which is what sec. 10.2 asks for when it requires them to
     "have a consistent type or else the function is invalid". *)
 
+val calc_integer_value : 'a calc -> int option
+(** [calc_integer_value calc] is the integer a math function stands for at an
+    [<integer>] slot: CSS Values 4 sec. 10.12 rounds it to the nearest integer,
+    a tie going toward positive infinity. It is [None] for a call that does not
+    resolve here, a [var()] among its operands or an infinite result, so a slot
+    checking its own range against it leaves such a call alone. *)
+
 val eval_numeric_calc : 'a calc -> float option
 (** [eval_numeric_calc calc] tries to evaluate a calc expression containing only
     numbers to a float. Returns [None] if the expression contains variables or

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2334,6 +2334,19 @@ let animations_timing () =
   neg_cursor read_declaration "grid-row-start: calc(0)";
   neg_cursor read_declaration "grid-row-start: center calc(0)";
   neg_cursor read_declaration "grid-row-start: center 0";
+  (* sec. 10.12 rounds a call at an <integer> slot to the nearest integer, ties
+     toward positive infinity, so a call that resolves reaches sec. 8.3's range
+     as the integer it rounds to and the ones rounding to zero are no line.
+     Chrome 153 refuses each of these and keeps calc(-.6), which rounds to
+     -1. *)
+  neg_cursor read_declaration "grid-area: calc(1/2/3/4/5)";
+  neg_cursor read_declaration "grid-area: calc(2 * 1/2/3/4/5)";
+  neg_cursor read_declaration "grid-row-start: calc(-1/2)";
+  neg_cursor read_declaration "grid-row-start: calc(.4)";
+  neg_cursor read_declaration "grid-row-start: calc(-.4)";
+  neg_cursor read_declaration "grid-row-start: calc(-.5)";
+  check_declaration ~expected:"grid-row-start:calc(-.6)"
+    ~optimized:"grid-row-start:calc(-.6)" "grid-row-start: calc(-.6)";
 
   (* sec. 10 allows a math function wherever an <integer> is allowed, and sec.
      10.12 rounds the call and clamps it, so a fractional or out-of-range call


### PR DESCRIPTION
`grid-area: calc(1/2/3/4/5)` used to read as a line: a math call at a `<grid-line>` index kept its wrapper without ever reaching the range, though the value it resolves to rounds to zero, which is no line. Chrome 153 refuses it and every other row here.