### PR TITLE
values: send a round() tie toward positive infinity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -382,6 +382,11 @@ to lose a whole rule over one bad piece. Both are gone.
   Chrome computes all three the same way. Sec. 10.12 clamps such a call at
   computed-value time, so the wrapper stays and only the arithmetic moves; the
   504-file corpus is byte-identical (#1181)
+- `round()` sends a tie to the nearest multiple toward positive infinity, so
+  `round(-3, 2)` folds to `-2` where it used to fold to `-4`. CSS Values 4 sec.
+  10.7.3 gives that tie-break, and it is the one an `<integer>` slot already
+  used. The rule had three copies, one per argument type, and they disagreed;
+  there is now one (#1182)
 - `sign()` folds only where its argument's sign is settled, so
   `margin-left: calc(10px * sign(-1em))` keeps its call where
   `sign(-1px)` still folds to `-10px`. The answer turns on whether the argument

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -245,15 +245,7 @@ let rec eval_number_value : number -> float option = function
   | Round (strategy, value, step) -> (
       match (eval_number_value value, eval_number_value step) with
       | Some value, Some step when step <> 0. ->
-          let quotient = value /. step in
-          let rounded =
-            match strategy with
-            | "up" -> Float.ceil quotient
-            | "down" -> Float.floor quotient
-            | "to-zero" -> Float.trunc quotient
-            | _ -> Float.round quotient
-          in
-          Some (rounded *. step)
+          Some (Values.round_to_step strategy value step)
       | _ -> None)
   | Mod (a, b) -> (
       match (eval_number_value a, eval_number_value b) with

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -682,7 +682,11 @@ let round_to_step strategy value step =
       | "up" -> Float.ceil q
       | "down" -> Float.floor q
       | "to-zero" -> Float.trunc q
-      | _ -> Float.round q
+      (* Sec. 10.7.3 sends a tie to the nearest multiple toward positive
+         infinity, the rule sec. 10.12 gives an [<integer>] slot too.
+         [Float.round] sends it away from zero, which answers the other way for
+         a negative value. *)
+      | _ -> Float.floor (q +. 0.5)
     in
     q *. step
 
@@ -2250,12 +2254,10 @@ let linear_lp_calc calc =
             (Val (lp_of_unit unit n))
             rest)
 
-let round_length_step strategy value step =
-  match strategy with
-  | "up" -> Float.ceil (value /. step) *. step
-  | "down" -> Float.floor (value /. step) *. step
-  | "to-zero" -> Float.trunc (value /. step) *. step
-  | _ -> Float.round (value /. step) *. step
+(* One rounding rule, written once: the strategy and its tie-break are sec.
+   10.7.3's whatever the argument's type, and three copies of it is how a tie
+   came to be broken two different ways. *)
+let round_length_step = round_to_step
 
 (* Typed math-call printer: emit [name(arg1,arg2,...)] from a typed list of
    length values, deferring to [pp_length] for each component (so nested

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -728,6 +728,12 @@ val percentage_math_function_calls :
     property puts on it. Every other math function keeps [read], which holds the
     call to the slot's type. *)
 
+val round_to_step : string -> float -> float -> float
+(** [round_to_step strategy value step] is CSS Values 4 sec. 10.7.3's [round()]:
+    the multiple of [step] the strategy names, and for the default [nearest] the
+    closest one with a tie going toward positive infinity. A zero [step] has no
+    multiples, so the value comes back unchanged. *)
+
 val is_element_relative_unit : string -> bool
 (** [is_element_relative_unit u] is whether [u] is one of CSS Values 4 sec.
     5.1.1's font-relative or sec. 5.1.4's container-relative length units, the

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1972,6 +1972,31 @@ let negative_calc_keeps_the_call () =
      length any of these properties reads as a literal. *)
   check_declaration ~expected:"width:calc(10px*sign(-1vw))"
     ~optimized:"width:calc(10px*sign(-1vw))" "width: calc(10px * sign(-1vw))";
+  (* Sec. 10.7.3 rounds to the nearest multiple of the step and sends a tie
+     toward positive infinity, which is the rule sec. 10.12 gives an <integer>
+     slot and #1163 gave the grid line index. The other three strategies name
+     their own direction, so only [nearest] has a tie to break. Chrome 153
+     agrees on every row. *)
+  List.iter
+    (fun (value, folded) ->
+      check_declaration
+        ~expected:(String.concat "" [ "margin-left:"; value ])
+        ~optimized:(String.concat "" [ "margin-left:"; folded ])
+        (String.concat "" [ "margin-left: "; value ]))
+    [
+      ("round(-3px,2px)", "-2px");
+      ("round(3px,2px)", "4px");
+      ("round(-5px,2px)", "-4px");
+      ("round(5px,2px)", "6px");
+      (* A zero length drops its unit at the top level, which is the zero strip
+         the optimizer already does everywhere. *)
+      ("round(-1px,2px)", "0");
+      ("round(-3.5px,1px)", "-3px");
+      ("round(3.5px,1px)", "4px");
+      ("round(up,-3px,2px)", "-2px");
+      ("round(down,-3px,2px)", "-4px");
+      ("round(to-zero,-3px,2px)", "-2px");
+    ];
   (* CSS Values 4 sec. 10.6 makes [sign()] answer -1, 0 or +1, so the answer
      turns on whether the argument is zero. A relative unit's reference can be:
      a zero font-size, a zero viewport, a zero container, a percentage of zero.

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -2135,7 +2135,7 @@ let spec_math_range_keeps_the_call () =
   (* CSS Sizing 4 sec. 5 gives [<ratio>] the [0,inf] numbers of sec. 6.5. *)
   decl_optimizes ~prop:"aspect-ratio" ~into:"calc(-1)" "sign(-1px)";
   decl_optimizes ~prop:"aspect-ratio" ~into:"calc(-1)" "calc(-1)";
-  decl_optimizes ~prop:"aspect-ratio" ~into:"calc(-4)" "round(-3,2)";
+  decl_optimizes ~prop:"aspect-ratio" ~into:"calc(-2)" "round(-3,2)";
   decl_optimizes ~prop:"aspect-ratio" ~into:"1" "calc(1)";
   decl_optimizes ~prop:"aspect-ratio" ~into:"1" "1";
   (* CSS Backgrounds 3 sec. 4.1 gives each radius a [0,inf]
@@ -2159,7 +2159,7 @@ let spec_math_range_keeps_the_call () =
   decl_optimizes ~prop:"flex" ~into:"1" "calc(1)";
   decl_optimizes ~prop:"flex-grow" ~into:"calc(-1)" "sign(-1px)";
   decl_optimizes ~prop:"flex-grow" ~into:"calc(-1)" "calc(-1)";
-  decl_optimizes ~prop:"flex-grow" ~into:"calc(-4)" "round(-3,2)";
+  decl_optimizes ~prop:"flex-grow" ~into:"calc(-2)" "round(-3,2)";
   decl_optimizes ~prop:"flex-grow" ~into:"2" "calc(2)";
   decl_optimizes ~prop:"flex-shrink" ~into:"calc(-1)" "sign(-1px)";
   decl_optimizes ~prop:"flex-shrink" ~into:"calc(-1)" "calc(-1)";
@@ -2171,7 +2171,7 @@ let spec_math_range_keeps_the_call () =
   (* CSS Text 4 sec. 4.2 [tab-size], [0,inf]. *)
   decl_optimizes ~prop:"tab-size" ~into:"calc(-1)" "sign(-1px)";
   decl_optimizes ~prop:"tab-size" ~into:"calc(-1)" "calc(-1)";
-  decl_optimizes ~prop:"tab-size" ~into:"calc(-4)" "round(-3,2)";
+  decl_optimizes ~prop:"tab-size" ~into:"calc(-2)" "round(-3,2)";
   decl_optimizes ~prop:"tab-size" ~into:"4" "calc(4)";
   (* CSS Animations 1 sec. 3.4 [animation-iteration-count], [0,inf], and the
      shorthand slot that reads through it. *)


### PR DESCRIPTION
`round(-3, 2)` folded to `-4`; CSS Values 4 sec. 10.7.3 breaks a tie toward positive infinity and Chrome 153 answers `-2`. It is the same tie-break #1163 gave the grid line index.

The rule had three copies, one per argument type, and they disagreed. They now read one.