### PR TITLE
animation: fold an all-initial shorthand onto none

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -619,8 +619,10 @@ to lose a whole rule over one bad piece. Both are gone.
   after. `a{width:1.0px}b{width:1px}` folds, and so do `flex-basis`,
   `column-width`, `size`, `initial-letter-wrap`, `background-size` and
   `mask-size`; a unit minifies lowercase whatever its case, so `width:10.0PX`
-  is `10px`; and `content:'x'` and `content:"x"` are one string (#1150, #1185,
-  #1186, #1187, #1188)
+  is `10px`; `content:'x'` and `content:"x"` are one string; and an `animation`
+  holding nothing but initials is the `animation:none` it prints as, so
+  `animation-range:normal` is dropped after either spelling rather than after
+  one of them (#1150, #1185, #1186, #1187, #1188, #1190)
 - `--minify` and `cascade diff` are faster on a large stylesheet, for
   byte-identical output. The slowest corpus stylesheet drops sharply, a long run
   of rules sharing one selector no longer allocates quadratically, a 4,000

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -2029,10 +2029,31 @@ let normalize_animation_shorthand ~ctx (a : animation_shorthand) :
   then a
   else { a with duration; timing_function; delay; iteration_count }
 
+(* [pp_animation_initial_none] writes [none] for a shorthand holding nothing but
+   initials, on the ground CSS Animations 1 (ED) sec. 4.9 gives: what such a
+   value declares is the eight initials, which is what [animation:none]
+   declares. Fold onto the constructor the printer names, or the two reach one
+   minified text through two nodes, which anything keyed on the node reads as
+   two values -- the pass dropping a reset-only longhand the shorthand already
+   covers included, so one declaration optimised two ways.
+
+   Only a name that is the keyword [none] folds. A quoted ["none"] names a
+   keyframes rule rather than the absent name, and the printer equates the two
+   under [--minify] alone, so folding it here would change what the unminified
+   round-trip says. *)
+let animation_is_all_initial (a : animation_shorthand) =
+  (not (Animation.has_non_defaults a))
+  &&
+  match a.name with
+  | Option.None | Option.Some (None : animation_name) -> true
+  | Option.Some _ -> false
+
 let normalize_animation ~ctx : animation -> animation = function
   | Shorthand a as value ->
       let a' = normalize_animation_shorthand ~ctx a in
-      if a' == a then value else Shorthand a'
+      if animation_is_all_initial a' then (None : animation)
+      else if a' == a then value
+      else Shorthand a'
   | value -> value
 
 let rec pp_animation : animation Pp.t =

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -6719,14 +6719,23 @@ let implied_longhand covering covered : Declaration.declaration option =
       (* Scroll-driven Animations 1 appendix A.3 and CSS Animations 2 sec. 4.12
          make the timeline and the two range ends reset-only sub-properties: the
          shorthand has no slot for a range, so it always writes [normal] there.
-         Single animation only; a comma list assigns per-item values. *)
-      match (value : Properties.animation list) with
-      | [ Properties.Shorthand s ] -> (
+         [animation:none] is the same assignment with every slot left at its
+         initial, so it implies the same longhands as the shorthand spelling of
+         it and a later one of them is as redundant. Single animation only; a
+         comma list assigns per-item values. *)
+      let timeline : Properties.animation_timeline option =
+        match (value : Properties.animation list) with
+        | [ Properties.Shorthand s ] ->
+            Some (Option.value s.timeline ~default:Properties.Auto)
+        | [ Properties.None ] -> Some Properties.Auto
+        | _ -> Option.none
+      in
+      match timeline with
+      | Option.None -> None
+      | Some timeline -> (
           match unwrap_theme_guard covered with
           | Declaration { property = Properties.Animation_timeline; _ } ->
-              Some
-                (Declaration.v Animation_timeline
-                   (Option.value s.timeline ~default:Properties.Auto))
+              Some (Declaration.v Animation_timeline timeline)
           | Declaration { property = Properties.Animation_range_start; _ } ->
               Some
                 (Declaration.v Animation_range_start
@@ -6739,8 +6748,7 @@ let implied_longhand covering covered : Declaration.declaration option =
               Some
                 (Declaration.v Animation_range
                    (Range (Normal, None) : Properties.animation_range))
-          | _ -> None)
-      | _ -> None)
+          | _ -> None))
   | Declaration { property = Properties.Font; value; _ } -> (
       (* [font] resets style/weight/stretch/line-height to [normal] unless set;
          font-variant uses a narrower type in the shorthand, so leave it. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6970,6 +6970,28 @@ let quoted_content_is_one_node () =
       ("a{content:'a\"b'}b{content:\"a\\\"b\"}", "a,b{content:\"a\\\"b\"}");
     ]
 
+(* CSS Animations 1 (ED) sec. 4.9: what an [animation] whose every slot holds
+   its initial declares is the eight initials, which is what [animation:none]
+   declares, and the printer writes [none] for both. The two stayed separate
+   nodes, so the same declaration optimised two ways: the reset-only longhands
+   the shorthand covers were dropped after one spelling and kept after the
+   other, which made the result depend on whether the sheet had been through
+   [fmt] on the way. *)
+let all_initial_animation_is_none () =
+  List.iter
+    (fun (css, minified_css) ->
+      Alcotest.(check string) css minified_css (minified css))
+    [
+      ("a{animation:normal}b{animation:none}", "a,b{animation:none}");
+      ("a{animation:none;animation-range:normal}", "a{animation:none}");
+      ("a{animation:none;animation-timeline:auto}", "a{animation:none}");
+      (* A slot that is not the initial keeps the shorthand it was written
+         in. *)
+      ("a{animation:reverse}", "a{animation:reverse}");
+      ( "a{animation:none;animation-range:1px}",
+        "a{animation:none;animation-range:1px}" );
+    ]
+
 let unfolded_lengths_are_one_value () =
   let case (property, merged) =
     let css =
@@ -7516,6 +7538,8 @@ let declaration_tests =
       uppercase_units_minify_lowercase;
     test_case "printed units are lowercase" `Quick printed_units_are_lowercase;
     test_case "quoted content is one node" `Quick quoted_content_is_one_node;
+    test_case "all-initial animation is none" `Quick
+      all_initial_animation_is_none;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;
     test_case "number spellings have one node" `Quick


### PR DESCRIPTION
An `animation` whose every slot holds its initial declares what `animation:none` declares, and the printer already wrote `none` for both, but the AST kept them apart. The pass that drops a reset-only longhand the shorthand covers read that node, so `a{animation:normal;animation-range:normal}` minified to `a{animation:none}` while `a{animation:none;animation-range:normal}` kept the longhand: the result turned on whether the sheet had been through `fmt` first.

Found by the readback oracle at seed 3, which the suite does not run. Follow-up to #1189.