### PR TITLE
props: fold the lengths five normalisers never reached

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -608,11 +608,12 @@ to lose a whole rule over one bad piece. Both are gone.
 - Computed-value evaluation resolves a direct `inherit`, `initial`, `unset`,
   `revert` or `revert-layer` for every typed property, and whether a property
   inherits is decided in one place from the typed property (#763, #764)
-- A length reaching one minified text through two nodes is one node, so
-  `a{width:1.0px}b{width:1px}` and `a{flex-basis:10.0px}b{flex-basis:10px}`
-  merge in the pass that minifies them rather than the one after. An authored
-  spelling the printer discards was kept as a node of its own, so one text
-  arrived through two of them (#1150, #1185)
+- A length reaching one minified text through two nodes is one node, so rules
+  writing one width merge in the pass that minifies them rather than the one
+  after: `a{width:1.0px}b{width:1px}` and the same for `flex-basis`,
+  `column-width`, `size`, `initial-letter-wrap`, `background-size` and
+  `mask-size`. An authored spelling the printer discards was kept as a node of
+  its own, so one text arrived through two of them (#1150, #1185, #1186)
 - `--minify` and `cascade diff` are faster on a large stylesheet, for
   byte-identical output. The slowest corpus stylesheet drops sharply, a long run
   of rules sharing one selector no longer allocates quadratically, a 4,000

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1066,6 +1066,24 @@ let rec pp_background_box : background_box Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* [background-size] and the two [mask-size] spellings share this value, and
+   nothing folded the length inside it, so an authored [10.0px] stayed a node of
+   its own beside the [10px] the canonical spelling reads as. *)
+let rec normalize_background_size : background_size -> background_size =
+ fun value ->
+  match value with
+  | Length len ->
+      let len' = Values.canonical_dimension len in
+      if len' == len then value else Length len'
+  | Size (a, b) ->
+      let a' = Values.canonical_dimension a in
+      let b' = Values.canonical_dimension b in
+      if a' == a && b' == b then value else Size (a', b')
+  | Layers layers ->
+      let layers' = List.map normalize_background_size layers in
+      if List.equal ( == ) layers layers' then value else Layers layers'
+  | _ -> value
+
 let rec pp_background_size : background_size Pp.t =
  fun ctx -> function
   | Layers layers -> Pp.list ~sep:Pp.comma pp_background_size ctx layers

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -154,6 +154,30 @@ let normalize_columns_value : columns_value -> columns_value =
       if len' == len then value else Both (len', count)
   | other -> other
 
+(* [column-width] and [size] hold their length the way [columns] holds its own,
+   and the printer drops the authored spelling under [--minify] just the same,
+   so they fold it for the same reason: two spellings of one width otherwise
+   reach one minified text through two nodes. *)
+let normalize_column_width : column_width -> column_width =
+ fun value ->
+  match value with
+  | Width len ->
+      let len' = Values.canonical_dimension len in
+      if len' == len then value else Width len'
+  | _ -> value
+
+let normalize_page_size : page_size -> page_size =
+ fun value ->
+  match value with
+  | Single len ->
+      let len' = Values.canonical_dimension len in
+      if len' == len then value else Single len'
+  | Pair (a, b) ->
+      let a' = Values.canonical_dimension a in
+      let b' = Values.canonical_dimension b in
+      if a' == a && b' == b then value else Pair (a', b')
+  | _ -> value
+
 let rec pp_columns_value : columns_value Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1331,6 +1331,17 @@ let rec pp_initial_letter_align : initial_letter_align Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_initial_letter_align ctx v
 
+(* The wrap length is the one part of this value the printer respells under
+   [--minify], so leaving the authored spelling here costs the merge that two
+   rules writing one width should get on the first pass. *)
+let normalize_initial_letter_wrap : initial_letter_wrap -> initial_letter_wrap =
+ fun value ->
+  match value with
+  | Length (Length len) ->
+      let len' = Values.canonical_dimension len in
+      if len' == len then value else Length (Length len')
+  | _ -> value
+
 let rec pp_initial_letter_wrap : initial_letter_wrap Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4623,6 +4623,13 @@ let normalize_property_value : type a.
   | Vertical_align -> normalize_vertical_align value
   | Border_image -> normalize_border_image value
   | Columns -> normalize_columns_value value
+  | Column_width -> normalize_column_width value
+  | Page_size -> normalize_page_size value
+  | Initial_letter_wrap -> normalize_initial_letter_wrap value
+  | Background_size -> normalize_background_size value
+  | Webkit_background_size -> normalize_background_size value
+  | Mask_size -> normalize_background_size value
+  | Webkit_mask_size -> normalize_background_size value
   | Column_count -> normalize_column_count value
   | Border_width ->
       normalize_box_shorthand ~is_substitution:is_border_width_substitution

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6912,6 +6912,33 @@ let minified css =
    in could not merge until a second pass re-read that text. One [--minify] has
    to reach the stable answer: CSS Values 4 sec. 6.7.2 gives the two spellings
    one serialisation, so they are one value and one node. *)
+(* The same defect in the properties whose values hold a length the property's
+   own normaliser never reaches. [10.0px] and [10px] are one value under CSS
+   Values 4 sec. 6.7.2 and print alike once the sheet is optimised, so the rules
+   holding them have to merge in that pass rather than the one after. *)
+let unfolded_lengths_are_one_value () =
+  let case (property, merged) =
+    let css =
+      Pp.to_string
+        (fun ctx () ->
+          Pp.string ctx "a{";
+          Pp.string ctx property;
+          Pp.string ctx ":10.0px}b{";
+          Pp.string ctx property;
+          Pp.string ctx ":10px}")
+        ()
+    in
+    Alcotest.(check string) property merged (minified css)
+  in
+  List.iter case
+    [
+      ("column-width", "a,b{column-width:10px}");
+      ("initial-letter-wrap", "a,b{initial-letter-wrap:10px}");
+      ("size", "a,b{size:10px}");
+      ("background-size", "a,b{background-size:10px}");
+      ("mask-size", "a,b{-webkit-mask-size:10px;mask-size:10px}");
+    ]
+
 let flex_basis_spellings_are_one_value () =
   let a = sole_declaration ".a{flex-basis:10.0px}" in
   let b = sole_declaration ".b{flex-basis:10px}" in
@@ -7350,6 +7377,8 @@ let declaration_tests =
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "flex-basis spellings are one value" `Quick
       flex_basis_spellings_are_one_value;
+    test_case "unfolded lengths are one value" `Quick
+      unfolded_lengths_are_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;
     test_case "number spellings have one node" `Quick


### PR DESCRIPTION
A rule pair like `a{background-size:10.0px}b{background-size:10px}` needed two `--minify` passes to merge, and the same held for `column-width`, `size`, `initial-letter-wrap` and `mask-size`. None of those values had a normaliser that reached its length, so an authored spelling stayed the `Dimension` the reader built: it printed `10px` like the canonical one and still hashed apart.

Each folds through `Values.canonical_dimension` now, which `columns` already used for the same value. `background-size` recurses through its layers and both size pairs. Byte-identical on all 504 files of the SatCSS corpus. Follow-up to #1150 and #1185.