### PR TITLE
test: pin that one nth parity overlaps itself

### DIFF
--- a/test/test_selector_summary.ml
+++ b/test/test_selector_summary.ml
@@ -137,6 +137,17 @@ let child_positions () =
     ":nth-child(3)";
   check_overlap "odd and even nth child are disjoint" false ":nth-child(odd)"
     ":nth-child(even)";
+  (* One parity against itself is one set of elements, not two, however the two
+     sides spell it. Selectors 4 sec. 9.3 reads [odd] as [2n+1] and [even] as
+     [2n], so proving these disjoint would let a rewrite cross a dependency the
+     DOM really has: every element either side matches, the other matches
+     too. *)
+  check_overlap "one parity spelled two ways may overlap" true ":nth-child(odd)"
+    ":nth-child(2n+1)";
+  check_overlap "one parity spelled two ways may overlap, even" true
+    ":nth-child(even)" ":nth-child(2n)";
+  check_overlap "a parity against itself may overlap" true ":nth-child(odd)"
+    ":nth-child(odd)";
   check_overlap "first-child can overlap last-child on an only child" true
     ":first-child" ":last-child";
   check_overlap "nth fact conflicts with matching not nth" false ":nth-child(2)"


### PR DESCRIPTION
`Selector_summary.may_overlap` is the hard disjointness claim the optimizer's dependency checks rest on: a `false` lets a rewrite cross a dependency. It was tested for one parity against the other, against an index, and against `:first-child` — but never against itself, which is the case that must answer "may overlap", since Selectors 4 section 9.3 reads `odd` as `2n+1` and `even` as `2n`.

A mutation making `nth_disjoint` answer *disjoint* for `Odd, Odd` survived the whole suite, and it is not harmless. On `github-stripmq-csso.css` it silently deletes a rule:

    table.capped-list tr:nth-child(2n){background-color:#fcfcfc}

Declaring `Even` disjoint from `Even` convinces the optimizer that rule can collide with nothing, so it drops it as dead — the table's zebra striping disappears. Output shrinks 25 bytes and `--diff=canonical` reports the two forms are not equivalent. That is exactly the failure mode the backlog records from the head-only experiment: output moves, the suite stays green, and only a corpus diff notices.

Found by the first mutation campaign over `lib/selector_summary.ml` (20 mutants, 13 killed). Test-only, so no changelog entry.