### PR TITLE
font-style: require a unit on the oblique angle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -223,8 +223,9 @@ to lose a whole rule over one bad piece. Both are gone.
   `padding-bottom: anchor-size(width)`, `translate: auto`,
   `border-top-color: calc(2px - 3px)`, `border-image: none, none`,
   `font-language-override: "default"`, `grid-template-rows: -2px`,
-  `grid-template: 10px`, `grid-area: calc(1/2/3/4/5)`, `quotes:`, `border:` and
-  a `@page size` given a percentage. Ranges, units, sizing functions and the
+  `grid-template: 10px`, `grid-area: calc(1/2/3/4/5)`,
+  `font-style: oblique 0`, `quotes:`, `border:` and a `@page size` given a
+  percentage. Ranges, units, sizing functions and the
   closed `<color>` production are each checked, where the reader carried any
   dimension or any well-formed token run through, and a range now answers for
   the integer a math call rounds to rather than letting the call past, so a
@@ -232,7 +233,7 @@ to lose a whole rule over one bad piece. Both are gone.
   for a custom property. This release adds
   `Cascade.Properties.read_border_image_source`
   (#640, #982, #1000, #1001, #1002, #1003, #1004, #1005, #1006, #1007, #1009,
-  #1010, #1015, #1077, #1078, #1163)
+  #1010, #1015, #1077, #1078, #1163, #1165)
 - A `<custom-ident>` refuses the names CSS Values 4 sec. 4.2 reserves, in every
   ASCII case permutation, so `animation-name: default`, `counter-reset: DEFAULT`,
   `view-transition-name: default` and a `default` counter-style symbol are

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -100,14 +100,18 @@ let rec read_font_style t : font_style =
       Cursor.ws t;
       if Cursor.is_done t then Oblique
       else
-        let first = read_angle t in
+        (* CSS Values 4 sec. 6 drops the unit on a zero [<length>] and on
+           nothing else, so an angle slot that takes a bare zero spells it
+           [<angle> | <zero>] the way Transforms 1 sec. 11 does. CSS Fonts 4
+           sec. 2.4 writes [oblique <angle [-90deg,90deg]>?] and grants none. *)
+        let first = read_angle_unit_required t in
         Cursor.ws t;
         if Cursor.is_done t then Oblique_angle first
         else
           (* CSS Fonts 4 sec. 4.4 swaps the endpoints of a descending [oblique
              <angle> <angle>] range rather than rejecting it, so the reader
              keeps the order it was written in. *)
-          let second = read_angle t in
+          let second = read_angle_unit_required t in
           Oblique_range (first, second))
     t
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -971,6 +971,20 @@ let font_properties () =
   check_declaration ~expected:"font-style:normal" "font-style: normal";
   check_declaration ~expected:"font-style:italic" "font-style: italic";
   check_declaration ~expected:"font-style:oblique" "font-style: oblique";
+  (* CSS Values 4 sec. 6 drops the unit on a zero <length> and on nothing else.
+     A slot taking a bare zero angle says so, as Transforms 1 sec. 11 and Filter
+     Effects 1 sec. 8 do with [<angle> | <zero>]; CSS Fonts 4 sec. 2.4 writes
+     [oblique <angle [-90deg,90deg]>?] and grants no zero, so the unit is
+     required here. Chrome 153 drops the bare zero and keeps the other three. *)
+  neg_cursor read_declaration "font-style: oblique 0";
+  neg_cursor read_declaration "font-style: oblique 0 10deg";
+  check_declaration ~expected:"font-style:oblique 0deg"
+    "font-style: oblique 0deg";
+  check_declaration ~expected:"transform:rotate(0deg)" "transform: rotate(0)";
+  (* Sec. 8 makes [hue-rotate()]'s argument optional and zero by default, so the
+     shortest spelling of a zero rotation is the empty call, which Chrome reads
+     back as the same filter. *)
+  check_declaration ~expected:"filter:hue-rotate()" "filter: hue-rotate(0)";
 
   (* Font family - list type *)
   check_declaration ~expected:"font-family:Arial" "font-family: Arial";


### PR DESCRIPTION
`font-style: oblique 0` used to read as `oblique 0deg`, which every browser drops: the angle reader here was the one that takes a bare zero, and CSS Fonts 4 sec. 2.4 writes a plain `<angle>` where Transforms and Filter Effects write `<angle> | <zero>`.