### PR TITLE
font-face: refuse a CSS-wide keyword at a range endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -224,8 +224,9 @@ to lose a whole rule over one bad piece. Both are gone.
   `border-top-color: calc(2px - 3px)`, `border-image: none, none`,
   `font-language-override: "default"`, `grid-template-rows: -2px`,
   `grid-template: 10px`, `grid-area: calc(1/2/3/4/5)`,
-  `font-style: oblique 0`, `quotes:`, `border:` and a `@page size` given a
-  percentage. Ranges, units, sizing functions and the
+  `font-style: oblique 0`, an `@font-face` `font-weight` or `font-stretch`
+  range with a CSS-wide keyword for an endpoint, `quotes:`, `border:` and a
+  `@page size` given a percentage. Ranges, units, sizing functions and the
   closed `<color>` production are each checked, where the reader carried any
   dimension or any well-formed token run through, and a range now answers for
   the integer a math call rounds to rather than letting the call past, so a
@@ -233,7 +234,7 @@ to lose a whole rule over one bad piece. Both are gone.
   for a custom property. This release adds
   `Cascade.Properties.read_border_image_source`
   (#640, #982, #1000, #1001, #1002, #1003, #1004, #1005, #1006, #1007, #1009,
-  #1010, #1015, #1077, #1078, #1163, #1165)
+  #1010, #1015, #1077, #1078, #1163, #1165, #1166)
 - A `<custom-ident>` refuses the names CSS Values 4 sec. 4.2 reserves, in every
   ASCII case permutation, so `animation-name: default`, `counter-reset: DEFAULT`,
   `view-transition-name: default` and a `default` counter-style symbol are

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2352,6 +2352,18 @@ let read_descriptor_block normalize inner =
 let descriptor_is_auto value =
   String.equal (String.lowercase_ascii (String.trim value)) "auto"
 
+(* Sec. 4.6's "except that the CSS-wide keywords are omitted" answers for an
+   endpoint of the [{1,2}] range as much as for the whole value.
+   [refuse_css_wide_descriptor] cannot: it stands at the boundary, where a
+   [<family-name>] sequence reads a keyword as an ordinary ident, so it fires
+   only on one standing alone. *)
+let refuse_css_wide_endpoint c =
+  match Cursor.peek c with
+  | Some (Component.Preserved { kind = Token.Ident name; _ })
+    when Properties.is_css_wide_keyword name ->
+      Cursor.err_invalid c ("CSS-wide keyword in @font-face descriptor: " ^ name)
+  | Some _ | None -> ()
+
 let read_font_weight_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
@@ -2359,6 +2371,7 @@ let read_font_weight_descriptor r =
       else
         let c = Cursor.of_string value in
         let absolute () =
+          refuse_css_wide_endpoint c;
           match Properties.read_font_weight c with
           | Bolder | Lighter ->
               Cursor.err_invalid c
@@ -2408,11 +2421,15 @@ let read_font_stretch_descriptor r =
       if descriptor_is_auto value then Font_stretch_auto
       else
         let c = Cursor.of_string value in
-        let first = Properties.read_font_stretch c in
+        let endpoint () =
+          refuse_css_wide_endpoint c;
+          Properties.read_font_stretch c
+        in
+        let first = endpoint () in
         Cursor.ws c;
         if Cursor.is_done c then Font_stretch first
         else
-          let second = Properties.read_font_stretch c in
+          let second = endpoint () in
           Cursor.ws c;
           Cursor.expect_eof c;
           Font_stretch_range (first, second))

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -878,6 +878,29 @@ let spec_fontface_descriptors () =
   check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-weight: 400 \
      lighter; }";
+  (* Sec. 4.6 gives these descriptors the property's values "except that the
+     CSS-wide keywords are omitted", and an endpoint of the range is one of
+     those values, so a keyword is no more a value there than it is alone. The
+     one alone is already refused; a pair of them, or one beside a real
+     endpoint, was written back as a declaration Chrome 153 drops. *)
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
+     inherit inherit; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: 400 \
+     inherit; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
+     initial unset; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+     inherit inherit; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+     normal inherit; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+     inherit normal; }";
   (* sec. 4.2 and 4.3 make font-family and src required, so a CSS-wide keyword
      in either costs the whole rule the way any other missing one does. *)
   check_stylesheet ~expected:""


### PR DESCRIPTION
`@font-face { font-weight: 400 inherit }` and `font-stretch: inherit inherit` used to be written back, though every browser drops them. The boundary check refuses a CSS-wide keyword only when it stands alone, because a `<family-name>` sequence reads one as an ordinary ident; the two range descriptors now check each endpoint.