### PR TITLE
line-height: read a comparison at its length half

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,10 +49,13 @@ entry points both moved.
   `font-size-adjust`, `baseline-shift`, `columns`, `font-stretch` and
   `interest-delay`, and the `@font-face` descriptors `ascent-override`,
   `descent-override`, `line-gap-override` and `size-adjust`, which hold the
-  percentage the call resolves to. `Cascade.Properties.font_weight`,
+  percentage the call resolves to. `line-height: min(120%, 1px)` reads too: a
+  comparison there answers a `<length-percentage>` that resolves only at
+  used-value time, so `Cascade.Properties.line_height` gains `Min`, `Max` and
+  `Clamp` beside `Calc`. `Cascade.Properties.font_weight`,
   `webkit_line_clamp`, `zoom`, `border_image_slice_item` and
   `shape_image_threshold` gain `Calc`, and `grid_line` gains `Calc_name`
-  (#1072, #1086, #1124, #1125, #1126, #1145, #1148, #1161, #1164)
+  (#1072, #1086, #1124, #1125, #1126, #1145, #1148, #1161, #1164, #1174)
 - A math function takes only the operands CSS Values 4 sec. 10.8 grants, so
   `width: calc(inherit)`, `height: calc(auto)`, `border-width: calc(medium)`,
   `width: calc(fit-content(20rem))` and `width: min(unset, 1px)` are dropped

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4695,6 +4695,13 @@ type line_height = Properties.line_height =
   | Unset
   | Revert
   | Revert_layer
+  | Min of line_height list
+  | Max of line_height list
+  | Clamp of line_height * line_height * line_height
+      (** CSS Values 4 sec. 10.2 comparison functions over the
+          [<length-percentage>] half of the grammar. A length beside a
+          percentage resolves only at used-value time, so the call stands here
+          rather than folding to one of its arguments. *)
   | Calc of line_height calc
   | Var of line_height var
 

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1393,6 +1393,12 @@ let rec pp_line_height : line_height Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_line_height ctx v
+  | Min args -> Pp.call "min" (Pp.list ~sep:Pp.comma pp_line_height) ctx args
+  | Max args -> Pp.call "max" (Pp.list ~sep:Pp.comma pp_line_height) ctx args
+  | Clamp (low, value, high) ->
+      Pp.call "clamp"
+        (Pp.list ~sep:Pp.comma pp_line_height)
+        ctx [ low; value; high ]
   | Calc c ->
       pp_calc
         ~unwrap_num:(match c with Num f -> f >= 0. | _ -> true)
@@ -1519,6 +1525,61 @@ let read_bare_math read t : line_height =
   | Calc (Num n) when n >= 0. -> Num n
   | value -> value
 
+(* CSS Values 4 sec. 10.2 gives min(), max() and clamp() their arguments' own
+   type, so they read at either half of sec. 5.1's [<number> |
+   <length-percentage>]. Over numbers the calc path folds the call to the
+   coefficient it answers; over a length there is no coefficient to fold to,
+   since a percentage resolves only at used-value time, so the call stands the
+   way it does at a [<length>] slot.
+
+   Sec. 10.2 also requires the arguments to have a consistent type. The number
+   path answers for a comparison of numbers, so an argument here carries a unit
+   and a bare number beside one is a mix of the two types. *)
+let read_line_height_comparison_arg t : line_height =
+  match read_line_height_length ~allow_negative:true t with
+  | Num _ | Number { unit = Option.None; _ } ->
+      Cursor.err_expected t "length or percentage"
+  | value -> value
+
+let read_line_height_list_call name mk t : line_height =
+  Cursor.call name t (fun inner ->
+      let args =
+        Cursor.list ~sep:Cursor.comma ~at_least:1
+          read_line_height_comparison_arg inner
+      in
+      Cursor.ws inner;
+      Cursor.expect_eof inner;
+      mk args)
+
+let read_line_height_clamp t : line_height =
+  Cursor.call "clamp" t (fun inner ->
+      let low = read_line_height_comparison_arg inner in
+      Cursor.ws inner;
+      Cursor.comma inner;
+      let value = read_line_height_comparison_arg inner in
+      Cursor.ws inner;
+      Cursor.comma inner;
+      let high = read_line_height_comparison_arg inner in
+      Cursor.ws inner;
+      Cursor.expect_eof inner;
+      (Clamp (low, value, high) : line_height))
+
+(* The number path first, so a comparison whose arguments are all numbers keeps
+   folding to the coefficient it always did. *)
+let line_height_math_calls number =
+  ( "min",
+    fun t ->
+      Cursor.one_of
+        [ number; read_line_height_list_call "min" (fun a -> Min a) ]
+        t )
+  :: ( "max",
+       fun t ->
+         Cursor.one_of
+           [ number; read_line_height_list_call "max" (fun a -> Max a) ]
+           t )
+  :: ("clamp", fun t -> Cursor.one_of [ number; read_line_height_clamp ] t)
+  :: Values.math_function_calls_beside_comparisons number
+
 let rec read_line_height_in_math t : line_height =
   let read_var t : line_height = Var (read_var read_line_height_in_math t) in
   let read_calc t : line_height =
@@ -1529,7 +1590,7 @@ let rec read_line_height_in_math t : line_height =
   Cursor.enum_or_calls "line-height" []
     ~calls:
       (("var", read_var) :: ("calc", read_calc)
-      :: Values.math_function_calls (read_bare_math read_calc))
+      :: line_height_math_calls (read_bare_math read_calc))
     ~default:(read_line_height_length ~allow_negative:true)
     t
 
