### PR TITLE
image: read a gradient interpolation over every colour space

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -375,6 +375,12 @@ to lose a whole rule over one bad piece. Both are gone.
   An escaped name reads as the name it spells: `@supports (--x\3b y: red)` is
   read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer `b`
   of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141, #1162)
+- A gradient's `<color-interpolation-method>` takes the fifteen colour spaces
+  `color-mix()` takes, so `linear-gradient(in srgb-linear, red, blue)` and
+  `in hwb longer hue` read where they were dropped, and a hue method after a
+  rectangular space is refused. `Cascade.Properties.color_interpolation`
+  carries the space: its six `In_*` constructors are now one `In` of a
+  `color_space` and an optional hue method (#1177)
 - A comparison function's operand is printed as it was written, so
   `border-width: min(var(--x), 1px)` no longer collects a `calc()` around the
   reference and `min(calc(var(--x) + 1px), 2px)` no longer collects a second

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3002,14 +3002,13 @@ type hue_interpolation_method = Properties.hue_interpolation_method =
   | Increasing
   | Decreasing
 
-(** Color interpolation for gradients *)
+(** Colour interpolation for gradients. CSS Color 5 sec. 9 spells one
+    [<color-interpolation-method>] wherever one appears, over the same fifteen
+    spaces [color-mix()] takes, so the space is carried rather than named in a
+    constructor of its own. Sec. 9.1 puts the [<hue-interpolation-method>] after
+    a polar space only. *)
 type color_interpolation = Properties.color_interpolation =
-  | In_oklab
-  | In_oklch of hue_interpolation_method option
-  | In_srgb
-  | In_hsl of hue_interpolation_method option
-  | In_lab
-  | In_lch of hue_interpolation_method option
+  | In of color_space * hue_interpolation_method option
   | Var of color_interpolation var
 
 (** Gradient direction values *)

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -21,24 +21,17 @@ let pp_hue_interpolation_method ctx = function
   | Increasing -> Pp.string ctx "increasing hue"
   | Decreasing -> Pp.string ctx "decreasing hue"
 
-let pp_polar_with_hue ctx space (hue : hue_interpolation_method option) =
-  Pp.string ctx "in ";
-  Pp.string ctx space;
-  match hue with
-  | None -> ()
-  | Some hue ->
-      Pp.space ctx ();
-      pp_hue_interpolation_method ctx hue
-
 let rec pp_color_interpolation : color_interpolation Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_color_interpolation ctx v
-  | In_oklab -> Pp.string ctx "in oklab"
-  | In_oklch hue -> pp_polar_with_hue ctx "oklch" hue
-  | In_srgb -> Pp.string ctx "in srgb"
-  | In_hsl hue -> pp_polar_with_hue ctx "hsl" hue
-  | In_lab -> Pp.string ctx "in lab"
-  | In_lch hue -> pp_polar_with_hue ctx "lch" hue
+  | In (space, hue) -> (
+      Pp.string ctx "in ";
+      Values.pp_color_space ctx space;
+      match hue with
+      | None -> ()
+      | Some hue ->
+          Pp.space ctx ();
+          pp_hue_interpolation_method ctx hue)
 
 (* CSS Color 5 section 9.1: after a polar color space (lch / oklch / hsl / hwb),
    the [<color-interpolation-method>] may carry a trailing
@@ -73,19 +66,22 @@ let read_color_interpolation (t : Cursor.t) : color_interpolation =
       (* At the component-value level, [in oklab] lexes as two separate idents;
          [inoklab] lexes as a single ident and would fail [expect_string "in"]
          above, so no extra whitespace check is needed here. *)
-      let space = String.lowercase_ascii_preserve (Cursor.ident t) in
-      let hue () =
-        Cursor.ws t;
-        read_hue_interpolation_method t
+      (* Sec. 9 gives the method the same spaces [color-mix()] takes, so it
+         reads through the one reader that answers for all fifteen. Sec. 9.1
+         puts a [<hue-interpolation-method>] after a polar space only, so a
+         rectangular one never looks for it and a hue written after it is left
+         unread, which the caller reports. *)
+      let space = Values.read_color_space t in
+      let hue =
+        match space with
+        | Hsl | Hwb | Lch | Oklch ->
+            Cursor.ws t;
+            read_hue_interpolation_method t
+        | Srgb | Srgb_linear | Display_p3 | A98_rgb | Prophoto_rgb | Rec2020
+        | Lab | Oklab | Xyz | Xyz_d50 | Xyz_d65 ->
+            None
       in
-      match space with
-      | "oklab" -> In_oklab
-      | "oklch" -> In_oklch (hue ())
-      | "srgb" -> In_srgb
-      | "hsl" -> In_hsl (hue ())
-      | "lab" -> In_lab
-      | "lch" -> In_lch (hue ())
-      | _ -> Cursor.err_invalid t "color-interpolation")
+      In (space, hue))
 
 let rec pp_gradient_direction : gradient_direction Pp.t =
  fun ctx -> function

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2691,13 +2691,13 @@ type background_size =
     polar color space (lch / oklch / hsl / hwb). *)
 type hue_interpolation_method = Shorter | Longer | Increasing | Decreasing
 
