### PR TITLE
border-width: print a comparison operand as it was written

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -373,6 +373,10 @@ to lose a whole rule over one bad piece. Both are gone.
   An escaped name reads as the name it spells: `@supports (--x\3b y: red)` is
   read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer `b`
   of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141, #1162)
+- A comparison function's operand is printed as it was written, so
+  `border-width: min(var(--x), 1px)` no longer collects a `calc()` around the
+  reference and `min(calc(var(--x) + 1px), 2px)` no longer collects a second
+  one. CSS Values 4 sec. 10.1 makes a lone `var()` a whole `<calc-sum>` (#1175)
 - Cascade reads back everything it writes. Minified `@scope to (...)`, `rotate`
   with a negative axis, a relative colour's channels, a `-webkit-gradient`
   `color-stop()` and `center` point, `text-decoration: none solid`,

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -879,7 +879,15 @@ let rec pp_border_width : border_width Pp.t =
 and pp_border_width_calc_contents ctx calc =
   match length_of_border_width_calc calc with
   | Some lc -> pp_length_calc_contents ctx lc
-  | None -> pp_calc pp_border_width ctx calc
+  | None -> (
+      (* Sec. 10.2 spells the operand slot [<calc-sum>], and sec. 10.1 makes a
+         lone [var()] one, so the reference stands as authored; an operand that
+         already carries its own [calc()] keeps that one rather than collecting
+         a second. *)
+      match calc with
+      | Var v -> pp_var pp_border_width ctx v
+      | Nested inner -> pp_calc pp_border_width ctx inner
+      | calc -> pp_calc pp_border_width ctx calc)
 
 and pp_border_width_minmax name ctx args =
   Pp.call name (Pp.list ~sep:Pp.comma pp_border_width_calc_contents) ctx args

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2092,6 +2092,13 @@ let test_border_width () =
   check_border_width "min(3dvh,4px)";
   check_border_width "max(3dvh,4px)";
   check_border_width "clamp(1dvh,3dvh,4px)";
+  (* Sec. 10.2 spells a comparison's argument [<calc-sum>], and sec. 10.1 makes
+     a lone [var()] one, so the operand needs no [calc()] around it: the value
+     is printed back as it was written, which is what [width] over the same
+     production already does. *)
+  check_border_width "min(var(--x),1px)";
+  check_border_width "max(var(--x),1px)";
+  check_border_width "clamp(var(--x),2px,3px)";
   (* One unit does compare with itself, and a container-query length grows with
      its multiplier, so the smaller multiple is the minimum. The fold is a
      node-changing rewrite (two different ASTs would otherwise print the same


### PR DESCRIPTION
`border-width: min(var(--x), 1px)` printed `min(calc(var(--x)), 1px)`, and an operand that already spelled its own `calc()` collected a second. CSS Values 4 sec. 10.1 makes a lone `var()` a whole `<calc-sum>`, which is what the operand slot asks for; `width` over the same production already printed it back as authored.