### PR TITLE
content: fold a quoted string onto its value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -608,14 +608,13 @@ to lose a whole rule over one bad piece. Both are gone.
 - Computed-value evaluation resolves a direct `inherit`, `initial`, `unset`,
   `revert` or `revert-layer` for every typed property, and whether a property
   inherits is decided in one place from the typed property (#763, #764)
-- A length reaching one minified text through two nodes is one node, so rules
-  writing one width merge in the pass that minifies them rather than the one
-  after: `a{width:1.0px}b{width:1px}` and the same for `flex-basis`,
+- A value reaching one minified text through two nodes is one node, so rules
+  writing one of them merge in the pass that minifies them rather than the one
+  after. `a{width:1.0px}b{width:1px}` folds, and so do `flex-basis`,
   `column-width`, `size`, `initial-letter-wrap`, `background-size` and
-  `mask-size`. A unit minifies lowercase whatever its case, so `width:10.0PX`
-  is `10px` where it was `10PX`. An authored spelling the printer discards was
-  kept as a node of its own, so one text arrived through two of them (#1150,
-  #1185, #1186, #1187)
+  `mask-size`; a unit minifies lowercase whatever its case, so `width:10.0PX`
+  is `10px`; and `content:'x'` and `content:"x"` are one string (#1150, #1185,
+  #1186, #1187, #1188)
 - `--minify` and `cascade diff` are faster on a large stylesheet, for
   byte-identical output. The slowest corpus stylesheet drops sharply, a long run
   of rules sharing one selector no longer allocates quadratically, a 4,000

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2291,6 +2291,20 @@ let rec pp_content : content Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_content ctx v
 
+(* CSS Values 4 sec. 6.7.2 gives a string one serialisation, and [--minify]
+   writes that one whichever quote the author chose: the quote and the authored
+   spelling survive only in the round-trip the printer keeps for unminified
+   output. Fold onto [String] once that round-trip is gone, or [content:'x'] and
+   [content:"x"] reach one minified text through two nodes, which anything keyed
+   on the node reads as two values. *)
+let rec normalize_content (c : content) : content =
+  match c with
+  | Quoted { value; _ } -> String value
+  | Content_list items ->
+      let items' = List.map normalize_content items in
+      if List.equal ( == ) items items' then c else Content_list items'
+  | _ -> c
+
 let pp_counter_item ctx { name; value } =
   pp_ident ctx name;
   match value with
@@ -4623,6 +4637,7 @@ let normalize_property_value : type a.
   | Vertical_align -> normalize_vertical_align value
   | Border_image -> normalize_border_image value
   | Columns -> normalize_columns_value value
+  | Content -> normalize_content value
   | Column_width -> normalize_column_width value
   | Page_size -> normalize_page_size value
   | Initial_letter_wrap -> normalize_initial_letter_wrap value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6953,6 +6953,23 @@ let printed_units_are_lowercase () =
       ("a{border-width:10.0PX}", "a{border-width:10px}");
     ]
 
+(* CSS Values 4 sec. 6.7.2 gives a string one serialisation, and [--minify]
+   writes that one, so the quote the author picked is a round-trip detail rather
+   than part of the value. It was kept as a node of its own, so [content:'x']
+   and [content:"x"] reached one minified text through two nodes and the rules
+   holding them could not merge until a second pass re-read that text. *)
+let quoted_content_is_one_node () =
+  List.iter
+    (fun (css, minified_css) ->
+      Alcotest.(check string) css minified_css (minified css))
+    [
+      ("a{content:'x'}b{content:\"x\"}", "a,b{content:\"x\"}");
+      ("a{content:'x' 'y'}b{content:\"x\" \"y\"}", "a,b{content:\"x\" \"y\"}");
+      (* A quote the serialisation has to escape is still one answer, so the two
+         spellings of it are still one node. *)
+      ("a{content:'a\"b'}b{content:\"a\\\"b\"}", "a,b{content:\"a\\\"b\"}");
+    ]
+
 let unfolded_lengths_are_one_value () =
   let case (property, merged) =
     let css =
@@ -7419,6 +7436,7 @@ let declaration_tests =
     test_case "uppercase units minify lowercase" `Quick
       uppercase_units_minify_lowercase;
     test_case "printed units are lowercase" `Quick printed_units_are_lowercase;
+    test_case "quoted content is one node" `Quick quoted_content_is_one_node;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;
     test_case "number spellings have one node" `Quick


### PR DESCRIPTION
CSS Values 4 sec. 6.7.2 gives a string one serialisation, so `content:'x'` and `content:"x"` both minify to `content:"x"`. The quote the author picked was kept as a node of its own, so the two rules did not merge until a second `--minify` pass re-read that text.

The fold is byte-neutral in itself, but it lets two passes keyed on the node fire: over the 504-file SatCSS corpus 498 files are byte-identical and the six that change are canonically identical to what they were, for a net 11 bytes. Follow-up to #1187.