### PR TITLE
color-scheme: keep only at an end of the list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -224,9 +224,9 @@ to lose a whole rule over one bad piece. Both are gone.
   `border-top-color: calc(2px - 3px)`, `border-image: none, none`,
   `font-language-override: "default"`, `grid-template-rows: -2px`,
   `grid-template: 10px`, `grid-area: calc(1/2/3/4/5)`,
-  `font-style: oblique 0`, an `@font-face` `font-weight` or `font-stretch`
-  range with a CSS-wide keyword for an endpoint, `quotes:`, `border:` and a
-  `@page size` given a percentage. Ranges, units, sizing functions and the
+  `font-style: oblique 0`, `color-scheme: light only dark`, an `@font-face`
+  `font-weight` or `font-stretch` range with a CSS-wide keyword for an
+  endpoint, `quotes:`, `border:` and a `@page size` given a percentage. Ranges, units, sizing functions and the
   closed `<color>` production are each checked, where the reader carried any
   dimension or any well-formed token run through, and a range now answers for
   the integer a math call rounds to rather than letting the call past, so a
@@ -234,7 +234,7 @@ to lose a whole rule over one bad piece. Both are gone.
   for a custom property. This release adds
   `Cascade.Properties.read_border_image_source`
   (#640, #982, #1000, #1001, #1002, #1003, #1004, #1005, #1006, #1007, #1009,
-  #1010, #1015, #1077, #1078, #1163, #1165, #1166)
+  #1010, #1015, #1077, #1078, #1163, #1165, #1166, #1169)
 - A `<custom-ident>` refuses the names CSS Values 4 sec. 4.2 reserves, in every
   ASCII case permutation, so `animation-name: default`, `counter-reset: DEFAULT`,
   `view-transition-name: default` and a `default` counter-style symbol are

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -1230,6 +1230,17 @@ let color_scheme_of_idents t names : color_scheme =
           "color-scheme: [only] must be combined with a color scheme";
       if List.length (List.filter is_only keywords) > 1 then
         Cursor.err_invalid t "color-scheme: [only] cannot be repeated";
+      (* CSS Values 4 sec. 2.2 makes each operand of a [&&] a contiguous run, so
+         the keyword stands at one end of the whole value and never inside it:
+         [light only dark] splits the list into two rather than naming one. *)
+      let interior =
+        match keywords with
+        | [] -> []
+        | _ :: rest -> (
+            match List.rev rest with [] -> [] | _ :: mid -> List.rev mid)
+      in
+      if List.exists is_only interior then
+        Cursor.err_invalid t "color-scheme: [only] cannot stand inside the list";
       Custom names
 
 (* Every ident of the grammar above that is not the [<custom-ident>]: sec. 2.2

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -5557,6 +5557,14 @@ let spec_remaining_prop_vectors () =
       "color-scheme: only only";
       "color-scheme: only light only";
       "color-scheme: only dark only";
+      (* CSS Values 4 sec. 2.2 makes each operand of a [&&] a contiguous run, so
+         sec. 2.2's [[light | dark | <custom-ident>]+ && only?] puts [only] at
+         one end of the list and never inside it. Chrome 153 drops each of these
+         and reads [light dark only] and [only light dark]. *)
+      "color-scheme: light only light";
+      "color-scheme: dark only dark";
+      "color-scheme: both only both";
+      "color-scheme: light only dark";
       (* CSS Color Adjust 1 sec. 2.2 spells the list item [light | dark |
          <custom-ident>], and CSS Values 4 sec. 4.2 keeps [default] out of every
          one of those in all ASCII case permutations. *)


### PR DESCRIPTION
`color-scheme: light only light` and `light only dark` used to read, though every browser drops them: `only` was counted but never placed, where CSS Values 4 sec. 2.2 makes each operand of a `&&` a contiguous run.