### PR TITLE
values: read back the separator the printer drops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -475,6 +475,12 @@ to lose a whole rule over one bad piece. Both are gone.
   `;` before the sibling that follows. Both printed CSS browsers and cascade's
   own reader reject, losing the block or running two declarations together
   (#319, #370)
+- A relative colour's channel list reads back as the sheet it was printed from.
+  `rgb(from #639 20% g b)` minifies to `rgb(from #639 20%g b)`, which CSS Syntax
+  3 sec. 4.3.3 reads as the same two channels, but the reader kept the tighter
+  spelling as a value of its own, so the sheet did not survive its own emission.
+  A `rotate` axis after a `var()` angle drops the separator the `)` already
+  provides (#1189)
 - A `calc()` printed without `--minify` keeps the parentheses the author wrote,
   redundant ones included, while `--minify` removes those and keeps a
   precedence-sensitive `calc((1px - var(--a)) * 3)` (#721)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -965,14 +965,15 @@ let rec pp_rotate_value : rotate_value Pp.t =
   | Axis (x, y, z, a) ->
       (* CSS Transforms 2 sec. 5 [rotate] [<angle> <number>{3}] is shorter under
          minify when the angle leads (csso convention) and a following number
-         drops the separator if it starts with a sign. The first number keeps
-         it: the angle ends in its unit, so [0deg-1] is the one dimension
-         [0deg-1] rather than an angle and a number. *)
+         drops the separator if it starts with a sign. The boundary after the
+         angle is [token_sp]'s to judge: an angle ending in its unit is an ident
+         sequence a [-] continues, so [0deg-1] would be the one dimension
+         [0deg-1], while one ending in [)] delimits itself. *)
       let pp_sep ctx (next : float) =
         if Pp.minified ctx && next < 0. then () else Pp.space ctx ()
       in
       pp_required_unit_angle ctx a;
-      Pp.space ctx ();
+      Pp.token_sp ctx ();
       Pp.float ctx x;
       pp_sep ctx y;
       Pp.float ctx y;

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -2694,6 +2694,21 @@ let relative_color_space_elidable body i =
         || (next >= 'a' && next <= 'z')
     | _ -> false
 
+(* The reading [relative_color_space_elidable] owes. Where the printer drops a
+   separator the reader has to put one back, or one channel list written the two
+   ways it may be written is two tails that print alike: CSS Syntax 3 (ED) sec.
+   4.3.3 ends a percentage at its [%] and sec. 4.3.5 ends a block at its [)], so
+   [20%g] carries the channels [20%] and [g] exactly as [20% g] does. The two
+   answers have to name the same positions or a tail stops round-tripping. *)
+let relative_color_splits_tokens prev body i =
+  match prev with
+  | '%' ->
+      body_starts_number body i
+      || (body.[i] >= 'A' && body.[i] <= 'Z')
+      || (body.[i] >= 'a' && body.[i] <= 'z')
+  | ')' -> body_starts_number body i || body.[i] = '.'
+  | _ -> false
+
 let minify_relative_color_spaces body =
   let len = String.length body in
   let buf = Buffer.create len in
@@ -7203,6 +7218,12 @@ let normalize_relative_color_tail tail =
           loop (skip_spaces (i + 1)) false
       | c ->
           add_pending_space buf last_was_space;
+          if
+            Buffer.length buf > 0
+            && relative_color_splits_tokens
+                 (Buffer.nth buf (Buffer.length buf - 1))
+                 tail i
+          then Buffer.add_char buf ' ';
           Buffer.add_char buf c;
           loop (i + 1) false
   in

--- a/test/helpers/css_test_helpers.ml
+++ b/test/helpers/css_test_helpers.ml
@@ -144,6 +144,40 @@ let decl_lossless ~prop ~into input =
         |> String.trim)
   | Error _ -> Alcotest.failf "parse failed: %s" (wrap input)
 
