### PR TITLE
diff: fold a legacy name alias into its unprefixed twin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -696,6 +696,16 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Canonical diff
 
+- `--diff=canonical` reads a prefixed declaration the WHATWG Compatibility
+  Standard section 3.4.1 names a legacy name alias as the same property as its
+  unprefixed twin, so an identical pair normalizes to the twin alone:
+  `a{-webkit-transform:none;transform:none}` and `a{transform:none}` compare
+  equal, and so do the other 57 properties on that list. Only
+  `-webkit-text-decoration-color` did, which is not on the list at all. A prefix
+  the section does not name stays a property of its own, `-moz-` spellings and
+  `-webkit-user-select` among them, as does a differing value or importance. A
+  check comparing a sheet against a minified form that dropped or synthesised
+  one of those aliases changes answer (#1200)
 - A browser-backed sweep checks the guarantee itself: every pair
   `--diff=canonical` reports identical is rendered in headless Chrome and every
   computed-style difference is a conflation

--- a/README.md
+++ b/README.md
@@ -175,9 +175,16 @@ gate that treated 2 as 0 would pass while the files differ. The report and the
   compare equal, since none of those moves can change a computed value.
   Cascade-significant order is kept distinct (two writes of the same
   property, a shorthand and its longhand, a load-bearing vendor-prefixed
-  fallback, `@layer` blocks). An identical
-  `-webkit-text-decoration-color`/`text-decoration-color` twin is normalized
-  away; a differing or prefixed-only declaration remains distinct. Equivalent
+  fallback, `@layer` blocks). A prefixed
+  declaration the [WHATWG Compatibility Standard](https://compat.spec.whatwg.org/#css-legacy-name-aliases)
+  section 3.4.1 names a legacy name alias is the same property as its
+  unprefixed twin, so an identical pair of them normalizes to the twin alone,
+  `-webkit-transform`/`transform` and the rest of that list. A prefix the
+  section does not name is a property of its own, `-moz-` spellings and
+  `-webkit-user-select` among them, and stays distinct; so does a differing
+  value or importance, or a prefix with no unprefixed twin.
+  `-webkit-text-decoration-color` is not on the list but every engine shipping
+  the prefix aliases it, and Cascade normalizes it too. Equivalent
   shorthand decompositions are still not modelled.
   Numeric arithmetic follows the same precision mode as minification: an exact
   quotient such as `calc(28/14)` compares equal to `2` in either mode. By

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -6460,14 +6460,103 @@ let vendor_alias_twin vendor twin =
       || vendor_alias_twin_flex vendor twin
       || vendor_alias_twin_visual vendor twin
 
-(* Canonical comparison follows Cascade's configured normalization for this
-   typed compatibility alias without enabling every target-dependent optimizer
-   rewrite. A differing fallback, mismatched importance, or prefix without a
-   standard twin remains observable and is kept. *)
+(* WHATWG Compatibility Standard sec. 3.4.1: these [-webkit-] properties "must
+   be supported as legacy name aliases of the corresponding unprefixed
+   property", and CSS Cascade 5 sec. 2.3 makes a legacy name alias the SAME
+   property under a second name rather than a property of its own. A prefix the
+   list does not name is a private extension in the vendor's namespace, so it is
+   its own property and never an alias -- [-moz-] spellings and
+   [-webkit-user-select] among them. *)
+let legacy_name_alias_of = function
+  | "-webkit-align-content" -> Some "align-content"
+  | "-webkit-align-items" -> Some "align-items"
+  | "-webkit-align-self" -> Some "align-self"
+  | "-webkit-animation" -> Some "animation"
+  | "-webkit-animation-delay" -> Some "animation-delay"
+  | "-webkit-animation-direction" -> Some "animation-direction"
+  | "-webkit-animation-duration" -> Some "animation-duration"
+  | "-webkit-animation-fill-mode" -> Some "animation-fill-mode"
+  | "-webkit-animation-iteration-count" -> Some "animation-iteration-count"
+  | "-webkit-animation-name" -> Some "animation-name"
+  | "-webkit-animation-play-state" -> Some "animation-play-state"
+  | "-webkit-animation-timing-function" -> Some "animation-timing-function"
+  | "-webkit-backface-visibility" -> Some "backface-visibility"
+  | "-webkit-background-clip" -> Some "background-clip"
+  | "-webkit-background-origin" -> Some "background-origin"
+  | "-webkit-background-size" -> Some "background-size"
+  | "-webkit-border-bottom-left-radius" -> Some "border-bottom-left-radius"
+  | "-webkit-border-bottom-right-radius" -> Some "border-bottom-right-radius"
+  | "-webkit-border-radius" -> Some "border-radius"
+  | "-webkit-border-top-left-radius" -> Some "border-top-left-radius"
+  | "-webkit-border-top-right-radius" -> Some "border-top-right-radius"
+  | "-webkit-box-shadow" -> Some "box-shadow"
+  | "-webkit-box-sizing" -> Some "box-sizing"
+  | "-webkit-filter" -> Some "filter"
+  | "-webkit-flex" -> Some "flex"
+  | "-webkit-flex-basis" -> Some "flex-basis"
+  | "-webkit-flex-direction" -> Some "flex-direction"
+  | "-webkit-flex-flow" -> Some "flex-flow"
+  | "-webkit-flex-grow" -> Some "flex-grow"
+  | "-webkit-flex-shrink" -> Some "flex-shrink"
+  | "-webkit-flex-wrap" -> Some "flex-wrap"
+  | "-webkit-justify-content" -> Some "justify-content"
+  | "-webkit-mask" -> Some "mask"
+  | "-webkit-mask-box-image" -> Some "mask-border"
+  | "-webkit-mask-box-image-outset" -> Some "mask-border-outset"
+  | "-webkit-mask-box-image-repeat" -> Some "mask-border-repeat"
+  | "-webkit-mask-box-image-slice" -> Some "mask-border-slice"
+  | "-webkit-mask-box-image-source" -> Some "mask-border-source"
+  | "-webkit-mask-box-image-width" -> Some "mask-border-width"
+  | "-webkit-mask-clip" -> Some "mask-clip"
+  | "-webkit-mask-composite" -> Some "mask-composite"
+  | "-webkit-mask-image" -> Some "mask-image"
+  | "-webkit-mask-origin" -> Some "mask-origin"
+  | "-webkit-mask-position" -> Some "mask-position"
+  | "-webkit-mask-repeat" -> Some "mask-repeat"
+  | "-webkit-mask-size" -> Some "mask-size"
+  | "-webkit-order" -> Some "order"
+  | "-webkit-perspective" -> Some "perspective"
+  | "-webkit-perspective-origin" -> Some "perspective-origin"
+  | "-webkit-transform" -> Some "transform"
+  | "-webkit-transform-origin" -> Some "transform-origin"
+  | "-webkit-transform-style" -> Some "transform-style"
+  | "-webkit-transition" -> Some "transition"
+  | "-webkit-transition-delay" -> Some "transition-delay"
+  | "-webkit-transition-duration" -> Some "transition-duration"
+  | "-webkit-transition-property" -> Some "transition-property"
+  | "-webkit-transition-timing-function" -> Some "transition-timing-function"
+  | _ -> None
+
+(* One property written twice with one value says what writing it once says, so
+   the alias and its twin compare as the twin alone. This assumes nothing about
+   which browsers are targeted -- the two names ARE one property -- so it holds
+   where the target-dependent prefix drops do not. A differing value or
+   importance is two writes of one property and stays. *)
+let legacy_name_alias_twin vendor twin =
+  match legacy_name_alias_of (Declaration.property_name vendor) with
+  | None -> false
+  | Some unprefixed ->
+      String.equal unprefixed (Declaration.property_name twin)
+      && same_value_text vendor twin
+      && Bool.equal
+           (Declaration.is_important vendor)
+           (Declaration.is_important twin)
+
+(* Canonical comparison follows the aliasing the specs prove on their own,
+   without enabling every target-dependent optimizer rewrite. Sec. 3.4.1 above
+   settles the [-webkit-] list; [-webkit-text-decoration-color] is not on it but
+   every engine that ships the prefix aliases it, and Cascade normalizes it
+   whatever the target. A differing fallback, mismatched importance, or prefix
+   without a standard twin remains observable and is kept. *)
 let drop_redundant_decoration_color_aliases declarations =
   filter_preserve
     (fun declaration ->
-      not (List.exists (decoration_color_alias_twin declaration) declarations))
+      not
+        (List.exists
+           (fun twin ->
+             decoration_color_alias_twin declaration twin
+             || legacy_name_alias_twin declaration twin)
+           declarations))
     declarations
 
 (* If [name] starts with a CSS vendor prefix ([-webkit-] / [-moz-] / [-ms-] /

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -138,12 +138,15 @@ let canonical_keeps_target_gated_content () =
     "so do they with the guard written at the top level" false
     (equal ".a{color:red}@supports (display:grid){.a{color:blue}}"
        ".a{color:green}@supports (display:grid){.a{color:blue}}");
-  (* A vendor-prefixed declaration is the only one an engine that needs the
-     prefix reads, so dropping it is not dropping a spelling. *)
+  (* A vendor-prefixed declaration the WHATWG Compatibility Standard sec. 3.4.1
+     does not name is a private extension in the vendor's namespace and the only
+     declaration an engine that reads it sees, so dropping it is not dropping a
+     spelling. A prefix the section DOES name is the same property as its twin
+     and folds; [canonical_legacy_name_alias] covers that side. *)
   Alcotest.(check bool)
-    "a vendor-prefixed twin is not nothing" false
-    (equal ".a{-webkit-transition:all 1s;transition:all 1s}"
-       ".a{transition:all 1s}");
+    "an unlisted vendor-prefixed twin is not nothing" false
+    (equal ".a{-webkit-user-select:none;user-select:none}"
+       ".a{user-select:none}");
   (* CSS Cascade 5 sec. 3.1: [supports()] on an [@import] decides whether the
      sheet loads at all. *)
   Alcotest.(check bool)
@@ -443,6 +446,46 @@ let canonical_supports_hoisting () =
         lab,red,red)){.a{--x:blue}}"
        ".a{--x:red}@supports (color:color-mix(in \
         lab,red,red)){.a{--x:blue}}.a{color:var(--x)}")
