### PR TITLE
bench: fail the corpus sweep on a fixture it cannot minify

### DIFF
--- a/bench/corpus_sweep.sh
+++ b/bench/corpus_sweep.sh
@@ -166,5 +166,10 @@ LC_ALL=C awk -F'\t' -v top="$TOP" -v ab="${BASELINE:+1}" '
       for (j = i + 1; j <= k; j++)
         if (time[order[j]] + 0 > time[order[i]] + 0) { t = order[i]; order[i] = order[j]; order[j] = t }
     for (i = 1; i <= k && i <= top; i++) printf "%8.2fs  %s\n", time[order[i]], order[i]
+    # A fixture cascade cannot minify is not a slow file, it is a hole in the
+    # gate: the sweep still prints totals, and a byte-identity A/B calls the
+    # pair identical because both binaries failed alike. One corrupted fixture
+    # went unnoticed for six days that way. Exit non-zero so it cannot.
+    if (nfail) exit 1
   }
 ' "$RESULTS"


### PR DESCRIPTION
The sweep printed `1 failed` in its summary and exited 0, so a fixture cascade refuses is one word in a line nobody reads. Under `-b` it is worse than silent: both binaries fail on the file alike, so it counts toward "byte-identical on every file" while proving nothing about the change under test.

`youtube-stripmq.css` in the local corpus had a copy of `lib/shorthand.ml` pasted into it from byte 10313 to EOF and had been failing since 3 September, so every sweep since covered 503 files rather than 504. The fixture is gitignored and generated, and restoring it is `git -C bench/satcss/scripts/.tool checkout -- benchmarks/`.

Tooling-only, so no changelog entry. Follow-up to #1191.