### PR TITLE
values: fold sign() only where the argument's sign is settled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -375,6 +375,11 @@ to lose a whole rule over one bad piece. Both are gone.
   An escaped name reads as the name it spells: `@supports (--x\3b y: red)` is
   read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer `b`
   of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141, #1162)
+- `sign()` folds only where its argument's sign is settled, so
+  `margin-left: calc(10px * sign(-1em))` keeps its call where
+  `sign(-1px)` still folds to `-10px`. The answer turns on whether the argument
+  is zero and a relative unit's reference can be one: a zero font-size, a zero
+  viewport, a zero container, a percentage of zero (#1180)
 - An `@property` `initial-value` at a non-universal `syntax` refuses a length
   that resolves against an element, so `initial-value: 3em`, `3rem`, `3cqw` and
   `calc(1px + 2em)` drop the rule where `3px`, `3vw` and `calc(1px + 2px)` read.

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -884,6 +884,37 @@ let combine_math_result op l r =
 (* CSS Values 4 sec. 10.11 types an operand tree: [+] and [-] need matching
    units, [*] takes at most one dimensioned operand and [/] a unitless divisor.
    Anything else is not an operand Cascade can reduce to a single value. *)
+(* CSS Values 4 sec. 5.2 absolute lengths, and the canonical units of the other
+   dimensions: each denotes the same quantity wherever it is written. Every
+   other unit -- sec. 5.1's relative lengths, the container ones, a percentage
+   -- resolves against something an element is given, and that reference can be
+   zero. *)
+let absolute_units =
+  [
+    "px";
+    "cm";
+    "mm";
+    "q";
+    "in";
+    "pt";
+    "pc";
+    "s";
+    "ms";
+    "deg";
+    "rad";
+    "grad";
+    "turn";
+    "hz";
+    "khz";
+    "dpi";
+    "dpcm";
+    "dppx";
+    "x";
+  ]
+
+let is_absolute_unit unit =
+  List.mem (String.lowercase_ascii unit) absolute_units
+
 let rec math_arg_result (arg : math_arg) : math_result option =
   match arg with
   | Lit f -> Option.some (Scalar f)
@@ -928,6 +959,23 @@ and math_fn_result (fn : math_fn) : math_result option =
       stepped_result (round_to_step strategy) value step
   | Mod_n (a, b) -> stepped_result mod_value a b
   | Rem_n (a, b) -> stepped_result Float.rem a b
+  (* Sec. 10.6: the answer turns on whether the argument is zero, and a relative
+     unit has a reference that can be -- a zero font-size, a zero viewport, a
+     zero container, a percentage of zero -- so the coefficient's sign is not
+     the value's and the call waits for the reference. An absolute unit has none
+     to wait for. *)
+  | Sign_n a -> (
+      let sign v =
+        if Float.is_nan v then Float.nan
+        else if v > 0. then 1.
+        else if v < 0. then -1.
+        else v
+      in
+      match math_arg_result a with
+      | Some (Scalar v) -> Option.some (Scalar (sign v))
+      | Some (United (v, unit)) when is_absolute_unit unit ->
+          Option.some (Scalar (sign v))
+      | Some (United _) | None -> Option.none)
   (* Every other math function is typed [<number>] in, [<number>] out, bar the
      inverse trig functions, whose [<angle>] result only the angle evaluator can
      place. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1971,7 +1971,33 @@ let negative_calc_keeps_the_call () =
   (* The record this was found on: the sign is known but the result is not a
      length any of these properties reads as a literal. *)
   check_declaration ~expected:"width:calc(10px*sign(-1vw))"
-    ~optimized:"width:calc(10px*sign(-1vw))" "width: calc(10px * sign(-1vw))"
+    ~optimized:"width:calc(10px*sign(-1vw))" "width: calc(10px * sign(-1vw))";
+  (* CSS Values 4 sec. 10.6 makes [sign()] answer -1, 0 or +1, so the answer
+     turns on whether the argument is zero. A relative unit's reference can be:
+     a zero font-size, a zero viewport, a zero container, a percentage of zero.
+     So the sign of the coefficient is not the sign of the value and the call
+     waits for the reference, where an absolute unit has no reference to wait
+     for. Chrome 153 keeps every row of the first list and folds every row of
+     the second, at a property that takes a negative length so the fold is the
+     only thing under test. *)
+  List.iter
+    (fun unit ->
+      let value = String.concat "" [ "calc(10px * sign(-1"; unit; "))" ] in
+      let held =
+        String.concat "" [ "margin-left:calc(10px*sign(-1"; unit; "))" ]
+      in
+      check_declaration ~expected:held ~optimized:held
+        (String.concat "" [ "margin-left: "; value ]))
+    [ "em"; "rem"; "ex"; "ch"; "vw"; "vh"; "vmin"; "dvw"; "cqw"; "%" ];
+  List.iter
+    (fun unit ->
+      let value = String.concat "" [ "calc(10px * sign(-1"; unit; "))" ] in
+      check_declaration
+        ~expected:
+          (String.concat "" [ "margin-left:calc(10px*sign(-1"; unit; "))" ])
+        ~optimized:"margin-left:-10px"
+        (String.concat "" [ "margin-left: "; value ]))
+    [ "px"; "cm"; "pt"; "s"; "deg" ]
 
 (* CSS Backgrounds 3 (ED) sec. 2.10 resets every longhand the shorthand covers,
    so a layer that fills no slot declares what [background: none] declares. [0


### PR DESCRIPTION
`margin-left: calc(10px * sign(-1em))` folded to `-10px`. `sign()` answers -1, 0 or +1 and the answer turns on whether the argument is zero, which a relative unit's reference can be: a zero font-size, a zero viewport, a zero container, a percentage of zero. Chrome 153 keeps the call for every relative unit and folds every absolute one.