+
+(* WHATWG Compatibility Standard sec. 3.4.1 lists the [-webkit-] properties that
+   "must be supported as legacy name aliases of the corresponding unprefixed
+   property", and CSS Cascade 5 sec. 2.3 makes a legacy name alias the SAME
+   property under a second name. So a listed prefixed declaration and its
+   unprefixed twin carrying one value declare that property twice with that
+   value, which is what declaring it once says: the pair compares equal to the
+   twin alone, whatever engine reads it. Nothing about a browser target is
+   assumed, so this holds under [~enforce_spec:true] too.
+
+   A prefix the list does NOT name is a private extension in the vendor's own
+   namespace and a property of its own, so it stays distinct however its value
+   reads. A differing value or importance is two writes of one property and
+   stays distinct as well. *)
+let canonical_legacy_name_alias () =
+  let case label expected a b =
+    Alcotest.(check bool)
+      label expected
+      (Cascade_diff.Css_compare.equal ~mode:`Canonical a b)
+  in
+  case "a listed alias with one value is the twin alone" true
+    "a{-webkit-transform:none;transform:none}" "a{transform:none}";
+  case "the listed alias holds for box-shadow" true
+    "a{-webkit-box-shadow:1px 1px red;box-shadow:1px 1px red}"
+    "a{box-shadow:1px 1px red}";
+  case "the listed alias holds for flex-wrap" true
+    "a{-webkit-flex-wrap:wrap;flex-wrap:wrap}" "a{flex-wrap:wrap}";
+  case "the listed alias holds for animation-delay" true
+    "a{-webkit-animation-delay:1s;animation-delay:1s}" "a{animation-delay:1s}";
+  case "a differing value is two writes of one property" false
+    "a{-webkit-transform:none;transform:scale(2)}" "a{transform:scale(2)}";
+  case "a listed alias alone is not the unprefixed property dropped" false
+    "a{-webkit-transform:none}" "a{}";
+  (* [-moz-] prefixes are named nowhere in the list, and neither is
+     [-webkit-user-select]: each is its own property. *)
+  case "an unlisted -moz- prefix stays distinct" false
+    "a{-moz-box-sizing:border-box;box-sizing:border-box}"
+    "a{box-sizing:border-box}";
+  case "an unlisted -webkit- prefix stays distinct" false
+    "a{-webkit-user-select:none;user-select:none}" "a{user-select:none}"
 
 (* CSS Variables 1 secs. 2 and 3 make a custom property an ordinary cascade slot
    and substitute its computed value into the property containing [var()]. A
@@ -1941,6 +1984,8 @@ let suite =
         `Quick canonical_declaration_after_nested_rule;
       Alcotest.test_case "canonical supports hoisting" `Quick
         canonical_supports_hoisting;
+      Alcotest.test_case "canonical legacy name alias" `Quick
+        canonical_legacy_name_alias;
       Alcotest.test_case "canonical var reader crosses guarded writer" `Quick
         canonical_var_reader_crosses_guarded_writer;
       Alcotest.test_case "canonical keeps custom-property importance" `Quick


### PR DESCRIPTION
The canonical projection normalized exactly one prefixed declaration, `-webkit-text-decoration-color`, which the WHATWG Compatibility Standard does not name at all — and kept distinct the 58 properties [section 3.4.1](https://compat.spec.whatwg.org/#css-legacy-name-aliases) requires be supported as legacy name aliases. CSS Cascade 5 section 2.3 makes such an alias the same property under a second name, so `a{-webkit-transform:none;transform:none}` writes one property twice with one value and compares as `a{transform:none}`.

That follows from the two specifications rather than from a browser target, so it holds under `~enforce_spec:true` where the target-dependent prefix drops deliberately do not. A prefix section 3.4.1 does not name stays a property of its own, `-moz-` spellings and `-webkit-user-select` among them, as does a differing value or importance.

The README stated the old rule as though it were general and now states this one. A pre-existing test argued its case from `-webkit-transition`, a listed alias; its point holds for a private extension, so it moves to `-webkit-user-select`.