### PR TITLE
font-face: read a math function at the percentage descriptors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,10 +47,12 @@ entry points both moved.
   round(1.5px, 1px)` reads where only `width` did. Thirteen readers that
   admitted no math at all now do, among them `stroke-width`, `initial-letter`,
   `font-size-adjust`, `baseline-shift`, `columns`, `font-stretch` and
-  `interest-delay`. `Cascade.Properties.font_weight`,
+  `interest-delay`, and the `@font-face` descriptors `ascent-override`,
+  `descent-override`, `line-gap-override` and `size-adjust`, which hold the
+  percentage the call resolves to. `Cascade.Properties.font_weight`,
   `webkit_line_clamp`, `zoom`, `border_image_slice_item` and
   `shape_image_threshold` gain `Calc`, and `grid_line` gains `Calc_name`
-  (#1072, #1086, #1124, #1125, #1126, #1145, #1148, #1161)
+  (#1072, #1086, #1124, #1125, #1126, #1145, #1148, #1161, #1164)
 - A math function takes only the operands CSS Values 4 sec. 10.8 grants, so
   `width: calc(inherit)`, `height: calc(auto)`, `border-width: calc(medium)`,
   `width: calc(fit-content(20rem))` and `width: min(unset, 1px)` are dropped

--- a/fuzz/fuzz_font_face.ml
+++ b/fuzz/fuzz_font_face.ml
@@ -183,6 +183,10 @@ let test_spec_metric_vectors buf =
         ("0%", Css.Font_face.Percent 0.);
         ("100%", Css.Font_face.Percent 100.);
         ("125.5%", Css.Font_face.Percent 125.5);
+        (* Sec. 10.1 puts a math function wherever the percentage stands, and
+           the descriptor holds the percentage it answers. *)
+        ("calc(50%)", Css.Font_face.Percent 50.);
+        ("min(50%,75%)", Css.Font_face.Percent 50.);
       ]
       buf 3
   in
@@ -194,7 +198,7 @@ let test_spec_metric_vectors buf =
   | None -> failf "valid font metric vector rejected: %S" input
 
 let test_invalid_metric_vectors buf =
-  let input = pick [ "-1%"; "auto"; "100"; "calc(1%)" ] buf 4 in
+  let input = pick [ "-1%"; "auto"; "100"; "calc(1px)"; "calc(1)" ] buf 4 in
   match parse_metric input with
   | None -> ()
   | Some metric ->
@@ -208,6 +212,7 @@ let test_spec_size_adjust_vectors buf =
         ("0%", Css.Font_face.Pct 0.);
         ("100%", Css.Font_face.Pct 100.);
         ("125.5%", Css.Font_face.Pct 125.5);
+        ("calc(50%)", Css.Font_face.Pct 50.);
       ]
       buf 5
   in
@@ -219,7 +224,7 @@ let test_spec_size_adjust_vectors buf =
   | None -> failf "valid font size-adjust vector rejected: %S" input
 
 let test_invalid_size_adjust_vectors buf =
-  let input = pick [ "-1%"; "normal"; "auto"; "100"; "calc(100%)" ] buf 6 in
+  let input = pick [ "-1%"; "normal"; "auto"; "100"; "calc(1px)" ] buf 6 in
   match parse_size_adjust input with
   | None -> ()
   | Some size_adjust ->

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -187,6 +187,14 @@ let rec read_metric_override t : metric_override =
   | Some (Component.Func { node = { name; _ }; _ })
     when String.lowercase_ascii name = "var" ->
       Var (Values.read_var read_metric_override t)
+  (* Sec. 10.1 puts a math function wherever the [<percentage>] stands, so the
+     descriptor takes one and answers with the percentage it resolves to: there
+     is no calculation node here to park an unresolved call in. Sec. 4.10's
+     [0,inf] range then reads that percentage the way it reads a literal. *)
+  | Some (Component.Func _) when Values.looking_at_percentage_math t ->
+      let value = Values.read_folded_percentage_math t in
+      if valid_percentage value then Percent value
+      else Cursor.err_invalid t "metric override"
   | Some _ | None -> Cursor.err_invalid t "metric override"
 
 (* CSS Fonts 5 sec. 4.4: [<percentage [0,inf]>]. *)
@@ -199,6 +207,12 @@ let rec read_size_adjust t : size_adjust =
     when valid_percentage number.Token.value ->
       Cursor.skip t;
       Pct number.Token.value
+  (* Sec. 10.1 again: the descriptor takes the call and holds the percentage it
+     answers, since it has no calculation node of its own. *)
+  | Some (Component.Func _) when Values.looking_at_percentage_math t ->
+      let value = Values.read_folded_percentage_math t in
+      if valid_percentage value then Pct value
+      else Cursor.err_invalid t "size-adjust"
   | Some _ | None -> Cursor.err_invalid t "size-adjust"
 
 let read_whole read s =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5992,6 +5992,33 @@ let percentage_math_function_calls ~pct read =
        (fun n -> (n, read))
        (computed_typed_math_function_names @ number_math_function_names)
 
+(* Sec. 10.1 puts a math function wherever the [<percentage>] stands and makes
+   [calc()] one of them rather than the gate to the rest, so both spellings
+   answer the same percentage. A slot holding a percentage and no calculation
+   node takes the answer and nothing else: a call this cannot reduce -- a
+   [var()] among its operands, or a result of another type -- is no value for
+   it. *)
+let read_folded_percentage_math t =
+  let body name =
+    Cursor.call name t (fun inner ->
+        let value = read_percentage_argument inner in
+        Cursor.ws inner;
+        Cursor.expect_eof inner;
+        value)
+  in
+  if Cursor.looking_at_func "calc" t then body "calc"
+  else if Cursor.looking_at_func "-webkit-calc" t then body "-webkit-calc"
+  else
+    match Cursor.peek_function_name t with
+    | Some "min" -> read_percentage_list_call "min" Float.min infinity t
+    | Some "max" -> read_percentage_list_call "max" Float.max neg_infinity t
+    | Some "clamp" -> read_percentage_clamp t
+    | Some _ when looking_at_math_function t -> read_percentage_argument t
+    | Some _ | None -> Cursor.err_expected t "percentage"
+
+let looking_at_percentage_math t =
+  Cursor.looking_at_calc t || looking_at_math_function t
+
 let read_calc : type a.
     ?result_type:
       [ `Number

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -720,6 +720,19 @@ val percentage_math_function_calls :
     property puts on it. Every other math function keeps [read], which holds the
     call to the slot's type. *)
 
