### PR TITLE
flex: fold a flex-basis dimension onto its own unit variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -609,10 +609,10 @@ to lose a whole rule over one bad piece. Both are gone.
   `revert` or `revert-layer` for every typed property, and whether a property
   inherits is decided in one place from the typed property (#763, #764)
 - A length reaching one minified text through two nodes is one node, so
-  `a{width:1.0px}b{width:1px}` merges in the pass that minifies it rather than
-  the one after. `Declaration.hash` keys the structural value and short-circuits
-  `Declaration.same_minified`, and the reader kept an authored spelling the
-  printer already discards, so one text arrived through two nodes (#1150)
+  `a{width:1.0px}b{width:1px}` and `a{flex-basis:10.0px}b{flex-basis:10px}`
+  merge in the pass that minifies them rather than the one after. An authored
+  spelling the printer discards was kept as a node of its own, so one text
+  arrived through two of them (#1150, #1185)
 - `--minify` and `cascade diff` are faster on a large stylesheet, for
   byte-identical output. The slowest corpus stylesheet drops sharply, a long run
   of rules sharing one selector no longer allocates quadratically, a 4,000

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -53,6 +53,51 @@ let rec normalize_flex_factor (value : flex_factor) : flex_factor =
       | folded -> if folded == c then value else Calc folded)
   | _ -> value
 
+(* [read_length] hands every authored spelling that is not already the canonical
+   one - [10.0px], [1e1px], [+10px] among them - to [Dimension], which keeps the
+   text so that printing a sheet nobody optimised gives it back. Optimising
+   drops that text from the output, so a node left apart from the [Px 10.] the
+   canonical spelling reads as costs a merge: the two print alike and still hash
+   apart, and the rules holding them only join on a second pass. Fold a known
+   unit back onto its own variant and leave an unknown one alone. *)
+let flex_basis_of_unit n : string -> flex_basis option = function
+  | "%" -> Option.Some (Pct n : flex_basis)
+  | "px" -> Option.Some (Px n : flex_basis)
+  | "cm" -> Option.Some (Cm n : flex_basis)
+  | "mm" -> Option.Some (Mm n : flex_basis)
+  | "q" -> Option.Some (Q n : flex_basis)
+  | "in" -> Option.Some (In n : flex_basis)
+  | "pt" -> Option.Some (Pt n : flex_basis)
+  | "pc" -> Option.Some (Pc n : flex_basis)
+  | "rem" -> Option.Some (Rem n : flex_basis)
+  | "em" -> Option.Some (Em n : flex_basis)
+  | "ex" -> Option.Some (Ex n : flex_basis)
+  | "cap" -> Option.Some (Cap n : flex_basis)
+  | "ic" -> Option.Some (Ic n : flex_basis)
+  | "ric" -> Option.Some (Ric n : flex_basis)
+  | "rlh" -> Option.Some (Rlh n : flex_basis)
+  | "vw" -> Option.Some (Vw n : flex_basis)
+  | "vh" -> Option.Some (Vh n : flex_basis)
+  | "vmin" -> Option.Some (Vmin n : flex_basis)
+  | "vmax" -> Option.Some (Vmax n : flex_basis)
+  | "vi" -> Option.Some (Vi n : flex_basis)
+  | "vb" -> Option.Some (Vb n : flex_basis)
+  | "dvh" -> Option.Some (Dvh n : flex_basis)
+  | "dvw" -> Option.Some (Dvw n : flex_basis)
+  | "dvmin" -> Option.Some (Dvmin n : flex_basis)
+  | "dvmax" -> Option.Some (Dvmax n : flex_basis)
+  | "lvh" -> Option.Some (Lvh n : flex_basis)
+  | "lvw" -> Option.Some (Lvw n : flex_basis)
+  | "lvmin" -> Option.Some (Lvmin n : flex_basis)
+  | "lvmax" -> Option.Some (Lvmax n : flex_basis)
+  | "svh" -> Option.Some (Svh n : flex_basis)
+  | "svw" -> Option.Some (Svw n : flex_basis)
+  | "svmin" -> Option.Some (Svmin n : flex_basis)
+  | "svmax" -> Option.Some (Svmax n : flex_basis)
+  | "ch" -> Option.Some (Ch n : flex_basis)
+  | "lh" -> Option.Some (Lh n : flex_basis)
+  | _ -> Option.None
+
 let rec normalize_flex_basis (value : flex_basis) : flex_basis =
   match value with
   | Px 0.
@@ -94,6 +139,10 @@ let rec normalize_flex_basis (value : flex_basis) : flex_basis =
       match eval_calc c with
       | Val v -> normalize_flex_basis v
       | folded -> if folded == c then value else Calc folded)
+  | Dimension { value = n; unit; _ } -> (
+      match flex_basis_of_unit n unit with
+      | Option.Some folded -> normalize_flex_basis folded
+      | Option.None -> value)
   | _ -> value
 
 let normalize_flex (value : flex) : flex =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6905,6 +6905,29 @@ let sole_declaration css =
 let minified css =
   Css.to_string ~minify:true (Css.optimize (Css.of_string_exn css))
 
+(* A [<length>] reaches [flex-basis] through the property's own mirror of the
+   length variants, and that mirror's normaliser folds only a zero and a
+   [calc()]. So [10.0px] stayed the dimension the reader built while [10px] was
+   the folded [Px 10.], the printer spelled both [10px], and the rules they sat
+   in could not merge until a second pass re-read that text. One [--minify] has
+   to reach the stable answer: CSS Values 4 sec. 6.7.2 gives the two spellings
+   one serialisation, so they are one value and one node. *)
+let flex_basis_spellings_are_one_value () =
+  let a = sole_declaration ".a{flex-basis:10.0px}" in
+  let b = sole_declaration ".b{flex-basis:10px}" in
+  Alcotest.(check string)
+    "the authored spelling folds" "flex-basis:10px"
+    (Css.Declaration.to_string ~minify:true a);
+  Alcotest.(check int)
+    "hash reads the two as one value" (Css.Declaration.hash a)
+    (Css.Declaration.hash b);
+  Alcotest.(check bool)
+    "the two spellings are equal" true
+    (Css.Declaration.equal_declaration a b);
+  Alcotest.(check string)
+    "one pass merges the rules" "a,b{flex-basis:10px}"
+    (minified "a{flex-basis:10.0px}b{flex-basis:10px}")
+
 let nan_declaration_is_one_value () =
   (* Parsed apart so the two are distinct heap blocks: a physical-equality
      short-circuit must not stand in for the answer. *)
@@ -7325,6 +7348,8 @@ let declaration_tests =
     test_case "conic gradient var has one node" `Quick
       conic_gradient_var_has_one_node;
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
+    test_case "flex-basis spellings are one value" `Quick
+      flex_basis_spellings_are_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;
     test_case "number spellings have one node" `Quick


### PR DESCRIPTION
A rule pair like `a{flex-basis:10.0px}b{flex-basis:10px}` needed two `--minify` passes to merge. `flex-basis` reads a length through the property's own mirror of the length variants, and that mirror's normaliser folded only a zero and a `calc()`, so every other authored spelling stayed the `Dimension` the reader built: it printed `10px` like the canonical one and still hashed apart. `flex_basis_of_unit` now maps a known unit back onto its variant at any value, and an unknown unit keeps the `Dimension` it had.

Follow-up to #1150, which fixed the same defect for `width`. Printing without `--minify` does not optimise, so the authored spelling still comes back.