### PR TITLE
background-position: read a layer list at the axis longhands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -250,13 +250,15 @@ to lose a whole rule over one bad piece. Both are gone.
   `transition-behavior: normal, normal` read where they were dropped, while `text-shadow: none, none`, `box-shadow: none, none` and
   `list-style: none none none` are dropped with a warning: `none` is a whole
   value there, not a list item, and CSS Values 4 sec. 2.2 takes each option of
-  a `||` at most once, while `place-items: stretch center` reads: `stretch` is
+  a `||` at most once, while `background-position-x: center, 10px` reads, one
+  position per background layer as the pair has, and `place-items: stretch
+  center` reads: `stretch` is
   a value of both halves of that shorthand, so the slot after it is an ordinary
   `justify-items` value. An unquoted `font-family` name refuses a generic keyword
   only where it heads the sequence, so `font-family: serif serif` is dropped
   and `font-family: Cambria Math` reads, at the `@font-face` and
   `@font-palette-values` descriptors as at the property
-  (#1147, #1167, #1171, #1173)
+  (#1147, #1167, #1171, #1173, #1176)
 - A `@keyframes` name is spelled the way its value requires, so
   `@keyframes "default"` keeps its quotes where it used to print as
   `@keyframes default`, which every browser drops, and `@keyframes "none"` is

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5931,6 +5931,9 @@ type background_position_axis = Properties.background_position_axis =
   | Edge of position_axis_edge
   | Offset of length_percentage
   | Edge_offset of position_axis_edge * length_percentage
+  | Layers of background_position_axis list
+      (** CSS Backgrounds 4 sec. 3.6 spells the axis longhand with the same [#]
+          the pair carries, so it names one position per background layer. *)
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1108,6 +1108,8 @@ let rec pp_background_position_axis : background_position_axis Pp.t =
       pp_position_axis_edge ctx e;
       Pp.space ctx ();
       pp_length_percentage ctx lp
+  | Layers positions ->
+      Pp.list ~sep:Pp.comma pp_background_position_axis ctx positions
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -1921,7 +1923,7 @@ let read_background_box_list t : background_box =
    [left 10px] and [10px] name the same position and the shorter wins. The zero
    percentage of the start edge is what [left] / [top] names, and the hundred
    percent is [right] / [bottom]. *)
-let normalize_background_position_axis :
+let rec normalize_background_position_axis :
     background_position_axis -> background_position_axis =
  fun value ->
   let lp = Values.normalize_length_percentage in
@@ -1933,6 +1935,12 @@ let normalize_background_position_axis :
   | Offset o -> preserve_if_equal value (Offset (lp o))
   | Edge_offset (e, o) when start_edge e -> Offset (lp o)
   | Edge_offset (e, o) -> preserve_if_equal value (Edge_offset (e, lp o))
+  (* Each layer holds a position of its own, so the fold reaches every one of
+     them: a list left alone is a second node printing what the folded one
+     prints. *)
+  | Layers positions ->
+      preserve_if_equal value
+        (Layers (List.map normalize_background_position_axis positions))
   | other -> other
 
 let read_background_position t : background_position =
@@ -1984,13 +1992,24 @@ let read_background_position_axis ~label ~start_edge ~end_edge =
   in
   read
 
+(* Sec. 3.6 spells the longhand with the same [#] the pair carries, so a comma
+   separates one layer's position from the next. One position is the bare
+   constructor: a lone [Layers [p]] would be a second node printing the same
+   text. A CSS-wide keyword is the whole value, which the reader below answers
+   before this sees a comma. *)
+let read_background_position_axis_list ~label ~start_edge ~end_edge t =
+  let read t = read_background_position_axis ~label ~start_edge ~end_edge t in
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 read t with
+  | [ position ] -> position
+  | positions -> (Layers positions : background_position_axis)
+
 let read_background_position_x t =
-  read_background_position_axis ~label:"background-position-x" ~start_edge:Left
-    ~end_edge:Right t
+  read_background_position_axis_list ~label:"background-position-x"
+    ~start_edge:Left ~end_edge:Right t
 
 let read_background_position_y t =
-  read_background_position_axis ~label:"background-position-y" ~start_edge:Top
-    ~end_edge:Bottom t
+  read_background_position_axis_list ~label:"background-position-y"
+    ~start_edge:Top ~end_edge:Bottom t
 
 module Background_shorthand = struct
   let read_image_item t =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2770,6 +2770,11 @@ type background_position_axis =
   | Edge of position_axis_edge
   | Offset of length_percentage
   | Edge_offset of position_axis_edge * length_percentage
+  | Layers of background_position_axis list
+      (** CSS Backgrounds 4 sec. 3.6 spells the axis longhand with the same [#]
+          the pair carries, so it names one position per background layer. A
+          single position is the bare constructor, the way [mask] holds one
+          layer beside its list. *)
   | Inherit
   | Initial
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -761,11 +761,15 @@ let vars_of_position_value (value : Properties.position_value) : any_var list =
       vars_of_length_percentage lp1 @ vars_of_length_percentage lp2
   | _ -> []
 
-let vars_of_background_position_axis
+let rec vars_of_background_position_axis
     (value : Properties.background_position_axis) : any_var list =
   match value with
   | Var v -> [ V v ]
   | Offset lp | Edge_offset (_, lp) -> vars_of_length_percentage lp
+  (* A layer of the list holds a position of its own, so a reference inside one
+     is a reference the caller has to see. *)
+  | Layers positions ->
+      List.concat_map vars_of_background_position_axis positions
   | _ -> []
 
 let rec vars_of_gradient_direction (value : Properties.gradient_direction) :

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -502,6 +502,16 @@ let special_cases () =
     "background-position: 30% 50%, 70% 50%;";
   check_declaration ~expected:"background-position:var(--x) 20%"
     "background-position: var(--x) 20%;";
+  (* CSS Backgrounds 4 sec. 3.6 spells each axis longhand with the same [#] the
+     pair carries, so it names one position per layer too. Chrome 153 reads each
+     of these and gives them back comma-separated. *)
+  check_declaration ~expected:"background-position-x:center,10px"
+    "background-position-x: center, 10px;";
+  check_declaration ~expected:"background-position-y:center,10px"
+    "background-position-y: center, 10px;";
+  check_declaration
+    ~expected:"background-position-x:left 10px,right 20px,center"
+    "background-position-x: left 10px, right 20px, center;";
   (* CSS Values 4 (ED) sec. 8.3 spells one alternative of <position> as "[ left
      | center | right | <length-percentage> ] [ top | center | bottom |
      <length-percentage> ]", so an offset in the first slot pairs with an edge


### PR DESCRIPTION
`background-position-x: center, 10px` and its `-y` twin used to be dropped, though `background-position` reads the same comma list: CSS Backgrounds 4 sec. 3.6 spells each longhand with the same `#`, one position per background layer. `Cascade.Properties.background_position_axis` gains `Layers`.