### PR TITLE
place-items: read the slot after stretch as a justify value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -247,10 +247,12 @@ to lose a whole rule over one bad piece. Both are gone.
   were dropped, while `text-shadow: none, none`, `box-shadow: none, none` and
   `list-style: none none none` are dropped with a warning: `none` is a whole
   value there, not a list item, and CSS Values 4 sec. 2.2 takes each option of
-  a `||` at most once. An unquoted `font-family` name refuses a generic keyword
+  a `||` at most once, while `place-items: stretch center` reads: `stretch` is
+  a value of both halves of that shorthand, so the slot after it is an ordinary
+  `justify-items` value. An unquoted `font-family` name refuses a generic keyword
   only where it heads the sequence, so `font-family: serif serif` is dropped
   and `font-family: Cambria Math` reads, at the `@font-face` and
-  `@font-palette-values` descriptors as at the property (#1147, #1167)
+  `@font-palette-values` descriptors as at the property (#1147, #1167, #1171)
 - A `@keyframes` name is spelled the way its value requires, so
   `@keyframes "default"` keeps its quotes where it used to print as
   `@keyframes default`, which every browser drops, and `@keyframes "none"` is

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -585,14 +585,17 @@ let read_place_items_safe t =
   | "center" -> Center_safe
   | kw -> Cursor.err_invalid t ("place-items safe " ^ kw)
 
-let read_place_items_stretch t =
+(* css-align-3 (ED) sec. 5.2 spells [place-items] as [<'align-items'>
+   <'justify-items'>?], and [stretch] is one value of each, so the slot after it
+   is an ordinary justify-items value rather than a repeat of the keyword.
+   [Stretch_stretch] keeps the pair the printer folds back to one word. *)
+let read_place_items_stretch t : place_items =
   Cursor.expect_string "stretch" t;
   Cursor.ws t;
-  if
-    Cursor.option (fun t -> Cursor.expect_string "stretch" t) t
-    |> Option.is_some
-  then Stretch_stretch
-  else Stretch
+  match Cursor.option read_justify_items t with
+  | None -> Stretch
+  | Some (Stretch : justify_items) -> Stretch_stretch
+  | Some justify -> Align_justify (Stretch, justify)
 
 let place_items_align : place_items -> align_items option = function
   | Normal -> Some (Normal : align_items)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4561,7 +4561,16 @@ let test_place_items () =
   (* The && is order-free, but the modifier is only read before the keyword. *)
   neg_cursor ~allow_partial:true read_place_items "baseline first";
   neg_cursor ~allow_partial:true read_place_items "baseline last";
-  neg_cursor read_place_items "invalid-place"
+  neg_cursor read_place_items "invalid-place";
+  (* sec. 5.2 spells the shorthand [<'align-items'> <'justify-items'>?], and
+     [stretch] is one value of each, so the slot after it is an ordinary
+     justify-items value rather than a repeat of the keyword. Chrome 153 reads
+     each of these and computes align-items: stretch beside the second half. *)
+  check_place_items "stretch center";
+  check_place_items "stretch normal";
+  check_place_items "stretch safe center";
+  check_place_items ~expected:"stretch" "stretch stretch";
+  check_place_items "center stretch"
 
 let test_box_decoration_break () =
   check_box_decoration_break "clone";


### PR DESCRIPTION
`place-items: stretch center` and `stretch normal` used to be dropped: the `stretch` branch took a second `stretch` and nothing else, where css-align-3 sec. 5.2 makes the slot after it an ordinary `justify-items` value.