### PR TITLE
test: read a rule's conflict from any contending pair

### DIFF
--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -343,6 +343,22 @@ let test_rules_conflict_declarations () =
       ( "two shorthands sharing no longhand",
         ".a{margin:1px}.a{padding:2px}",
         false );
+      (* Every case above writes one declaration a side, where "some pair
+         contends" and "every pair contends" are the same question. A rule
+         carrying more than one declaration separates them: [color] contends
+         with [color] and [margin] shares no slot with it, and the element still
+         computes a different colour once the two swap, so one contending pair
+         is the whole answer. Reading it as "every pair" understates the
+         conflict, and [merge_distant_media] acts on [false] by hoisting the
+         later block over this rule. *)
+      ( "a contending declaration beside one that shares no slot",
+        ".a{color:red}.a{color:blue;margin:1px}",
+        true );
+      (* The same shape with the contending pair written last, so neither the
+         first nor the last declaration of the pair decides it alone. *)
+      ( "a contending declaration behind one that shares no slot",
+        ".a{color:red}.a{margin:1px;color:blue}",
+        true );
     ]
 
 (* One property with two values on both sides, so the declarations always


### PR DESCRIPTION
`Block.rules_conflict` asks whether *some* declaration pair contends. All twelve cases pinning it wrote exactly one declaration a side — precisely where "some pair contends" and "every pair contends" are the same question — so a mutation to `List.for_all` survived the whole suite.

It is not harmless. `merge_distant_media` acts on a `false` answer by hoisting the later block over the rule:

    in     @media(1px){.a{color:red}} .a{color:blue;margin:1px} @media(1px){.a{color:green}}
    real   -> .a computes green
    mutant -> .a computes blue

`--diff=canonical` reports that as a real change. Reproduced on `@media` and `@container`.

Worth knowing for anyone testing this module: the 504-fixture SatCSS corpus cannot reach it. Every fixture is a `-stripmq` variant, so across all of them there are zero `@media`, `@supports`, `@layer`, `@container`, `@starting-style` and `@import` — and `block.ml` is entirely at-rule block merging. A "0 of 504 differ" result there means nothing.

Test-only, so no changelog entry.