### PR TITLE
rule-graph: check a merge's blockers before its bystanders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -382,6 +382,11 @@ to lose a whole rule over one bad piece. Both are gone.
   Chrome computes all three the same way. Sec. 10.12 clamps such a call at
   computed-value time, so the wrapper stays and only the arithmetic moves; the
   504-file corpus is byte-identical (#1181)
+- `--minify` spends less time on factorings it will refuse: minifying the
+  SatCSS corpus' largest sheets is 8-19% faster with byte-identical output on
+  all 504 of them. A merge moves its rules past whatever sits between them, so
+  those are the rules that can refuse it, and they are now examined first
+  (#1183)
 - `round()` sends a tie to the nearest multiple toward positive infinity, so
   `round(-3, 2)` folds to `-2` where it used to fold to `-4`. CSS Values 4 sec.
   10.7.3 gives that tie-break, and it is the one an `<integer>` slot already

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -1347,6 +1347,16 @@ let add_inherited_edge t graph consume succ p k reason =
    nodes. [seen] is stamped with [p] (each produced node has a distinct index)
    to dedupe without re-clearing. A produced node carrying the broad key
    conflicts with everything, so it falls back to a full scan (rare: [all]). *)
+(* A merge moves its rules past everything that sits between them, so a node in
+   that span is the one that can refuse the move: 93% of the rejections on a
+   real sheet are blocked by one. The order the candidates are visited in does
+   not change whether the rewrite is accepted, only how soon a refusal is found,
+   so putting the span first turns a rejection from a walk of the whole
+   neighbourhood into a walk of the part that can block it. *)
+let span_first ~lo ~hi candidates =
+  let within, outside = List.partition (fun k -> k > lo && k < hi) candidates in
+  List.rev_append (List.rev within) outside
+
 let external_candidates graph ~total ~consumed ~seen p =
   let acc = ref [] in
   let push k =
@@ -1397,6 +1407,10 @@ let external_candidates graph ~total ~consumed ~seen p =
 
 let add_external_edges t ~consume ~consumed ~total ~produced_count graph succ =
   let seen = Array.make (max total 1) (-1) in
+  let lo =
+    List.fold_left (fun a c -> min a (Node_id.to_int c)) max_int consume
+  in
+  let hi = List.fold_left (fun a c -> max a (Node_id.to_int c)) (-1) consume in
   let rec loop_produced pi =
     if pi = produced_count then Ok ()
     else
@@ -1412,7 +1426,9 @@ let add_external_edges t ~consume ~consumed ~total ~produced_count graph succ =
                 | Error _ as e -> e))
       in
       match
-        loop_candidates (external_candidates graph ~total ~consumed ~seen p)
+        loop_candidates
+          (span_first ~lo ~hi
+             (external_candidates graph ~total ~consumed ~seen p))
       with
       | Ok () -> loop_produced (pi + 1)
       | Error _ as e -> e


### PR DESCRIPTION
twitter-5-stripmq 3.49s -> 3.14s, netflix-stripmq 1.10s -> 0.89s, reddit-stripmq 3.44s -> 3.17s, byte-identical on all 504 corpus files.

93% of refused rewrites are blocked by a rule sitting between the ones being merged, but the candidates were visited in index order, so 511 refusals examined 105,463 candidates to reach their blocker. The span a merge moves through is examined first now.