### PR TITLE
rule-graph: drop the conflict edges reachability already implies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -382,11 +382,13 @@ to lose a whole rule over one bad piece. Both are gone.
   Chrome computes all three the same way. Sec. 10.12 clamps such a call at
   computed-value time, so the wrapper stays and only the arithmetic moves; the
   504-file corpus is byte-identical (#1181)
-- `--minify` spends less time on factorings it will refuse: minifying the
-  SatCSS corpus' largest sheets is 8-19% faster with byte-identical output on
-  all 504 of them. A merge moves its rules past whatever sits between them, so
-  those are the rules that can refuse it, and they are now examined first
-  (#1183)
+- `--minify` is several times faster on a large stylesheet, for byte-identical
+  output: the SatCSS corpus' worst sheet drops from 3.5s to 0.6s. The rule
+  conflict graph recorded every conflicting pair as its own edge, where the
+  relation is really a union of cliques, so most of those edges and the selector
+  comparisons behind them only restated an ordering the rest already imply; and
+  a merge is now offered first to the rules that sit between the ones it moves,
+  which are the rules that can refuse it (#1183, #1184)
 - `round()` sends a tie to the nearest multiple toward positive infinity, so
   `round(-3, 2)` folds to `-2` where it used to fold to `-4`. CSS Values 4 sec.
   10.7.3 gives that tie-break, and it is the one an `<integer>` slot already

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -658,9 +658,77 @@ let rec add_rule_overlaps bucket decls selectors summaries specificities value =
       add_rule_overlaps bucket decls selectors summaries specificities value
   | _ -> invalid_arg "Rule_graph.add_rule_overlaps"
 
+(* A run of [n] nodes closes into [n * n / 8] bytes. Past this length each
+   question walks the edges again and the graph holds nothing. *)
+let closure_node_limit = 16384
+
+(* A node's reachable set, one bit per node. The union below runs once per edge
+   of the cone being closed, so it goes a word at a time. *)
+module Reach = struct
+  let v count = Bytes.make ((count + 7) / 8) '\000'
+  let is_set set = Bytes.length set > 0
+
+  let mem set i =
+    Char.code (Bytes.get set (i lsr 3)) land (1 lsl (i land 7)) <> 0
+
+  let add set i =
+    let byte = i lsr 3 in
+    Bytes.set set byte
+      (Char.chr (Char.code (Bytes.get set byte) lor (1 lsl (i land 7))))
+
+  let union ~into set =
+    let len = Bytes.length into in
+    let words = len / 8 in
+    for w = 0 to words - 1 do
+      let at = w * 8 in
+      Bytes.set_int64_ne into at
+        (Int64.logor (Bytes.get_int64_ne into at) (Bytes.get_int64_ne set at))
+    done;
+    for at = words * 8 to len - 1 do
+      Bytes.set into at
+        (Char.chr
+           (Char.code (Bytes.get into at) lor Char.code (Bytes.get set at)))
+    done
+end
+
+(* Every conflicting pair as its own edge stores the same order twice over: on a
+   real sheet the relation is a union of dense cliques, and a clique over nodes
+   that already sit in source order has the same reachability as the chain
+   through it. So walk the candidates nearest first and keep [covered], the
+   ancestors of everything already linked: a candidate in there already reaches
+   [j] through an edge we hold, so its own edge adds no constraint and - the
+   point of doing this here - it never reaches [nodes_conflict_reason]. The
+   reduction is exact rather than a narrowing: reachability is identical and
+   only the redundant edges are gone. [covered] is [anc.(j)], so it ends the
+   walk holding [j]'s ancestors for a later target to read. *)
+let link_candidates t succ anc ~reduce j candidates =
+  let link i reason = succ.(i) <- (j, reason) :: succ.(i) in
+  if not reduce then
+    List.iter
+      (fun i ->
+        match nodes_conflict_reason t i j with
+        | Option.None -> ()
+        | Option.Some reason -> link i reason)
+      candidates
+  else begin
+    let covered = anc.(j) in
+    List.iter
+      (fun i ->
+        if not (Reach.mem covered i) then
+          match nodes_conflict_reason t i j with
+          | Option.None -> ()
+          | Option.Some reason ->
+              link i reason;
+              Reach.union ~into:covered anc.(i);
+              Reach.add covered i)
+      (List.sort (fun a b -> Int.compare b a) candidates)
+  end
+
 let source_order_edges t =
   let n = t.count in
   let succ = Array.make n [] in
+  let reduce = n <= closure_node_limit in
+  let anc = if reduce then Array.init n (fun _ -> Reach.v n) else [||] in
   let by_decl_key = Overlap_key_table.create 256 in
   let by_branch = String_table.create 256 in
   (* every prior node, bucketed by specificity: what a node carrying the broad
@@ -688,12 +756,7 @@ let source_order_edges t =
         (fun acc branch -> collect_string_bucket by_branch branch j seen acc)
         candidates t.branches.(j)
     in
-    List.iter
-      (fun i ->
-        match nodes_conflict_reason t i j with
-        | Option.None -> ()
-        | Option.Some reason -> succ.(i) <- (j, reason) :: succ.(i))
-      candidates;
+    link_candidates t succ anc ~reduce j candidates;
     add_rule_overlaps by_decl_key t.decl_overlaps.(j) t.selectors.(j)
       t.selector_summaries.(j) t.specificities.(j) j;
     List.iter
@@ -804,39 +867,6 @@ let walk_to t source target =
         end
   in
   visit [ source ]
-
-(* A node's reachable set, one bit per node. The union below runs once per edge
-   of the cone being closed, so it goes a word at a time. *)
-module Reach = struct
-  let v count = Bytes.make ((count + 7) / 8) '\000'
-  let is_set set = Bytes.length set > 0
-
-  let mem set i =
-    Char.code (Bytes.get set (i lsr 3)) land (1 lsl (i land 7)) <> 0
-
-  let add set i =
-    let byte = i lsr 3 in
-    Bytes.set set byte
-      (Char.chr (Char.code (Bytes.get set byte) lor (1 lsl (i land 7))))
-
-  let union ~into set =
-    let len = Bytes.length into in
-    let words = len / 8 in
-    for w = 0 to words - 1 do
-      let at = w * 8 in
-      Bytes.set_int64_ne into at
-        (Int64.logor (Bytes.get_int64_ne into at) (Bytes.get_int64_ne set at))
-    done;
-    for at = words * 8 to len - 1 do
-      Bytes.set into at
-        (Char.chr
-           (Char.code (Bytes.get into at) lor Char.code (Bytes.get set at)))
-    done
-end
-
-(* A run of [n] nodes closes into [n * n / 8] bytes. Past this length each
-   question walks the edges again and the graph holds nothing. *)
-let closure_node_limit = 16384
 
 (* One step of the closure walk: [Open] descends into a node, [Close] unions the
    sets of its successors - by then settled - into its own. *)


### PR DESCRIPTION
Minifying `twitter-5-stripmq` took 3.46s and `reddit-stripmq` 3.20s, against the "well under 100 ms" in README.md. The rule conflict relation is a union of dense cliques -- every rule writing a property at a tying specificity constrains every other one that does -- so a 2200-node graph carried around half a million edges at an average degree of 450, and building each pair as its own edge recorded the same ordering many times over.

A clique over nodes that already sit in source order has the same reachability as the chain through it, so `source_order_edges` now walks a target's candidates nearest first and skips any that the edges it has already added can reach. The real saving is that a skipped candidate never reaches `nodes_conflict_reason`. `twitter-5-stripmq` drops to 0.64s and `reddit-stripmq` to 1.04s, byte-identical on all 504 files of the SatCSS corpus, and the suite falls from 104s to 59s.

This is a reduction rather than a narrowing: reachability is unchanged and only redundant edges go. It lands in `source_order_edges` alone; `rewrite_successors` still builds pairwise edges and is the follow-up.