### PR TITLE
values: fold the arithmetic of a length call the range keeps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -375,6 +375,13 @@ to lose a whole rule over one bad piece. Both are gone.
   An escaped name reads as the name it spells: `@supports (--x\3b y: red)` is
   read, and `@layer a\2e b` names the layer `a.b` rather than the sublayer `b`
   of `a` (#437, #442, #602, #603, #604, #620, #622, #767, #1141, #1162)
+- A math call a property's range makes it keep folds its arithmetic first, so
+  `border-radius: calc(-1px * 2)` prints `calc(-2px)` and
+  `width: calc(-5px - 5px)` prints `calc(-10px)`. The length family returned the
+  authored call where the number and time families already folded and kept, and
+  Chrome computes all three the same way. Sec. 10.12 clamps such a call at
+  computed-value time, so the wrapper stays and only the arithmetic moves; the
+  504-file corpus is byte-identical (#1181)
 - `sign()` folds only where its argument's sign is settled, so
   `margin-left: calc(10px * sign(-1em))` keeps its call where
   `sign(-1px)` still folds to `-10px`. The answer turns on whether the argument

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3964,11 +3964,12 @@ let rec normalize_length ?(strip = true) ?(non_negative = false)
   in
   (* CSS Values 4 sec. 10.12 clamps a math function whose value falls outside
      the property's range at computed-value time and keeps the declaration, so
-     folding one to a literal the reader then refuses would drop it: keep the
-     call. A literal that was already negative is the reader's business, not
-     this fold's. *)
+     folding one to a literal the reader then refuses would drop it: the
+     arithmetic still folds, and the call stays around the result. A literal
+     that was already negative is the reader's business, not this fold's. *)
   let result =
-    if non_negative && negative_length result && not (negative_length l) then l
+    if non_negative && negative_length result && not (negative_length l) then
+      (Calc (Val result) : length)
     else result
   in
   if strip then strip_zero_length result else result
@@ -3981,7 +3982,13 @@ let normalize_length_percentage ?(strip = true) ?(non_negative = false)
   match lp with
   | Calc c -> (
       match c |> eval_lp_calc ~ctx |> linear_lp_calc |> eval_lp_calc ~ctx with
-      | Val (Length v) when non_negative && negative_length v -> lp
+      (* Sec. 10.12 clamps a call past the property's range at computed-value
+         time and keeps the declaration, so folding one to a literal the reader
+         then refuses would drop it: the arithmetic still folds, and the call
+         stays around the result. This is what [normalize_number] does for the
+         number and time families. *)
+      | Val (Length v) when non_negative && negative_length v ->
+          Calc (Val (Length v))
       | Val v -> v
       | folded -> Calc folded)
   | Length l ->

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -2142,10 +2142,15 @@ let spec_math_range_keeps_the_call () =
      [<length-percentage>]; the shorthand carries the range its longhands
      carry. *)
   decl_optimizes ~prop:"border-radius" ~into:"calc(-1px)" "calc(-1px)";
-  (* The [<length>] guard keeps the call as authored rather than the folded one
-     ([width: calc(-5px - 5px)] is the same shape), so the arithmetic under a
-     kept wrapper stays where the author put it. *)
-  decl_optimizes ~prop:"border-radius" ~into:"calc(-1px*2)" "calc(-1px * 2)";
+  (* Sec. 10.12 clamps a call past the range at computed-value time and keeps
+     the declaration, so the arithmetic folds and the wrapper stays around the
+     result: the length family answers here the way the number and time families
+     already do at [tab-size] and [interest-delay]. Chrome 153 gives
+     [calc(-2px)] for both rows below and [calc(-10px)] for [width: calc(-5px -
+     5px)], and drops the bare literal [-10px]. *)
+  decl_optimizes ~prop:"border-radius" ~into:"calc(-2px)" "calc(-1px * 2)";
+  decl_optimizes ~prop:"padding" ~into:"calc(-2px)" "calc(-1px * 2)";
+  decl_optimizes ~prop:"width" ~into:"calc(-10px)" "calc(-5px - 5px)";
   decl_optimizes ~prop:"border-radius" ~into:"1px" "calc(1px)";
   (* CSS Flexbox 1 sec. 7.2 gives both factors a [0,inf] [<number>], through the
      shorthand and the two longhands alike. *)
@@ -2185,10 +2190,11 @@ let spec_math_range_keeps_the_call () =
   decl_optimizes ~prop:"stroke-dasharray" ~into:"calc(-1px)" "calc(-1px)";
   decl_optimizes ~prop:"stroke-dasharray" ~into:"calc(-1)" "sign(-1px)";
   decl_optimizes ~prop:"stroke-dasharray" ~into:"1px" "calc(1px)";
-  (* SVG 2 sec. 13.5.3 calls a negative [stroke-width] invalid, and the number
-     branch already kept its call: the length branch carries the same range. *)
+  (* SVG 2 sec. 13.5.3 calls a negative [stroke-width] invalid, so the call
+     stays around the folded result the way it does at every other length slot.
+     Chrome 153 gives [calc(-1px)] for both rows. *)
   decl_optimizes ~prop:"stroke-width" ~into:"calc(-1px)" "calc(-1px)";
-  decl_optimizes ~prop:"stroke-width" ~into:"calc(2px - 3px)" "calc(2px - 3px)";
+  decl_optimizes ~prop:"stroke-width" ~into:"calc(-1px)" "calc(2px - 3px)";
   (* CSS Text 4 sec. 6.2 gives the three [hyphenate-limit-chars] counts a
      [1,inf] [<integer>]. *)
   decl_optimizes ~prop:"hyphenate-limit-chars" ~into:"calc(-1)" "sign(-1px)";


### PR DESCRIPTION
`border-radius: calc(-1px * 2)` kept its multiplication where `interest-delay: calc(-1s * 2)` already folded to `calc(-2s)`; the length family returned the authored node instead of the folded one. Sec. 10.12 clamps such a call at computed-value time, so the wrapper stays and only the arithmetic moves, which is what Chrome 153 computes for all three.

Settles the kept-call shape the backlog held open. The A/B corpus sweep is byte-identical on all 503 files, ratio 1.001x.