### PR TITLE
property: refuse an initial value no element can compute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -375,6 +375,14 @@ to lose a whole rule over one bad piece. Both are gone.
   An escaped name reads as the name it spells: `@supports (--x\3b y: red)` is
   read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer `b`
   of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141, #1162)
+- An `@property` `initial-value` at a non-universal `syntax` refuses a length
+  that resolves against an element, so `initial-value: 3em`, `3rem`, `3cqw` and
+  `calc(1px + 2em)` drop the rule where `3px`, `3vw` and `calc(1px + 2px)` read.
+  The registration happens before any element exists, so there is nothing for
+  such a length to resolve against; the universal syntax stores the value as
+  written and still takes every unit. This is CSS Properties and Values API 1
+  sec. 4.1 as Chrome enforces it, the reading #1142 already followed for the
+  substitution half (#1179)
 - A gradient's `<color-interpolation-method>` takes the fifteen colour spaces
   `color-mix()` takes, so `linear-gradient(in srgb-linear, red, blue)` and
   `in hwb longer hue` read where they were dropped, and a hue method after a

--- a/fuzz/fuzz_optimize.ml
+++ b/fuzz/fuzz_optimize.ml
@@ -712,7 +712,7 @@ let test_name_defining_atrules_preserved buf =
         "@font-face{font-family:Brand;src:url(brand.woff2)}.x{color:red}";
         "@keyframes fade{from{opacity:0}to{opacity:1}}.x{color:red}";
         "@property \
-         --gap{syntax:\"<length>\";inherits:false;initial-value:1rem}.x{padding:var(--gap)}";
+         --gap{syntax:\"<length>\";inherits:false;initial-value:1px}.x{padding:var(--gap)}";
         "@view-transition{navigation:auto}.x{view-transition-name:card}";
       ]
       buf 0

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3638,10 +3638,16 @@ let css_wide_keyword s =
    whole rule at every syntax, the universal one included. That is the revision
    of Properties and Values API 1 this reader follows throughout, the one that
    also makes syntax, inherits and a non-universal initial-value required;
-   today's ED sec. 3.3 ignores the descriptor alone instead. Not computational
-   independence, which is sec. 4.1 and binds registerProperty: Chrome keeps
-   [3em] here at the universal syntax. *)
-let read_property_initial_value r syntax str =
+   today's ED sec. 3.3 ignores the descriptor alone instead.
+
+   Sec. 4.1's computational independence is the second filter and reads the same
+   way. A non-universal syntax registers its initial value before any element
+   exists, so a length that resolves against one has nothing to resolve against;
+   the universal syntax stores the value as written and takes every unit. The ED
+   binds sec. 4.1 to registerProperty alone, and Chrome enforces it on the CSS
+   path too: the maintainer settled on 2026-09-09 that cascade follows Chrome
+   here, as it already does for the substitution half above. *)
+let read_property_initial_value ~universal r syntax str =
   if css_wide_keyword str then
     Cursor.err_invalid r "@property: initial-value cannot be CSS-wide keyword";
   (match Variables.substitution_fn_in_value_string str with
@@ -3650,6 +3656,17 @@ let read_property_initial_value r syntax str =
         (String.concat ""
            [ "@property: initial-value cannot contain "; fn; "()" ])
   | None -> ());
+  (if not universal then
+     match Variables.element_relative_in_value_string str with
+     | Some unit ->
+         Cursor.err_invalid r
+           (String.concat ""
+              [
+                "@property: initial-value cannot resolve against an element (";
+                unit;
+                ") at a non-universal syntax";
+              ])
+     | None -> ());
   let value_reader = Cursor.of_string str in
   let value = Variables.read_value value_reader syntax in
   Cursor.ws value_reader;
@@ -3887,7 +3904,10 @@ let read_property_rule (r : Cursor.t) : statement =
             Cursor.err_invalid r
               "@property: initial-value is required for non-universal syntax"
         | None -> Option.None
-        | Some str -> Some (read_property_initial_value r syntax str)
+        | Some str ->
+            Some
+              (read_property_initial_value ~universal:is_universal_syntax r
+                 syntax str)
       in
       Property { name; syntax; inherits; initial_value }
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5219,6 +5219,37 @@ let read_env : type a. (Cursor.t -> a) -> Cursor.t -> a env =
    never carries a negative-zero float, which breaks structural equality) and
    regenerate the repr from that value rather than echo the authored sign, so
    [-0px] / [+0px] serialise as [0px]. *)