+let statements_of name css =
+  match Css.of_string ~strict:false css with
+  | Ok p -> Css.statements p.stylesheet
+  | Error e ->
+      Alcotest.failf "%s: %s does not read: %s" name css (Error.to_string e)
+
+(** [minify_reads_back name ~expected source] checks the minified spelling and
+    then re-reads it. Comparing statements rather than the text a second pass
+    prints: an elided separator can turn one construct into another that then
+    prints back byte for byte for ever. *)
+let minify_reads_back name ~expected source =
+  let printed =
+    match Css.of_string ~strict:false source with
+    | Ok p -> p.stylesheet
+    | Error e ->
+        Alcotest.failf "%s: %s does not read: %s" name source
+          (Error.to_string e)
+  in
+  Alcotest.(check string) name expected (Css.to_string ~minify:true printed);
+  let back = statements_of name expected in
+  if not (List.equal Css.equal_statement (Css.statements printed) back) then
+    Alcotest.failf "%s: %s re-reads as another sheet\n  printed: %s" name
+      expected
+      (Css.to_string (Css.v back))
+
+(** [sheets_agree name a b] checks that two spellings of one sheet are one
+    value. *)
+let sheets_agree name a b =
+  if
+    not
+      (List.equal Css.equal_statement (statements_of name a)
+         (statements_of name b))
+  then Alcotest.failf "%s: %s and %s read as different values" name a b
+
 (** Generic check function for CSS value types. [expected] is a spec oracle, not
     a snapshot of current implementation behavior. *)
 let check_value type_name reader pp_func ?(minify = true) ?(roundtrip = false)

--- a/test/helpers/css_test_helpers.mli
+++ b/test/helpers/css_test_helpers.mli
@@ -87,6 +87,21 @@ val decl_lossless : prop:string -> into:string -> string -> unit
 (** [decl_lossless ~prop ~into input] checks the minify+optimize path with
     bounded approximation disabled on both optimization and printing. *)
 