+val looking_at_percentage_math : Cursor.t -> bool
+(** [looking_at_percentage_math t] is [true] on a [calc()] or on any other math
+    function, the two spellings {!read_folded_percentage_math} reads. *)
+
+val read_folded_percentage_math : Cursor.t -> float
+(** [read_folded_percentage_math t] reads a math function at a slot spelling a
+    [<percentage>] and answers the percentage it resolves to. CSS Values 4 sec.
+    10.1 puts such a function wherever the [<percentage>] stands and makes
+    [calc()] one of them rather than the gate to the rest, so both spellings
+    read here. It is for a slot that holds a percentage and has no calculation
+    node to park an unresolved call in: a call carrying a [var()], or one
+    answering another type, is refused rather than kept. *)
+
 val read_integer_calc : string -> Cursor.t -> [ `Int of int | `Calc of 'a calc ]
 (** [read_integer_calc name t] parses the math function at an [<integer>]
     position, which CSS Values 4 sec. 10.9 accepts wherever a literal integer

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -145,15 +145,48 @@ let test_spec_metric_parsing_edges () =
     (size_adjust_of_string "87.5%" |> string_of_size_adjust)
 
 let test_spec_metric_negative_vectors () =
-  List.iter expect_metric_rejected [ "-1%"; "auto"; "100"; "calc(1%)" ];
+  List.iter expect_metric_rejected [ "-1%"; "auto"; "100" ];
   Alcotest.(check string)
     "over 100 metric override still parses" "120%"
     (metric_override_of_string "120%" |> string_of_metric_override);
-  List.iter expect_size_adjust_rejected
-    [ "-10%"; "normal"; "auto"; "100"; "calc(100%)" ];
+  List.iter expect_size_adjust_rejected [ "-10%"; "normal"; "auto"; "100" ];
   Alcotest.(check string)
     "zero size adjust parses" "0%"
     (size_adjust_of_string "0%" |> string_of_size_adjust)
+
+(* CSS Values 4 sec. 10.1 puts a math function wherever a [<percentage>] is
+   allowed, and CSS Fonts 4 sec. 4.10 and Fonts 5 sec. 4.4 spell these four
+   descriptors with one, so a call reads here exactly as it does at a percentage
+   property. The descriptor has a percentage leaf and no calculation node, so a
+   call that resolves stands for the percentage it answers and one that answers
+   another type is no value for the slot. Chrome 153 reads every accepted row
+   and drops every rejected one. *)
+let spec_fontface_metric_math () =
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string)
+        input expected
+        (metric_override_of_string input |> string_of_metric_override))
+    [
+      ("calc(50%)", "50%");
+      ("calc(50% + 10%)", "60%");
+      ("min(50%,75%)", "50%");
+      ("clamp(10%,50%,90%)", "50%");
+      ("abs(-50%)", "50%");
+    ];
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string)
+        input expected
+        (size_adjust_of_string input |> string_of_size_adjust))
+    [
+      ("calc(50%)", "50%");
+      ("calc(50% + 10%)", "60%");
+      ("max(50%,75%)", "75%");
+      ("abs(-50%)", "50%");
+    ];
+  List.iter expect_metric_rejected [ "calc(1px)"; "calc(50)"; "min(1px,2px)" ];
+  List.iter expect_size_adjust_rejected [ "calc(1px)"; "calc(50)" ]
 
 let spec_fontface_source_edges () =
   let check_normalized name input expected =
@@ -750,6 +783,7 @@ let suite =
         test_spec_metric_parsing_edges;
       test_case "spec metric negative vectors" `Quick
         test_spec_metric_negative_vectors;
+      test_case "spec font-face metric math" `Quick spec_fontface_metric_math;
       test_case "spec font-face level 4/5 source edges" `Quick
         spec_fontface_source_edges;
       test_case "spec font-face metric descriptor edges" `Quick


### PR DESCRIPTION
`@font-face { size-adjust: calc(50%) }` and the three metric overrides used to be dropped: their readers matched a percentage token and nothing else. Each holds a percentage and has no calculation node, so a call answers with the percentage it resolves to and one that cannot resolve here stays refused.