### PR TITLE
props: keep every slot of a shorthand carrying a var()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -492,6 +492,17 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Minification
 
+- A shorthand carrying a `var()` keeps every component the author wrote, where
+  `--minify` dropped one holding its initial: `list-style: disc outside
+  var(--x)` became `list-style: var(--x)` and `text-decoration: solid var(--x)`
+  became `text-decoration: var(--x)`. CSS Variables 1 sec. 3 syntax-checks such
+  a declaration only after substitution, so the drop changed what it means
+  rather than only how it is spelled. With `--x: circle` the first substitutes
+  to two `<list-style-type>` values and is invalid at computed-value time,
+  leaving the longhands unset, while the minified form substitutes to a valid
+  `circle` that sets the type, so a page using this pattern rendered
+  differently. Re-run any minified output that puts a `var()` in one of these
+  two shorthands (#1194)
 - `--minify` writes a `calc()` it unwraps as the leaf it became, so
   `transition-duration: calc(120ms)` is `.12s` and not the `120ms` an operand is
   spelled, and `animation: calc(1)` is the `none` the bare `1` already gave.

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -801,10 +801,29 @@ let normalize_hyphenate_limit_chars ~ctx :
       if a' == a && b' == b && c' == c then value else Three (a', b', c')
   | other -> other
 
+(* CSS Variables 1 sec. 3 syntax-checks a shorthand carrying a [var()] only
+   after substitution, so which slot the substituted tokens fill is unknown
+   until computed-value time and a slot holding its initial is not spare.
+   [text-decoration: solid var(--x)] with [--x: dotted] substitutes to two
+   [<text-decoration-style>] values and is invalid at computed-value time,
+   leaving the longhands unset, where dropping the [solid] leaves
+   [text-decoration: var(--x)], which substitutes to a valid [dotted] and sets
+   the style. *)
+let text_decoration_slot_is_var (s : text_decoration_shorthand) =
+  List.exists
+    (function (Var _ : text_decoration_line) -> true | _ -> false)
+    s.lines
+  || (match s.style with
+    | Some (Var _ : text_decoration_style) -> true
+    | _ -> false)
+  || (match s.color with Some (Values.Var _) -> true | _ -> false)
+  || match s.thickness with Some (Values.Var _) -> true | _ -> false
+
 let normalize_text_decoration ?(lossless = false) :
     text_decoration -> text_decoration =
  fun value ->
   match value with
+  | Shorthand s when text_decoration_slot_is_var s -> value
   | Shorthand s -> (
       let style =
         drop_default

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -199,25 +199,44 @@ let pp_list_style_shorthand : list_style_shorthand Pp.t =
    shorthand takes its longhand initial - [outside] (sec. 3.5), [none] (sec.
    3.3) and [disc] (sec. 3.4). Writing an initial out names what leaving it out
    names, and leaving it out is the shorter spelling. *)
+(* CSS Variables 1 sec. 3 syntax-checks a shorthand carrying a [var()] only
+   after substitution, so which slot the substituted tokens fill is not known
+   until computed-value time and a slot holding its initial is not spare. The
+   reasoning above holds for a value with no [var()] in it and fails here:
+   [list-style: disc outside var(--x)] with [--x: circle] substitutes to two
+   [<list-style-type>] values and is invalid at computed-value time, leaving the
+   longhands unset, where dropping the initials leaves [list-style: var(--x)],
+   which substitutes to a valid [circle] and sets the type. Reordering stays
+   sound -- CSS Lists 3 sec. 2 spells the shorthand with [||], so its components
+   commute -- but nothing may leave. *)
+let list_style_slot_is_var (s : list_style_shorthand) =
+  (match s.type_ with Some (Var _ : list_style_type) -> true | _ -> false)
+  || (match s.position with
+    | Some (Var _ : list_style_position) -> true
+    | _ -> false)
+  || match s.image with Some (Var _ : list_style_image) -> true | _ -> false
+
 let normalize_list_style_shorthand (s : list_style_shorthand) :
     list_style_shorthand =