+(* CSS Values 4 sec. 5.1.1 font-relative and sec. 5.1.4 container-relative
+   lengths resolve against something an element is given -- its font, its query
+   container -- so a value carrying one has no computed form until an element
+   has it. Sec. 5.1.3's viewport lengths resolve against the viewport, which
+   every element shares, and sec. 5.2's absolute lengths against nothing, so
+   neither depends on an element. *)
+let element_relative_units =
+  [
+    "em";
+    "rem";
+    "ex";
+    "rex";
+    "cap";
+    "rcap";
+    "ch";
+    "rch";
+    "ic";
+    "ric";
+    "lh";
+    "rlh";
+    "cqw";
+    "cqh";
+    "cqi";
+    "cqb";
+    "cqmin";
+    "cqmax";
+  ]
+
+let is_element_relative_unit unit =
+  List.mem (String.lowercase_ascii unit) element_relative_units
+
 let normalize_signed_zero n repr =
   if n = 0.0 then (0.0, Pp.string_of_float 0.0) else (n, repr)
 

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -728,6 +728,13 @@ val percentage_math_function_calls :
     property puts on it. Every other math function keeps [read], which holds the
     call to the slot's type. *)
 
+val is_element_relative_unit : string -> bool
+(** [is_element_relative_unit u] is whether [u] is one of CSS Values 4 sec.
+    5.1.1's font-relative or sec. 5.1.4's container-relative length units, the
+    ones that resolve against something an element is given. Sec. 5.1.3's
+    viewport lengths and sec. 5.2's absolute ones answer [false]: they resolve
+    against the viewport, which every element shares, and against nothing. *)
+
 val looking_at_percentage_math : Cursor.t -> bool
 (** [looking_at_percentage_math t] is [true] on a [calc()] or on any other math
     function, the two spellings {!read_folded_percentage_math} reads. *)

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -91,6 +91,26 @@ let rec substitution_fn_in_components (components : Component.t list) =
 let substitution_fn_in_value_string value =
   substitution_fn_in_components (components_of_value_string value)
 
+(* The same walk for a dimension whose unit resolves against an element. Goes
+   into arguments and blocks, so one inside a [calc()] counts as much as one
+   written on its own. *)
+let rec element_relative_in_components (components : Component.t list) =
+  List.find_map
+    (fun (c : Component.t) ->
+      match c with
+      | Component.Preserved { Token.kind = Token.Dimension { unit_; _ }; _ }
+        when Values.is_element_relative_unit unit_ ->
+          Option.Some unit_
+      | Component.Preserved _ -> Option.None
+      | Component.Func { node = { arguments; _ }; _ } ->
+          element_relative_in_components arguments
+      | Component.Block { node = { value; _ }; _ } ->
+          element_relative_in_components value)
+    components
+
+let element_relative_in_value_string value =
+  element_relative_in_components (components_of_value_string value)
+
 (** Pretty-print a syntax descriptor to CSS syntax string *)
 let rec pp_syntax_inner : type a. a syntax Pp.t =
  fun ctx syn ->

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -25,6 +25,11 @@ val var_refs_in_value_string : string -> string list
     walks them, so a [var(] inside a string or [url()] is recognised as data,
     not a reference - unlike a textual scan. *)
 
+val element_relative_in_value_string : string -> string option
+(** [element_relative_in_value_string value] is the first unit in [value] that
+    {!Values.is_element_relative_unit} answers for, looking inside functions and
+    blocks so one written in a [calc()] counts. *)
+
 val substitution_fn_in_value_string : string -> string option
 (** [substitution_fn_in_value_string value] is the name of the first arbitrary
     substitution function ([var()], [attr()] or [env()]) anywhere in [value],

--- a/test/cli/dead_code.t
+++ b/test/cli/dead_code.t
@@ -472,23 +472,23 @@ view-transition behavior outside local declaration dead-code analysis.
   $ cat > name-defining.css <<EOF
   > @font-face { font-family: Brand; src: url("brand.woff2") }
   > @keyframes fade { from { opacity: 0 } to { opacity: 1 } }
-  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1rem }
+  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1px }
   > @view-transition { navigation: auto }
   > .x { color: red }
   > EOF
   $ cascade --minify name-defining.css
