### PR TITLE
support: measure the trailing bare auto at contain-intrinsic-size

### DIFF
--- a/lib/support.ml
+++ b/lib/support.ml
@@ -727,6 +727,21 @@ let measured =
       measured = "Chrome 153";
     };
     {
+      key = "css.properties.contain-intrinsic-size.none_auto";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "The same sec. 5.2 grammar puts auto before the none or length of its \
+         own slot and never after one, so none auto is a slot and a keyword \
+         with no slot to open. Chrome takes the trailing bare auto here too";
+      measured = "Chrome 153";
+    };
+    {
       key = "css.properties.break-before.all";
       support =
         {


### PR DESCRIPTION
The `auto_none_auto` entry beside this one already records that Chrome takes a trailing bare `auto` where CSS Sizing 4 sec. 5.2 opens no slot for it; it was keyed to that spelling alone, so `none auto` stood as an accept-set failure.