### PR TITLE
support: measure five @font-face productions the browser answers differently

### DIFF
--- a/lib/support.ml
+++ b/lib/support.ml
@@ -1137,6 +1137,84 @@ let measured =
          auto. Chrome accepts it from the SVG 1.1 grammar";
       measured = "Chrome 153";
     };
+    {
+      key = "css.at-rules.font-face.font-family.default";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Values 4 sec. 4.2 reserves default from <custom-ident> itself, so \
+         no word of a family sequence is one wherever it stands. Chrome reads \
+         default as a family word once another word stands beside it, at the \
+         descriptor as at the property";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.font-face.font-family.inherit";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Values 4 sec. 4.2 excludes the CSS-wide keywords from \
+         <custom-ident> itself, so no word of a family sequence is one \
+         wherever it stands. Chrome reads inherit as a family word once \
+         another word stands beside it, at the descriptor as at the property";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.font-face.font-weight.two_value_syntax";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Fonts 4 sec. 4.4 writes the descriptor auto | \
+         <font-weight-absolute>{1,2}, so a pair of endpoints is the range a \
+         variable font is asked for. Chrome takes only one value";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.font-face.font-stretch.two_value_syntax";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Fonts 4 sec. 4.5 writes the descriptor auto | \
+         <font-stretch-css3>{1,2}, so a pair of endpoints is the range a \
+         variable font is asked for. Chrome takes only one value";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.at-rules.font-face.font-variation-settings.string";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Fonts 4 sec. 6.6 writes each entry <opentype-tag> <number>, so a \
+         bare tag names an axis and sets it to nothing. Chrome takes the tag \
+         alone at the descriptor and gives it 1, where it refuses the same \
+         entry at the property";
+      measured = "Chrome 153";
+    };
   ]
 
 let measured_table =


### PR DESCRIPTION
The descriptor harness had no fact to read for any of these, so each stood as a failure rather than as a disagreement someone had looked at. With them `descriptor_set` reports 0 failures over 6271 values.