-  @font-face{font-family:Brand;src:url(brand.woff2)}@keyframes fade{0%{opacity:0}to{opacity:1}}@property --gap{syntax:"<length>";inherits:false;initial-value:1rem}@view-transition{navigation:auto}.x{color:red}
+  @font-face{font-family:Brand;src:url(brand.woff2)}@keyframes fade{0%{opacity:0}to{opacity:1}}@property --gap{syntax:"<length>";inherits:false;initial-value:1px}@view-transition{navigation:auto}.x{color:red}
 
 Registered custom properties are not dead even when the only local use
 is a var() reference. Registration changes syntax, inheritance, and the
 initial value at computed-value time.
 
   $ cat > registered-var.css <<EOF
-  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1rem }
+  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1px }
   > .x { padding: var(--gap) }
   > EOF
   $ cascade --minify registered-var.css
-  @property --gap{syntax:"<length>";inherits:false;initial-value:1rem}.x{padding:var(--gap)}
+  @property --gap{syntax:"<length>";inherits:false;initial-value:1px}.x{padding:var(--gap)}
 
 Rules must not merge across name-defining at-rules. Their source
 position can be observable through animation, property registration,
@@ -500,11 +500,11 @@ font loading, and future stylesheet APIs.
   > .theme { display: flex }
   > @keyframes fade { from { opacity: 0 } to { opacity: 1 } }
   > .theme { padding: 1rem }
-  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1rem }
+  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1px }
   > .theme { margin: 1rem }
   > EOF
   $ cascade --minify opaque-at-rules.css
-  .theme{color:red}@font-face{font-family:Brand;src:url(brand.woff2)}.theme{display:flex}@keyframes fade{0%{opacity:0}to{opacity:1}}.theme{padding:1rem}@property --gap{syntax:"<length>";inherits:false;initial-value:1rem}.theme{margin:1rem}
+  .theme{color:red}@font-face{font-family:Brand;src:url(brand.woff2)}.theme{display:flex}@keyframes fade{0%{opacity:0}to{opacity:1}}.theme{padding:1rem}@property --gap{syntax:"<length>";inherits:false;initial-value:1px}.theme{margin:1rem}
 
 Nested rules must not merge across a nested @scope boundary either.
 

--- a/test/cli/prune.t
+++ b/test/cli/prune.t
@@ -109,7 +109,7 @@ they are reached. Only [.gone] is decided here.
   > @layer base, theme;
   > @font-face { font-family: Brand; src: url("brand.woff2") }
   > @keyframes fade { from { opacity: 0 } }
-  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1rem }
+  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1px }
   > .gone { color: red }
   > EOF
   $ cascade prune page.html atrules.css