+val minify_reads_back : string -> expected:string -> string -> unit
+(** [minify_reads_back name ~expected source] checks that [source] minifies to
+    [expected] and that re-reading [expected] gives back the statements [source]
+    parsed to.
+
+    Comparing the text a second pass prints is weaker: CSS Syntax 3 (ED) sec. 4
+    tokenises greedily, so an elided separator can turn one construct into
+    another that prints back byte for byte for ever - [@scope to (.a)] minified
+    to [@scopeto (.a)] is a stable unknown at-rule. *)
+
+val sheets_agree : string -> string -> string -> unit
+(** [sheets_agree name a b] checks that two spellings of one sheet parse to the
+    same statements. Use it where the two differ only in whitespace a grammar
+    allows but does not require. *)
+
 val check_parse_error_fields :
   string -> Reader.parse_error -> Reader.parse_error -> unit
 (** [check_parse_error_fields name expected actual] compares message and got

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -7416,6 +7416,85 @@ let test_calc_sum_shortest_spelling () =
   shortest ~into:"calc(10% - 5vw)" "calc(-5vw + 10%)";
   shortest ~into:"calc(5vw - 10%)" "calc(-10% + 5vw)"
 
+(* CSS Syntax 3 (ED) sec. 4.2 makes [-] an ident code point and sec. 4.3.4 has a
+   dimension's unit consume an ident sequence, so [0deg-1] is the single
+   dimension [0deg-1] and the separator in front of a signed number is mandatory
+   after an angle. Only a number ends where one may follow it unseparated: sec.
+   4.3.12 stops consuming a number at a [-] no [e] or [.] precedes. A [)] ends
+   its block and separates from anything. *)
+let dimension_before_signed_number () =
+  minify_reads_back "rotate axis after a zero angle"
+    ~expected:"a{rotate:0deg -1 0 0}" "a { rotate: -1 0 0 0deg }";
+  minify_reads_back "rotate axis after an angle"
+    ~expected:"a{rotate:45deg 1-1-1}" "a { rotate: 1 -1 -1 45deg }";
+  minify_reads_back "rotate axis with an unsigned first component"
+    ~expected:"a{rotate:45deg 1 2-3}" "a { rotate: 1 2 -3 45deg }";
+  (* A [var()] angle ends on [)], which needs no separator after it. Only the
+     printed text is pinned: the reader takes the angle-first spelling of this
+     value as an opaque stream, so the emission does not carry the axis node
+     back either way. *)
+  check_declaration ~expected:"rotate:var(--a)1-1-1" "rotate:1 -1 -1 var(--a)";
+  minify_reads_back "scale number pair" ~expected:"a{scale:-1-2}"
+    "a { scale: -1 -2 }";
+  minify_reads_back "translate lengths" ~expected:"a{translate:1px -2px}"
+    "a { translate: 1px -2px }";
+  minify_reads_back "box-shadow lengths"
+    ~expected:"a{box-shadow:1px -2px 3px -4px red}"
+    "a { box-shadow: 1px -2px 3px -4px red }";
+  minify_reads_back "translate3d arguments"
+    ~expected:"a{transform:translate3d(1px,-2px,-3px)}"
+    "a { transform: translate3d(1px, -2px, -3px) }";
+  minify_reads_back "rotate3d arguments"
+    ~expected:"a{transform:rotate3d(1,-1,-1,45deg)}"
+    "a { transform: rotate3d(1, -1, -1, 45deg) }";
+  minify_reads_back "margin lengths" ~expected:"a{margin:-1px -2px}"
+    "a { margin: -1px -2px }"
+
+(* CSS Syntax 3 (ED) sec. 4.3.3 ends a percentage token at its [%] and sec.
+   4.3.5 ends a block at its [)], so neither can absorb what follows. CSS Color
+   5 sec. 4.1 gives each channel of a relative colour one component value, and
+   grammars are matched against tokens, so [20%g] carries the two channels [20%]
+   and [g] exactly as [20% g] does. The separator is droppable and the reader
+   owes the printer that reading. *)
+let relative_colour_channel_separator () =
+  minify_reads_back "percentage then keyword"
+    ~expected:"a{color:rgb(from #639 20%g b/alpha)}"
+    "a { color: rgb(from #639 20% g b / alpha) }";
+  minify_reads_back "keyword then percentage"
+    ~expected:"a{color:rgb(from #639 r 20%b/alpha)}"
+    "a { color: rgb(from #639 r 20% b / alpha) }";
+  minify_reads_back "percentage then number"
+    ~expected:"a{color:rgb(from #639 r 20%10)}"
+    "a { color: rgb(from #639 r 20% 10) }";
+  minify_reads_back "leading percentage then numbers"
+    ~expected:"a{color:rgb(from #639 0%10 10)}"
+    "a { color: rgb(from #639 0% 10 10) }";
+  minify_reads_back "math function then number"
+    ~expected:"a{color:rgb(from #639 r calc(g * 2)10)}"
+    "a { color: rgb(from #639 r calc(g * 2) 10) }"
+
+(* The same channel list is the same value in every relative colour function,
+   whichever of the two spellings the author wrote. *)
+let relative_colour_spellings_agree () =
+  sheets_agree "rgb" "a{color:rgb(from #639 20% g b)}"
+    "a{color:rgb(from #639 20%g b)}";
+  sheets_agree "hsl" "a{color:hsl(from #639 20% s l)}"
+    "a{color:hsl(from #639 20%s l)}";
+  sheets_agree "hwb" "a{color:hwb(from #639 20% w b)}"
+    "a{color:hwb(from #639 20%w b)}";
+  sheets_agree "lab" "a{color:lab(from #639 20% a b)}"
+    "a{color:lab(from #639 20%a b)}";
+  sheets_agree "lch" "a{color:lch(from #639 20% c h)}"
+    "a{color:lch(from #639 20%c h)}";
+  sheets_agree "oklab" "a{color:oklab(from #639 20% a b)}"
+    "a{color:oklab(from #639 20%a b)}";
+  sheets_agree "oklch" "a{color:oklch(from #639 20% c h)}"
+    "a{color:oklch(from #639 20%c h)}";
+  sheets_agree "color" "a{color:color(from #639 srgb 20% g b)}"
+    "a{color:color(from #639 srgb 20%g b)}";
+  sheets_agree "alpha slash" "a{color:rgb(from #639 r g b / alpha)}"
+    "a{color:rgb(from #639 r g b/alpha)}"
+
 let declaration_tests =
   [
     (* Core declaration type testing *)
@@ -7622,6 +7701,12 @@ let declaration_tests =
     test_case "property name case" `Quick property_case;
     test_case "special cases" `Quick special_cases;
     test_case "edge cases" `Quick edge_cases;
+    test_case "dimension before a signed number" `Quick
+      dimension_before_signed_number;
+    test_case "relative colour channel separator" `Quick
+      relative_colour_channel_separator;
+    test_case "relative colour spellings agree" `Quick
+      relative_colour_spellings_agree;
   ]
 
 let suite = ("declaration", declaration_tests)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4259,6 +4259,48 @@ let spec_current_at_rules () =
     "@container () { .x { color: red } }";
   neg_cursor read "@page : { margin: 1cm }"
 
