### PR TITLE
mask: read one image per layer of the shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -243,8 +243,8 @@ to lose a whole rule over one bad piece. Both are gone.
   own exclusion list, five of which had forgotten `default`; they now share
   `Cascade.Cursor.custom_ident` (#1143)
 - A value list carries the number of items its grammar grants, so
-  `mask: none, none` and `transition-behavior: normal, normal` read where they
-  were dropped, while `text-shadow: none, none`, `box-shadow: none, none` and
+  `mask: none, none`, `mask: none, 50%` and
+  `transition-behavior: normal, normal` read where they were dropped, while `text-shadow: none, none`, `box-shadow: none, none` and
   `list-style: none none none` are dropped with a warning: `none` is a whole
   value there, not a list item, and CSS Values 4 sec. 2.2 takes each option of
   a `||` at most once, while `place-items: stretch center` reads: `stretch` is
@@ -252,7 +252,8 @@ to lose a whole rule over one bad piece. Both are gone.
   `justify-items` value. An unquoted `font-family` name refuses a generic keyword
   only where it heads the sequence, so `font-family: serif serif` is dropped
   and `font-family: Cambria Math` reads, at the `@font-face` and
-  `@font-palette-values` descriptors as at the property (#1147, #1167, #1171)
+  `@font-palette-values` descriptors as at the property
+  (#1147, #1167, #1171, #1173)
 - A `@keyframes` name is spelled the way its value requires, so
   `@keyframes "default"` keeps its quotes where it used to print as
   `@keyframes default`, which every browser drops, and `@keyframes "none"` is

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -766,7 +766,11 @@ module Mask_shorthand = struct
     }
 
   let read_image_item t =
-    let image = read_background_image t in
+    (* A single image per layer: commas in the [mask] shorthand separate layers,
+       not images (that comma-list is the [mask-image] longhand), so reading the
+       longhand here eats the comma and then fails on a layer that does not open
+       with an image of its own. *)
+    let image = read_bg_image t in
     fun (mask : mask_layer) ->
       if mask.image = None then { mask with image = Some image } else mask
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5228,6 +5228,18 @@ let spec_generated_position_interaction_edges () =
   check_margin_trim_edge "block-end";
   check_mask "url(mask.png)";
   check_mask_layer "url(mask.png)";
+  (* CSS Masking 1 sec. 8.7 spells [mask] as [<mask-layer>#], so a comma in the
+     shorthand separates layers and the image slot of a layer holds one image:
+     the comma list belongs to the [mask-image] longhand. A layer after one that
+     opened with an image is an ordinary layer, so it need not open with one.
+     Chrome 153 reads each of these and gives the second layer the initial
+     image. *)
+  check_mask "none,50%";
+  check_mask "url(a.png),50%";
+  check_mask "url(a.png),50%,url(b.png)";
+  check_mask "none,alpha";
+  check_mask "50%,none";
+  check_mask "none,url(b.png)";
   check_nav "#next current";
   check_nav_scope "root";
   check_object_view_box "inset(10px 20px)";


### PR DESCRIPTION
`mask: none, 50%` and `mask: url(a.png), 50%` used to be dropped: the layer reader read the `mask-image` longhand, whose comma list is the layer separator here, so it ate the comma and then failed on a layer that did not open with an image of its own. `background`'s own layer reader already takes a single image.