### PR TITLE
values: serialise a dimension's unit in lowercase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -612,8 +612,10 @@ to lose a whole rule over one bad piece. Both are gone.
   writing one width merge in the pass that minifies them rather than the one
   after: `a{width:1.0px}b{width:1px}` and the same for `flex-basis`,
   `column-width`, `size`, `initial-letter-wrap`, `background-size` and
-  `mask-size`. An authored spelling the printer discards was kept as a node of
-  its own, so one text arrived through two of them (#1150, #1185, #1186)
+  `mask-size`. A unit minifies lowercase whatever its case, so `width:10.0PX`
+  is `10px` where it was `10PX`. An authored spelling the printer discards was
+  kept as a node of its own, so one text arrived through two of them (#1150,
+  #1185, #1186, #1187)
 - `--minify` and `cascade diff` are faster on a large stylesheet, for
   byte-identical output. The slowest corpus stylesheet drops sharply, a long run
   of rules sharing one selector no longer allocates quadratically, a 4,000

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -140,7 +140,7 @@ let rec normalize_flex_basis (value : flex_basis) : flex_basis =
       | Val v -> normalize_flex_basis v
       | folded -> if folded == c then value else Calc folded)
   | Dimension { value = n; unit; _ } -> (
-      match flex_basis_of_unit n unit with
+      match flex_basis_of_unit n (String.lowercase_ascii unit) with
       | Option.Some folded -> normalize_flex_basis folded
       | Option.None -> value)
   | _ -> value

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1386,7 +1386,13 @@ let rec pp_line_height : line_height Pp.t =
           Pp.string ctx unit
       | true, None -> Pp.float ctx value
       | true, Some "%" -> Pp.pct ctx value
-      | true, Some unit -> Pp.unit ctx value unit)
+      (* Values 4 sec. 6.7.2 serialises a unit lowercase, as the constructors
+         above print it, so the author's case ends at the unminified branch. A
+         unit none of them names has no other spelling to agree with. *)
+      | true, Some unit ->
+          Pp.unit ctx value
+            (if Values.is_length_unit unit then String.lowercase_ascii unit
+             else unit))
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -2565,7 +2571,7 @@ let normalize_line_height ?(lossless = false) (lh : line_height) : line_height =
      spelling under [--minify]. Fold onto the constructor where there is one, or
      the two spellings reach one minified text through two nodes. *)
   | Number { value; unit; _ } -> (
-      match unit with
+      match Option.map String.lowercase_ascii unit with
       | Option.None -> Num value
       | Option.Some "%" -> Pct value
       | Option.Some "px" -> Px value

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -2029,14 +2029,14 @@ let length_of_calc_unit (unit : length_unit) n : length =
    [Dimension] for the unminified round-trip, and the printer drops it under
    [--minify]: two spellings then reach one minified text through two nodes,
    which anything keyed on the node reads as two values. Fold back to the
-   constructor once the round-trip no longer needs the spelling. Only a unit the
-   constructor prints back verbatim folds, so no byte moves; a zero is left to
-   [strip_zero_length], whose unit strip is a type change this is not. *)
+   constructor once the round-trip no longer needs the spelling. The minified
+   printer lowercases the unit, as the constructors do, so the author's case
+   moves no byte here either; a zero is left to [strip_zero_length], whose unit
+   strip is a type change this is not. *)
 let canonical_dimension (l : length) : length =
   match l with