+(* CSS Syntax 3 (ED) sec. 4.3.1 consumes an ident sequence into the at-keyword,
+   so the space in front of an ident prelude is the only thing naming the rule:
+   [@scope to (...)] printed as [@scopeto (...)] is a different at-rule, and one
+   every browser drops. A [(] and a [)] each end their token, so a prelude that
+   opens or closes on one needs no separator; sec. 4.3.4 turns [to(] into a
+   function token, so [to] keeps the space after it either way. *)
+let at_keyword_prelude_separator () =
+  minify_reads_back "scope end only"
+    ~expected:"@scope to (.content>*){a{color:red}}"
+    "@scope to (.content > *) { a { color: red } }";
+  minify_reads_back "scope start and end"
+    ~expected:"@scope(.card)to (.footer){a{color:red}}"
+    "@scope (.card) to (.footer) { a { color: red } }";
+  minify_reads_back "scope start only" ~expected:"@scope(.card){a{color:red}}"
+    "@scope (.card) { a { color: red } }";
+  minify_reads_back "scope with neither" ~expected:"@scope{a{color:red}}"
+    "@scope { a { color: red } }";
+  minify_reads_back "media type" ~expected:"@media screen{a{color:red}}"
+    "@media screen { a { color: red } }";
+  minify_reads_back "media not" ~expected:"@media not all{a{color:red}}"
+    "@media not all { a { color: red } }";
+  minify_reads_back "supports not"
+    ~expected:"@supports not (display:grid){a{color:red}}"
+    "@supports not (display: grid) { a { color: red } }";
+  minify_reads_back "supports selector"
+    ~expected:"@supports selector(a){a{color:red}}"
+    "@supports selector(a) { a { color: red } }";
+  minify_reads_back "container name"
+    ~expected:"@container card (width>0px){a{color:red}}"
+    "@container card (width > 0px) { a { color: red } }";
+  minify_reads_back "container not"
+    ~expected:"@container not (width>0px){a{color:red}}"
+    "@container not (width > 0px) { a { color: red } }";
+  minify_reads_back "page name" ~expected:"@page toc{margin:1cm}"
+    "@page toc { margin: 1cm }";
+  minify_reads_back "layer name" ~expected:"@layer a{b{color:red}}"
+    "@layer a { b { color: red } }";
+  (* An unknown at-rule keeps its block byte for byte, so this source is written
+     minified: only the prelude separator is under test. *)
+  minify_reads_back "unknown at-rule" ~expected:"@foo bar{a{color:red}}"
+    "@foo bar{a{color:red}}"
+
 let font_palette_values_descriptor_matrix () =
   List.iter
     (fun (expected, input) -> check_stylesheet ~expected input)
@@ -10485,6 +10527,7 @@ let additional_tests =
       `Quick,
       custom_property_boundary );
     ("spec current-work at-rules", `Quick, spec_current_at_rules);
+    ("spec at-keyword prelude separator", `Quick, at_keyword_prelude_separator);
     ( "spec font-palette-values descriptor matrix",
       `Quick,
       font_palette_values_descriptor_matrix );


### PR DESCRIPTION
`rgb(from #639 20% g b)` minifies to `rgb(from #639 20%g b)`, which CSS Syntax 3 sec. 4.3.3 reads as the same two channels, but the reader only ever collapsed whitespace and never restored it, so the two spellings became two tails that print alike and the sheet did not survive its own emission. The reader now puts back exactly the separators `relative_color_space_elidable` drops.

The test commit was written by an earlier session on the parked `printer-required-separators` branch and is cherry-picked unchanged; it is what caught both this and the `rotate` separator. Follow-up to #1188.