-  let type_ =
-    drop_default ~is_default:(fun (t : list_style_type) -> t = Disc) s.type_
-  in
-  let position =
-    drop_default
-      ~is_default:(fun (p : list_style_position) -> p = Outside)
-      s.position
-  in
-  let image =
-    drop_default ~is_default:(fun (i : list_style_image) -> i = None) s.image
-  in
-  if
-    option_is_phys_same type_ s.type_
-    && option_is_phys_same position s.position
-    && option_is_phys_same image s.image
-  then s
-  else { type_; position; image }
+  if list_style_slot_is_var s then s
+  else
+    let type_ =
+      drop_default ~is_default:(fun (t : list_style_type) -> t = Disc) s.type_
+    in
+    let position =
+      drop_default
+        ~is_default:(fun (p : list_style_position) -> p = Outside)
+        s.position
+    in
+    let image =
+      drop_default ~is_default:(fun (i : list_style_image) -> i = None) s.image
+    in
+    if
+      option_is_phys_same type_ s.type_
+      && option_is_phys_same position s.position
+      && option_is_phys_same image s.image
+    then s
+    else { type_; position; image }
 
 let normalize_list_style : list_style -> list_style = function
   | Shorthand s as value ->

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6917,6 +6917,41 @@ let sole_declaration css =
 let minified css =
   Css.to_string ~minify:true (Css.optimize (Css.of_string_exn css))
 
+(* CSS Variables 1 sec. 3 makes a shorthand carrying a [var()] a
+   pending-substitution value: it is syntax-checked only after substitution, and
+   which slot the substituted tokens fill is not known before then. So a slot
+   holding its initial is not spare there, and dropping it changes what the
+   declaration means. [list-style: disc outside var(--x)] with [--x: circle]
+   substitutes to [disc outside circle], two [<list-style-type>] values, which
+   is invalid at computed-value time and leaves the longhands unset; dropping
+   the initials leaves [list-style: var(--x)], which substitutes to the valid
+   [circle] and sets the type. Every component the author wrote has to survive
+   once a [var()] is in the value. The order may change: sec. 2 of CSS Lists 3
+   spells the shorthand with [||], so the components commute. *)
+let var_shorthand_keeps_every_slot () =
+  let case (css, parts) =
+    let out = minified css in
+    List.iter
+      (fun part ->
+        Alcotest.(check bool)
+          (String.concat "" [ css; " keeps "; part ])
+          true
+          (Astring.String.is_infix ~affix:part out))
+      parts
+  in
+  List.iter case
+    [
+      ("a{list-style:disc outside var(--x)}", [ "disc"; "outside"; "var(--x)" ]);
+      ( "a{list-style:url(marker.png) outside var(--x)}",
+        [ "url(marker.png)"; "outside"; "var(--x)" ] );
+      (* [text-decoration] reaches the same drop through its own normaliser:
+         [solid] is [text-decoration-style]'s initial, and [--x: dotted] makes
+         the substituted value two styles rather than one. *)
+      ("a{text-decoration:solid var(--x)}", [ "solid"; "var(--x)" ]);
+      ( "a{text-decoration:underline solid var(--x)}",
+        [ "underline"; "solid"; "var(--x)" ] );
+    ]
+
 (* A [<length>] reaches [flex-basis] through the property's own mirror of the
    length variants, and that mirror's normaliser folds only a zero and a
    [calc()]. So [10.0px] stayed the dimension the reader built while [10px] was
@@ -7549,6 +7584,8 @@ let declaration_tests =
     test_case "uppercase units minify lowercase" `Quick
       uppercase_units_minify_lowercase;
     test_case "printed units are lowercase" `Quick printed_units_are_lowercase;
+    test_case "a var shorthand keeps every slot" `Quick
+      var_shorthand_keeps_every_slot;
     test_case "quoted content is one node" `Quick quoted_content_is_one_node;
     test_case "all-initial animation is none" `Quick
       all_initial_animation_is_none;


### PR DESCRIPTION
`list-style: disc outside var(--x)` minified to `list-style: var(--x)`, and `text-decoration: solid var(--x)` to `text-decoration: var(--x)`. CSS Variables 1 sec. 3 syntax-checks a shorthand containing `var()` only after substitution, so which slot the substituted tokens fill is unknown until computed-value time and a slot holding its initial is not spare. With `--x: circle` the authored value substitutes to two `<list-style-type>` values and is invalid at computed-value time, leaving the longhands unset, while the minified form substitutes to a valid `circle` that sets the type: a page using the pattern rendered differently.

Reordering is untouched, since both shorthands are spelled with `||` and their components commute. The 504-file corpus is byte-identical, so this only bites where a `var()` sits in one of these two shorthands. Found by the readback oracle at seed 2, once #1193 stopped masking it. Follow-up to #1193.