-  | Dimension { value; unit; _ }
-    when value <> 0. && String.equal (String.lowercase_ascii unit) unit -> (
-      match unit_of_string unit with
+  | Dimension { value; unit; _ } when value <> 0. -> (
+      match unit_of_string (String.lowercase_ascii unit) with
       | Some unit -> length_of_unit unit value
       | None -> l)
   | _ -> l
@@ -2425,7 +2425,15 @@ let rec pp_length ?(always = false) : length Pp.t =
   | Ch f -> pp_unit_fn f "ch"
   | Lh f -> pp_unit_fn f "lh"
   | Dimension { value; unit; repr } ->
-      if ctx.minify then pp_unit_fn value unit
+      (* CSS Values 4 sec. 6.7.2 serialises a dimension's unit in lowercase, and
+         the unit constructors print that way, so a dimension naming one of them
+         has to as well or the same width reads back two ways. A unit no
+         constructor covers is a future or [calc()]-only dimension token this
+         arm alone writes, so nothing contradicts the author's case there. The
+         unminified branch round-trips what the author wrote either way. *)
+      if ctx.minify then
+        pp_unit_fn value
+          (if is_length_unit unit then String.lowercase_ascii unit else unit)
       else (
         Pp.string ctx repr;
         Pp.string ctx unit)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6916,6 +6916,43 @@ let minified css =
    own normaliser never reaches. [10.0px] and [10px] are one value under CSS
    Values 4 sec. 6.7.2 and print alike once the sheet is optimised, so the rules
    holding them have to merge in that pass rather than the one after. *)
+(* CSS Values 4 sec. 6.7.2 serialises a dimension's unit in lowercase, and the
+   reader folds a canonically spelled number onto the unit constructor, which
+   prints that way. An authored number the printer respells kept the unit as the
+   author cased it instead, so one input was minified two ways: [10PX] came back
+   [10px] and [10.0PX] came back [10PX], and the two never merged. *)
+let uppercase_units_minify_lowercase () =
+  List.iter
+    (fun (css, minified_css) ->
+      Alcotest.(check string) css minified_css (minified css))
+    [
+      ("a{width:10.0PX}", "a{width:10px}");
+      ("a{width:10.0Q}", "a{width:10q}");
+      ("a{width:10.0VMIN}", "a{width:10vmin}");
+      ("a{width:10.0PX}b{width:10PX}", "a,b{width:10px}");
+      ("a{width:10.0PX}b{width:10px}", "a,b{width:10px}");
+      (* The two values holding their own mirror of the length constructors
+         decide the unit's case themselves, so they need the same answer. *)
+      ("a{line-height:10.0PX}", "a{line-height:10px}");
+      ("a{line-height:10.0PX}b{line-height:10PX}", "a,b{line-height:10px}");
+      ("a{flex-basis:10.0PX}b{flex-basis:10PX}", "a,b{flex-basis:10px}");
+    ]
+
+(* The printer is public without the optimizer, so a value holding its own
+   [Dimension] arm has to lowercase the unit there rather than lean on a
+   normaliser having folded the dimension away first. *)
+let printed_units_are_lowercase () =
+  List.iter
+    (fun (css, minified_css) ->
+      Alcotest.(check string)
+        css minified_css
+        (Css.to_string ~minify:true (Css.of_string_exn css)))
+    [
+      ("a{width:10.0PX}", "a{width:10px}");
+      ("a{line-height:10.0PX}", "a{line-height:10px}");
+      ("a{border-width:10.0PX}", "a{border-width:10px}");
+    ]
+
 let unfolded_lengths_are_one_value () =
   let case (property, merged) =
     let css =
@@ -7379,6 +7416,9 @@ let declaration_tests =
       flex_basis_spellings_are_one_value;
     test_case "unfolded lengths are one value" `Quick
       unfolded_lengths_are_one_value;
+    test_case "uppercase units minify lowercase" `Quick
+      uppercase_units_minify_lowercase;
+    test_case "printed units are lowercase" `Quick printed_units_are_lowercase;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;
     test_case "number spellings have one node" `Quick


### PR DESCRIPTION
CSS Values 4 sec. 6.7.2 lowercases a dimension's unit, which is how the unit constructors print, but a dimension kept the author's case: `width:10PX` minified to `10px` while `width:10.0PX` minified to `10PX`, so two spellings of one width never merged. The value types mirroring the length constructors, `line-height` and `flex-basis`, decided the case themselves and needed the same answer.

Follow-up to #1186.