@@ -129,7 +129,7 @@ they are reached. Only [.gone] is decided here.
   @property --gap {
     syntax: "<length>";
     inherits: false;
-    initial-value: 1rem;
+    initial-value: 1px;
   }
 
 

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -1092,7 +1092,7 @@ let serialization_invariants () =
        format(\"woff2\"); unicode-range: U+0025-00FF }";
       "@keyframes fade { from { opacity: 0 } to { opacity: 1 } }";
       "@property --gap { syntax: \"<length>\"; inherits: false; initial-value: \
-       1rem }";
+       1px }";
     ]
 
 let minified_shortest_spec_edges () =

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -4178,9 +4178,9 @@ let c61_no_named_atrule_merge () =
      fade{0%{opacity:0}to{opacity:1}}.theme{display:flex}";
   check_case "property registration boundary"
     ".theme{color:red}@property \
-     --gap{syntax:\"<length>\";inherits:false;initial-value:1rem}.theme{display:flex}"
+     --gap{syntax:\"<length>\";inherits:false;initial-value:1px}.theme{display:flex}"
     ".theme{color:red}@property \
-     --gap{syntax:\"<length>\";inherits:false;initial-value:1rem}.theme{display:flex}";
+     --gap{syntax:\"<length>\";inherits:false;initial-value:1px}.theme{display:flex}";
   check_case "view-transition boundary"
     ".theme{color:red}@view-transition{navigation:auto}.theme{display:flex}"
     ".theme{color:red}@view-transition{navigation:auto}.theme{display:flex}"

--- a/test/test_prune.ml
+++ b/test/test_prune.ml
@@ -142,7 +142,7 @@ let keeps_a_statement_with_no_selector () =
   let source =
     "@font-face{font-family:Brand;src:url(b.woff2)}@keyframes \
      fade{0%{opacity:0}}@property \
-     --gap{syntax:\"<length>\";inherits:false;initial-value:1rem}"
+     --gap{syntax:\"<length>\";inherits:false;initial-value:1px}"
   in
   let r = analyse source in
   check_verdicts "no rule was judged" [] r;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -490,9 +490,17 @@ let test_property_missing_descriptors () =
 (* An [initial-value] carrying var(), attr() or env() has nothing to substitute
    from at registration time, so Chrome 153 drops the
    whole rule at every syntax, the universal one included. The values below the
-   substitution cases are the other side of the same filter: they stay readable,
-   including the ones cascade knowingly keeps that Chrome drops for
-   computational independence ([3em] at a non-universal syntax). *)
+   substitution cases are the other side of the same filter.
+
+   Sec. 4.1's computational independence is the second filter, and Thomas
+   settled on 2026-09-09 that cascade follows Chrome here as it does for the
+   substitution half: a non-universal syntax registers its initial value before
+   any element exists, so a length that resolves against one cannot be computed.
+   Chrome 153 refuses the font-relative units of CSS Values 4 sec. 5.1.1 and the
+   container-relative ones of sec. 5.1.4 there, and takes sec. 5.1.3's viewport
+   lengths and sec. 5.2's absolute ones, which resolve against the viewport and
+   against nothing. The universal syntax stores the value as written and keeps
+   every unit. *)
 (* Not a roundtrip test *)
 let test_property_initial_value_substitution () =
   let expect_error what syntax value =
@@ -535,11 +543,36 @@ let test_property_initial_value_substitution () =
       "@property --x{syntax:\"<length>\";inherits:false;initial-value:5px}"
     "@property --x { syntax: \"<length>\"; inherits: false; initial-value: 5px \
      }";
+  List.iter
+    (fun unit ->
+      expect_error "element-relative unit at <length>" "<length>"
+        (String.concat "" [ "3"; unit ]))
+    [ "em"; "rem"; "ex"; "cap"; "ch"; "ic"; "lh"; "rlh"; "cqw"; "cqi"; "cqmax" ];
+  expect_error "element-relative unit inside a calc" "<length>"
+    "calc(1px + 2em)";
+  expect_error "element-relative unit at <length-percentage>"
+    "<length-percentage>" "3em";
+  List.iter
+    (fun value ->
+      check_stylesheet
+        ~expected:
+          (String.concat ""
+             [
+               "@property --x{syntax:\"<length>\";inherits:false;initial-value:";
+               value;
+               "}";
+             ])
+        (String.concat ""
+           [
+             "@property --x { syntax: \"<length>\"; inherits: false; \
+              initial-value: ";
+             value;
+             " }";
+           ]))
+    [ "3vw"; "3vmin"; "3dvw"; "calc(1px + 2px)" ];
   check_stylesheet
-    ~expected:
-      "@property --x{syntax:\"<length>\";inherits:false;initial-value:3em}"
-    "@property --x { syntax: \"<length>\"; inherits: false; initial-value: 3em \
-     }";
+    ~expected:"@property --x{syntax:\"*\";inherits:false;initial-value:3em}"
+    "@property --x { syntax: \"*\"; inherits: false; initial-value: 3em }";
   check_stylesheet
     ~expected:"@property --x{syntax:\"*\";inherits:false;initial-value:red}"
     "@property --x { syntax: \"*\"; inherits: false; initial-value: red }"


### PR DESCRIPTION
`@property { syntax: "<length>"; initial-value: 3em }` used to read; Chrome drops the rule, and so does cascade now. A non-universal syntax registers its initial value before any element exists, so a font- or container-relative length has nothing to resolve against; the universal syntax still takes every unit.

Settles the arbitration the backlog held: cascade follows Chrome here as #1142 did for the substitution half.