### PR TITLE
support: measure the outline shorthand's auto colour

### DIFF
--- a/lib/support.ml
+++ b/lib/support.ml
@@ -967,6 +967,23 @@ let measured =
       measured = "Chrome 153";
     };
     {
+      key = "css.properties.outline.auto";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "The colour slot of the shorthand is the sec. 3.4 <'outline-color'> \
+         above, so outline: solid auto fills style and colour and CSS Values 4 \
+         sec. 2.2 takes each option of the || once. Chrome reads auto only as \
+         the style, so a second style keyword beside it leaves the value with \
+         two, and it drops the declaration";
+      measured = "Chrome 153";
+    };
+    {
       key = "css.properties.user-select.contain";
       support =
         {


### PR DESCRIPTION
`outline: solid auto` stood as an accept-set failure with no fact behind it, though the `css.properties.outline-color.auto` entry beside it already records the same gap: Chrome reads `auto` only as the style. With this, `accept_set` reports no accepts-invalid.