### PR TITLE
font-family: turn a descriptor generic away only where it heads a name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -249,7 +249,8 @@ to lose a whole rule over one bad piece. Both are gone.
   value there, not a list item, and CSS Values 4 sec. 2.2 takes each option of
   a `||` at most once. An unquoted `font-family` name refuses a generic keyword
   only where it heads the sequence, so `font-family: serif serif` is dropped
-  and `font-family: Cambria Math` reads (#1147)
+  and `font-family: Cambria Math` reads, at the `@font-face` and
+  `@font-palette-values` descriptors as at the property (#1147, #1167)
 - A `@keyframes` name is spelled the way its value requires, so
   `@keyframes "default"` keeps its quotes where it used to print as
   `@keyframes default`, which every browser drops, and `@keyframes "none"` is

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1692,7 +1692,21 @@ let rec read_font_family_name t : font_family =
         match Cursor.peek_ident t with
         | Some _ ->
             let word = Cursor.ident ~keep_case:true t in
-            if is_font_family_reserved_word word then
+            (* A generic family name is the alternative the grammar reads
+               instead of a name, so it is turned away where that alternative
+               starts, at the first word, and is an ordinary [<custom-ident>]
+               after it: [Cambria Math] and [Foo serif] are installed fonts,
+               [serif Foo] is not. A CSS-wide keyword or [default] is excluded
+               from [<custom-ident>] itself (CSS Values 4 sec. 4.2), so it is
+               turned away at every word. This is the rule
+               [read_unquoted_family_name] applies to the property, over the
+               same production. *)
+            let reserved =
+              match acc with
+              | [] -> is_font_family_reserved_word word
+              | _ :: _ -> is_font_family_css_wide word
+            in
+            if reserved then
               Cursor.err_invalid t
                 "reserved word in an unquoted font-family name";
             Cursor.ws t;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -906,6 +906,21 @@ let spec_fontface_descriptors () =
   check_stylesheet ~expected:""
     "@font-face { font-family: inherit; src: url(font.woff2); }";
   check_stylesheet ~expected:"" "@font-face { font-family: Brand; src: unset; }";
+  (* Sec. 2.1.1 turns a generic family name away where it could be read as the
+     keyword rather than as a name, which is where the name starts: [Foo serif]
+     and [Cambria Math] are installed fonts and [serif Foo] is not. The
+     [font-family] property reads them that way; the descriptor held every word
+     of the sequence to the whole exclusion list, so it dropped a real font
+     name. Chrome 153 reads the first two at both and drops the third at
+     both. *)
+  check_stylesheet
+    ~expected:"@font-face{font-family:\"Cambria Math\";src:url(font.woff2)}"
+    "@font-face { font-family: Cambria Math; src: url(font.woff2); }";
+  check_stylesheet
+    ~expected:"@font-face{font-family:\"Foo serif\";src:url(font.woff2)}"
+    "@font-face { font-family: Foo serif; src: url(font.woff2); }";
+  check_stylesheet ~expected:""
+    "@font-face { font-family: serif Foo; src: url(font.woff2); }";
   (* A family name that merely starts with one is a name, not a keyword: sec.
      2.1.1 asks only that a bare identifier not BE a CSS-wide keyword. *)
   check_stylesheet
@@ -1478,8 +1493,15 @@ let font_family_descriptor_grammar () =
     "@font-face { font-family: Brand, Other; src: url(brand.woff2) }";
   strict_reject "generic @font-face family"
     "@font-face { font-family: serif; src: url(serif.woff2) }";
-  strict_reject "generic word in an unquoted @font-face family"
+  (* Sec. 2.1.1 turns the identifier away where it could be read as the generic
+     keyword rather than as a name, which is where the name starts. After the
+     first word it is an ordinary <custom-ident>, so [Brand serif] is a name and
+     [serif Brand] is not; the font-family property already reads them that way
+     and Chrome 153 reads both descriptors that way. *)
+  strict_accept "generic word after the first in an unquoted @font-face family"
     "@font-face { font-family: Brand serif; src: url(brand.woff2) }";
+  strict_reject "generic word heading an unquoted @font-face family"
+    "@font-face { font-family: serif Brand; src: url(brand.woff2) }";
   strict_reject "CSS-wide @font-face family"
     "@font-face { font-family: inherit; src: url(brand.woff2) }";
   strict_reject "empty @font-palette-values font-family"
@@ -1488,8 +1510,10 @@ let font_family_descriptor_grammar () =
     "@font-palette-values --serif { font-family: serif }";
   strict_reject "generic in an @font-palette-values family list"
     "@font-palette-values --brand { font-family: Brand, serif }";
-  strict_reject "generic word in an unquoted palette family"
+  strict_accept "generic word after the first in an unquoted palette family"
     "@font-palette-values --brand { font-family: Brand serif }";
+  strict_reject "generic word heading an unquoted palette family"
+    "@font-palette-values --brand { font-family: serif Brand }";
   strict_reject "CSS-wide @font-palette-values family"
     "@font-palette-values --brand { font-family: inherit }"
 


### PR DESCRIPTION
`@font-face { font-family: Cambria Math }` used to be dropped, taking the whole rule with it, though the `font-family` property reads the same name. The descriptor reader held every word of the sequence to the exclusion list where CSS Fonts 4 sec. 2.1.1 turns a generic away only at the first word.