### PR TITLE
readback: ask the value comparator whether a twin is a twin

### DIFF
--- a/test/spec/readback/readback.ml
+++ b/test/spec/readback/readback.ml
@@ -156,6 +156,21 @@ let extended name =
 
 let drop_prefixed_twins decls =
   let value decl = Cascade.Declaration.string_of_value ~minify:true decl in
+  (* The twin is synthesised from the value the optimizer would write while the
+     authored declaration still carries the spelling the author chose, so the
+     pair can differ as text and name one value: [mask:ADD] beside a
+     [-webkit-mask:none] the synthesis produced, because [add] is
+     [mask-composite]'s initial. Comparing the text left that twin in place on
+     one side only, and the model then reported the prefix policy it exists to
+     erase. Ask the value-level comparator instead. The guard itself stays: a
+     twin carrying a genuinely different value is still a finding, and
+     [equivalent_value] is the same canonical question mode [`Canonical] asks of
+     a whole sheet. *)
+  let same_value decl other name =
+    String.equal (value other) (value decl)
+    || Cascade_diff.Css_compare.equivalent_value ~property:name (value other)
+         (value decl)
+  in
   let twinned decl name =
     List.exists
       (fun other ->
@@ -163,7 +178,7 @@ let drop_prefixed_twins decls =
         && Bool.equal
              (Cascade.Declaration.is_important other)
              (Cascade.Declaration.is_important decl)
-        && String.equal (value other) (value decl))
+        && same_value decl other name)
       decls
   in
   List.filter


### PR DESCRIPTION
The oracle reported `b{mask:ADD}` as UNEQUAL against its own emission. The prefix synthesis writes the value the optimizer would (`-webkit-mask:none`) while the authored declaration keeps what the author wrote (`mask:ADD`), so one value reached `drop_prefixed_twins` as two texts and the twin was erased on the emission side only. What the model then reported was the prefix policy it exists to erase.

The guard is unchanged in intent: a twin whose value genuinely differs is still a finding, and the new test is `text-equal || equivalent_value`, so it can only drop twins that are canonically one value. Seeds 0, 1 and 3 report nothing; seed 2 now reports a real `list-style` instability this was masking. Follow-up to #1192.