### PR TITLE
shorthand: recognise a vendor twin by the value it spells

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -385,6 +385,12 @@ to lose a whole rule over one bad piece. Both are gone.
   `border-width: min(var(--x), 1px)` no longer collects a `calc()` around the
   reference and `min(calc(var(--x) + 1px), 2px)` no longer collects a second
   one. CSS Values 4 sec. 10.1 makes a lone `var()` a whole `<calc-sum>` (#1175)
+- A vendor prefix beside its unprefixed twin is recognised by the value the two
+  spell rather than by the nodes they were parsed into, so a `mask-image` given
+  a `var()` fallback its slot cannot type settles on one emission whether
+  cascade synthesised the prefix or an author wrote it. Minifying that output
+  again used to move it. Output grows 718 gzip bytes over the 504-file corpus
+  (0.01%) and the sweep is within timing noise (#1178)
 - Cascade reads back everything it writes. Minified `@scope to (...)`, `rotate`
   with a negative axis, a relative colour's channels, a `-webkit-gradient`
   `color-stop()` and `center` point, `text-decoration: none solid`,

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -6409,43 +6409,51 @@ let decoration_color_alias_twin vendor twin =
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
+(* Two declarations spell one value when their value text is the same. A
+   structural [=] on the two answers a different question: a [var()] fallback
+   the slot cannot type keeps the component values it was written as, source
+   spans included, so a prefix cascade synthesised beside its twin shares that
+   node and compares equal where an authored pair sat at two offsets and does
+   not. The drop below then depended on where the pair came from, and a
+   [mask-image: var(--x, 10px)] settled one way when synthesised and another
+   when read back. *)
+let same_value_text vendor twin =
+  String.equal
+    (Declaration.string_of_value ~minify:true vendor)
+    (Declaration.string_of_value ~minify:true twin)
+
 let vendor_alias_twin vendor twin =
   match (vendor, twin) with
-  | ( Declaration { property = Webkit_transform; value = v1; important = i1; _ },
-      Declaration { property = Transform; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_box_sizing; value = v1; important = i1; _ },
-      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_box_sizing; value = v1; important = i1; _ },
-      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_transform; important = i1; _ },
+      Declaration { property = Transform; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_box_sizing; important = i1; _ },
+      Declaration { property = Box_sizing; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
+  | ( Declaration { property = Moz_box_sizing; important = i1; _ },
+      Declaration { property = Box_sizing; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
   | ( Declaration { property = Webkit_text_decoration_color; _ },
       Declaration { property = Text_decoration_color; _ } ) ->
       decoration_color_alias_twin vendor twin
-  | ( Declaration { property = Webkit_mask_image; value = v1; important = i1; _ },
-      Declaration { property = Mask_image; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Webkit_user_select; value = v1; important = i1; _ },
-      Declaration { property = User_select; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_user_select; value = v1; important = i1; _ },
-      Declaration { property = User_select; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_hyphens; value = v1; important = i1; _ },
-      Declaration { property = Hyphens; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Webkit_text_size_adjust; value = v1; important = i1; _ },
-      Declaration { property = Text_size_adjust; value = v2; important = i2; _ }
-    ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Webkit_print_color_adjust; value = v1; important = i1; _ },
-      Declaration
-        { property = Print_color_adjust; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_mask_image; important = i1; _ },
+      Declaration { property = Mask_image; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_user_select; important = i1; _ },
+      Declaration { property = User_select; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
+  | ( Declaration { property = Moz_user_select; important = i1; _ },
+      Declaration { property = User_select; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_hyphens; important = i1; _ },
+      Declaration { property = Hyphens; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_text_size_adjust; important = i1; _ },
+      Declaration { property = Text_size_adjust; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_print_color_adjust; important = i1; _ },
+      Declaration { property = Print_color_adjust; important = i2; _ } ) ->
+      same_value_text vendor twin && Bool.equal i1 i2
   | _ ->
       vendor_alias_twin_animation vendor twin
       || vendor_alias_twin_transition vendor twin

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1168,11 +1168,11 @@ let test_vendor_prefix_strip () =
    properties that are not, which is exactly the set whose prefix a maintained
    browser may still need. *)
 let test_vendor_prefix_baseline_gate () =
-  let opt ?targets ?(enforce_spec = false) css =
+  let opt ?targets ?(enforce_spec = false) ?(scope = `Fragment) css =
     match Css.of_string css with
     | Ok p ->
         Css.to_string ~minify:true
-          (Css.optimize ?targets ~enforce_spec p.stylesheet)
+          (Css.optimize ?targets ~scope ~enforce_spec p.stylesheet)
         |> String.trim
     | Error _ -> Alcotest.fail "parse"
   in
@@ -1212,6 +1212,22 @@ let test_vendor_prefix_baseline_gate () =
     "enforce-spec keeps the mask-image prefix"
     ".a{-webkit-mask-image:none;mask-image:none}"
     (opt ~enforce_spec:true ".a{-webkit-mask-image:none;mask-image:none}");
+  (* The pair is the same pair however it got here: cascade synthesising the
+     prefix beside a lone [mask-image] and an author writing both must settle on
+     one emission, or the second pass over the first one's output moves. The
+     twin test asks whether the two spell the same value, which a [var()]
+     fallback the slot cannot type answers the same way wherever it was
+     written. *)
+  let sheet css = opt ~scope:`Stylesheet css in
+  Alcotest.(check string)
+    "an authored mask-image prefix pair settles where a synthesised one does"
+    (sheet ".a{mask-image:var(--x,10px)}")
+    (sheet ".a{-webkit-mask-image:var(--x,10px);mask-image:var(--x,10px)}");
+  Alcotest.(check string)
+    "the same pair over a fallback the slot can type"
+    (sheet ".a{mask-image:var(--x,url(a.png))}")
+    (sheet
+       ".a{-webkit-mask-image:var(--x,url(a.png));mask-image:var(--x,url(a.png))}");
   Alcotest.(check string)
     "enforce-spec keeps the box-sizing prefix"
     ".a{-webkit-box-sizing:border-box;box-sizing:border-box}"


### PR DESCRIPTION
The last `readback` finding: minifying `a{mask-image:var(--x, 10px)}` and then minifying that output gave two different sheets. The twin test compared values with a structural `=`, and a `var()` fallback the slot cannot type keeps the component values it was written as, spans included, so a synthesised prefix shares its twin's node and compares equal where an authored pair does not.

`readback` goes from 3 findings to 0 over 325,665 sheets, and `dune test` is green. Output grows 718 gzip bytes over the 504-file corpus (0.01%, 9,868 raw); the A/B sweep is 0.998x on CPU, within noise.