@@ -1551,7 +1612,7 @@ let rec read_line_height t : line_height =
     ]
     ~calls:
       (("var", read_var) :: ("calc", read_calc)
-      :: Values.math_function_calls (read_bare_math read_calc))
+      :: line_height_math_calls (read_bare_math read_calc))
     ~default:read_line_height_length t
 
 let rec read_font_palette (t : Cursor.t) : font_palette =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -47,6 +47,14 @@ type line_height =
   | Unset
   | Revert
   | Revert_layer
+  (* CSS Values 4 sec. 10.2 comparison functions over the [<length-percentage>]
+     half of the grammar. A comparison answers with one of its arguments, and a
+     length beside a percentage resolves only at used-value time, so the call
+     stands here rather than folding; the arguments reuse [line_height], which
+     already carries [Pct], the way [length] carries its own. *)
+  | Min of line_height list
+  | Max of line_height list
+  | Clamp of line_height * line_height * line_height
   | Calc of line_height calc
   | Var of line_height var
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5982,15 +5982,18 @@ let read_percentage_clamp t =
       Cursor.expect_eof inner;
       Float.max low (Float.min value high))
 
+let math_function_calls_beside_comparisons read =
+  List.map
+    (fun n -> (n, read))
+    (computed_typed_math_function_names @ number_math_function_names)
+
 let percentage_math_function_calls ~pct read =
   ("min", fun t -> pct t (read_percentage_list_call "min" Float.min infinity t))
   :: ( "max",
        fun t -> pct t (read_percentage_list_call "max" Float.max neg_infinity t)
      )
   :: ("clamp", fun t -> pct t (read_percentage_clamp t))
-  :: List.map
-       (fun n -> (n, read))
-       (computed_typed_math_function_names @ number_math_function_names)
+  :: math_function_calls_beside_comparisons read
 
 (* Sec. 10.1 puts a math function wherever the [<percentage>] stands and makes
    [calc()] one of them rather than the gate to the rest, so both spellings

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -708,6 +708,14 @@ val typed_math_function_calls :
     functions that answer the type of their arguments, for a slot that takes a
     [<length>] or another dimension rather than a [<number>]. *)
 
+val math_function_calls_beside_comparisons :
+  (Cursor.t -> 'a) -> (string * (Cursor.t -> 'a)) list
+(** [math_function_calls_beside_comparisons read] is {!math_function_calls}
+    without [min()], [max()] and [clamp()], for a slot reading those three
+    itself. CSS Values 4 sec. 10.2 answers a comparison with one of its
+    arguments, so a slot whose leaf can hold that argument reads it at its own
+    type where the shared path would fold it to a coefficient. *)
+
 val percentage_math_function_calls :
   pct:(Cursor.t -> float -> 'a) ->
   (Cursor.t -> 'a) ->

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1673,6 +1673,17 @@ let test_line_height () =
      does. *)
   check_line_height "2ch";
   check_line_height "3cqw";
+  (* CSS Values 4 sec. 10.2 gives a comparison its arguments' own type, so it
+     reads at either half of sec. 5.1's [<number> | <length-percentage>]. A
+     comparison over numbers folds to the coefficient it answers, one over a
+     length and a percentage resolves at used-value time and keeps its call, the
+     way it does at [width]. Chrome 153 reads every row. *)
+  check_line_height ~expected:"min(120%,1px)" "min(120%, 1px)";
+  check_line_height ~expected:"clamp(0px,120%,100px)" "clamp(0px, 120%, 100px)";
+  check_line_height ~expected:"clamp(1px,2em,3%)" "clamp(1px, 2em, 3%)";
+  check_line_height ~expected:"max(1px,2px)" "max(1px, 2px)";
+  decl_optimizes ~prop:"line-height" ~into:"1" "min(1, 2)";
+  neg_cursor read_line_height "min(1px, 2)";
   neg_cursor read_line_height "0s";
   neg_cursor read_line_height "45deg";
   neg_cursor read_line_height "10zz";


### PR DESCRIPTION
`line-height: min(120%, 1px)` and its clamp forms used to be dropped: `min()`, `max()` and `clamp()` read their arguments as bare numbers, so the property took none of them over a length while `abs()` and `round()` already read. A length beside a percentage resolves only at used-value time, so the call stands in the value and `line_height` gains `Min`, `Max` and `Clamp`. With this, `accept_set` reports no rejects-valid and no accepts-invalid.