+(** CSS Color 5 sec. 9 spells one [<color-interpolation-method>] wherever one
+    appears, over the same fifteen spaces [color-mix()] takes, so the space is
+    carried rather than named in a constructor of its own. Sec. 9.1 puts the
+    [<hue-interpolation-method>] after a polar space only, which is why the
+    reader answers [None] for every other space. *)
 type color_interpolation =
-  | In_oklab
-  | In_oklch of hue_interpolation_method option
-  | In_srgb
-  | In_hsl of hue_interpolation_method option
-  | In_lab
-  | In_lch of hue_interpolation_method option
+  | In of color_space * hue_interpolation_method option
   | Var of color_interpolation var
 
 type gradient_direction =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3019,6 +3019,28 @@ let test_color_interpolation () =
   check_color_interpolation "in hsl";
   check_color_interpolation "in lab";
   check_color_interpolation "in lch";
+  (* CSS Color 5 sec. 9.1 writes the method [in [ <rectangular-color-space> |
+     <polar-color-space> <hue-interpolation-method>? ]], and sec. 9 gives the
+     same fifteen spaces [color-mix()] takes. Chrome 153 reads each of these,
+     serialising [xyz] as [xyz-d65], and drops a hue method after a rectangular
+     space. *)
+  check_color_interpolation "in srgb-linear";
+  check_color_interpolation "in display-p3";
+  check_color_interpolation "in a98-rgb";
+  check_color_interpolation "in prophoto-rgb";
+  check_color_interpolation "in rec2020";
+  check_color_interpolation "in xyz-d50";
+  (* CSS Color 4 sec. 10.2 makes [xyz] and [xyz-d65] two names for one space, so
+     the shorter one is the spelling of both. *)
+  check_color_interpolation ~expected:"in xyz" "in xyz-d65";
+  check_color_interpolation "in xyz";
+  check_color_interpolation "in hwb";
+  check_color_interpolation "in hwb longer hue";
+  check_color_interpolation "in oklch increasing hue";
+  (* A rectangular space never looks for the hue method, so the two words are
+     left standing and the declaration around them is dropped. *)
+  neg_cursor ~allow_partial:true read_color_interpolation "in srgb shorter hue";
+  neg_cursor ~allow_partial:true read_color_interpolation "in oklab longer hue";
   neg_cursor read_color_interpolation "oklab";
   neg_cursor read_color_interpolation "in unknown";
   neg_cursor read_color_interpolation "in"


### PR DESCRIPTION
`linear-gradient(in srgb-linear, red, blue)` and `in hwb longer hue` used to be dropped: the gradient reader named six spaces in constructors of its own, where `color-mix()` over the same production reads all fifteen through `Values.read_color_space`. `color_interpolation` now carries the space, and sec. 9.1's hue method follows a polar space only.