### PR TITLE
diff: fold the vendor twins minification itself moves

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -696,16 +696,11 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Canonical diff
 
-- `--diff=canonical` reads a prefixed declaration the WHATWG Compatibility
-  Standard section 3.4.1 names a legacy name alias as the same property as its
-  unprefixed twin, so an identical pair normalizes to the twin alone:
-  `a{-webkit-transform:none;transform:none}` and `a{transform:none}` compare
-  equal, and so do the other 57 properties on that list. Only
-  `-webkit-text-decoration-color` did, which is not on the list at all. A prefix
-  the section does not name stays a property of its own, `-moz-` spellings and
-  `-webkit-user-select` among them, as does a differing value or importance. A
-  check comparing a sheet against a minified form that dropped or synthesised
-  one of those aliases changes answer (#1200)
+- `--diff=canonical` normalizes an identical prefixed/unprefixed declaration
+  pair to the unprefixed twin alone, so a sheet compares equal to its own
+  minified output whatever targets produced it. Only
+  `-webkit-text-decoration-color` did before. A prefix with no twin beside it,
+  and a twin with a different value or importance, stay distinct (#1200, #1208)
 - A browser-backed sweep checks the guarantee itself: every pair
   `--diff=canonical` reports identical is rendered in headless Chrome and every
   computed-style difference is a conflation

--- a/README.md
+++ b/README.md
@@ -176,16 +176,21 @@ gate that treated 2 as 0 would pass while the files differ. The report and the
   Cascade-significant order is kept distinct (two writes of the same
   property, a shorthand and its longhand, a load-bearing vendor-prefixed
   fallback, `@layer` blocks). A prefixed
-  declaration the [WHATWG Compatibility Standard](https://compat.spec.whatwg.org/#css-legacy-name-aliases)
-  section 3.4.1 names a legacy name alias is the same property as its
-  unprefixed twin, so an identical pair of them normalizes to the twin alone,
-  `-webkit-transform`/`transform` and the rest of that list. A prefix the
-  section does not name is a property of its own, `-moz-` spellings and
-  `-webkit-user-select` among them, and stays distinct; so does a differing
-  value or importance, or a prefix with no unprefixed twin.
-  `-webkit-text-decoration-color` is not on the list but every engine shipping
-  the prefix aliases it, and Cascade normalizes it too. Equivalent
-  shorthand decompositions are still not modelled.
+  declaration standing beside an identical unprefixed twin normalizes to the
+  twin alone, for either of two reasons. The
+  [WHATWG Compatibility Standard](https://compat.spec.whatwg.org/#css-legacy-name-aliases)
+  section 3.4.1 names 58 properties that must be supported as legacy name
+  aliases, and CSS Cascade 5 section 2.3 makes such an alias the same property
+  under a second name, so `-webkit-transform`/`transform` and the rest of that
+  list fold on the specifications alone, under `--enforce-spec` too. Every
+  other prefixed twin folds because minification itself moves it: `--minify`
+  writes `-webkit-backdrop-filter` beside `backdrop-filter` for a target that
+  needs it and drops `-moz-box-sizing` beside `box-sizing` for one that does
+  not, and which spelling a run emits is a fact about the declared targets
+  rather than about the sheet, so a comparison that has to hold a sheet equal
+  to its own minified output reads the two alike. A differing value or
+  importance, and a prefix with no unprefixed twin beside it, stay distinct.
+  Equivalent shorthand decompositions are still not modelled.
   Numeric arithmetic follows the same precision mode as minification: an exact
   quotient such as `calc(28/14)` compares equal to `2` in either mode. By
   default, `calc(28/18)` compares equal to Cascade's six-significant-figure

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -767,13 +767,34 @@ let rec canonical_missing_component_colors ~lossless (stmts : statement list) :
                (canonical_missing_component_colors ~lossless))
     stmts
 
-(* The normal optimizer drops this typed alias under its maintained-browser
-   policy, but the canonical optimizer runs spec-literally so it does not erase
-   other compatibility content. Apply only the alias equivalence promised by
-   canonical comparison, at every declaration site. *)
+(* [decl] is the prefixed spelling {!Webkit_fallback} synthesises beside
+   [standard], carrying its value and importance. {!Webkit_fallback.is_pair}
+   already asks that question with no targets to consult, and {!kind_of} names
+   which half is the prefixed one, so the family table is read rather than
+   restated. *)
+let synthesised_webkit_twin decl standard =
+  match Webkit_fallback.kind_of standard with
+  | Some kind ->
+      Webkit_fallback.is_prefixed kind decl
+      && Webkit_fallback.is_pair standard decl
+  | None -> false
+
+(* The canonical optimizer runs spec-literally, so it neither adds a prefixed
+   twin nor drops one and would report a sheet's own minified output as a
+   change. Both prefix passes own a table of which spellings alias which, and
+   both gate the rewrite on the declared targets; a projection cannot know the
+   targets a sheet was written or minified for, so it reads the two tables with
+   their gates open and folds the twin into the declaration it mirrors. A
+   prefixed declaration standing alone is the only spelling an engine that needs
+   the prefix reads, and stays. *)
 let canonical_vendor_aliases (stmts : statement list) : statement list =
-  Stylesheet.map_declarations Shorthand.drop_redundant_decoration_color_aliases
-    stmts
+  let drop_twins decls =
+    Shorthand.drop_redundant_vendor_aliases
+      (Common.List.filter_preserve
+         (fun decl -> not (List.exists (synthesised_webkit_twin decl) decls))
+         decls)
+  in
+  Stylesheet.map_declarations drop_twins stmts
 
 (* CSS Properties and Values API 1 sec. 2: registrations for different custom
    property names are order-independent, and for the same name the last one

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -6542,23 +6542,6 @@ let legacy_name_alias_twin vendor twin =
            (Declaration.is_important vendor)
            (Declaration.is_important twin)
 
-(* Canonical comparison follows the aliasing the specs prove on their own,
-   without enabling every target-dependent optimizer rewrite. Sec. 3.4.1 above
-   settles the [-webkit-] list; [-webkit-text-decoration-color] is not on it but
-   every engine that ships the prefix aliases it, and Cascade normalizes it
-   whatever the target. A differing fallback, mismatched importance, or prefix
-   without a standard twin remains observable and is kept. *)
-let drop_redundant_decoration_color_aliases declarations =
-  filter_preserve
-    (fun declaration ->
-      not
-        (List.exists
-           (fun twin ->
-             decoration_color_alias_twin declaration twin
-             || legacy_name_alias_twin declaration twin)
-           declarations))
-    declarations
-
 (* If [name] starts with a CSS vendor prefix ([-webkit-] / [-moz-] / [-ms-] /
    [-o-]) return the unprefixed remainder; otherwise [None]. *)
 let strip_vendor_prefix name =
@@ -6630,6 +6613,26 @@ let unprefixed_is_widely_available twin =
     | key -> key
   in
   not (Hashtbl.mem greenfield_keys key)
+
+(* The same relation {!drop_vendor_aliases} reads, with the Baseline gate open,
+   for canonical comparison. Sec. 3.4.1 above settles the [-webkit-] legacy
+   names on its own; the rest of the table is aliasing Cascade asserts, and
+   whether a run keeps or drops such a twin turns on the declared targets. A
+   projection that has to read a sheet and its own minified output as one sheet
+   cannot ask that question, so it folds every twin the drop could reach. A
+   differing value, mismatched importance, or a prefix with no unprefixed twin
+   beside it is still content and stays. *)
+let drop_redundant_vendor_aliases declarations =
+  filter_preserve
+    (fun declaration ->
+      not
+        (List.exists
+           (fun twin ->
+             vendor_alias_twin declaration twin
+             || text_vendor_alias_twin declaration twin
+             || legacy_name_alias_twin declaration twin)
+           declarations))
+    declarations
 
 (* Drop a vendor-prefixed declaration when its unprefixed sibling appears in the
    same rule with the same value and importance and is widely available. The

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -85,11 +85,15 @@ val declarations_commute :
     a different value. Selectors are not read, so two runs that could never meet
     on one element still count as constrained when their properties clash. *)
 
-val drop_redundant_decoration_color_aliases :
+val drop_redundant_vendor_aliases :
   Declaration.declaration list -> Declaration.declaration list
-(** Drop an identical WebKit [text-decoration-color] compatibility alias when
-    its unprefixed twin is present. Differing values or importance, and a
-    prefixed-only declaration, are kept. *)
+(** Drop every vendor-prefixed compatibility alias whose unprefixed twin stands
+    in the same list with the same value and importance. This is the alias
+    relation the optimizer's own prefix drop reads, with that pass's
+    browser-target gate open: which of the two spellings a run emits is a fact
+    about the declared targets, so a comparison projection has to read them
+    alike. Differing values or importance, and a prefixed declaration with no
+    unprefixed twin beside it, are kept. *)
 
 val is_all_declaration : Declaration.declaration -> bool
 (** Whether a declaration is the [all] shorthand. *)

--- a/test/cli/canonical_vendor_twins.t
+++ b/test/cli/canonical_vendor_twins.t
@@ -1,0 +1,112 @@
+CLI: cascade diff --diff=canonical - a sheet against its own minified form.
+
+--minify synthesises a vendor-prefixed twin where a declared target reads only
+the prefixed spelling, and drops an authored one the unprefixed property has
+superseded. Both rewrites leave a prefixed declaration whose unprefixed twin
+carries the same value and importance, which the canonical projection reads as
+the twin alone. So every sheet below compares equal to its own minified output,
+in either direction and whatever target settled the prefix.
+
+  $ for css in \
+  > 'a{-webkit-transform:none;transform:none}' \
+  > 'a{-webkit-user-select:none;user-select:none}' \
+  > 'a{-webkit-box-shadow:1px 1px red;box-shadow:1px 1px red}' \
+  > 'a{user-select:var(--x,)}' \
+  > 'a{-webkit-transition:all 1s;transition:all 1s}' \
+  > 'a{-webkit-animation-delay:1s;animation-delay:1s}' \
+  > 'a{-webkit-flex-wrap:wrap;flex-wrap:wrap}' \
+  > 'a{-moz-box-sizing:border-box;box-sizing:border-box}' \
+  > 'a{-webkit-line-clamp:2;line-clamp:2}' \
+  > 'a{backdrop-filter:blur(1px)}' \
+  > 'a{mask-size:cover}' \
+  > 'a{mask:url(a.png)}' \
+  > ; do
+  >   printf '%s' "$css" > src.css
+  >   cascade fmt --minify src.css > min.css
+  >   if cascade diff --diff=canonical src.css min.css > /dev/null; then
+  >     echo "same: $css"
+  >   else
+  >     echo "DIFFERS: $css -> $(cat min.css)"
+  >   fi
+  > done
+  same: a{-webkit-transform:none;transform:none}
+  same: a{-webkit-user-select:none;user-select:none}
+  same: a{-webkit-box-shadow:1px 1px red;box-shadow:1px 1px red}
+  same: a{user-select:var(--x,)}
+  same: a{-webkit-transition:all 1s;transition:all 1s}
+  same: a{-webkit-animation-delay:1s;animation-delay:1s}
+  same: a{-webkit-flex-wrap:wrap;flex-wrap:wrap}
+  same: a{-moz-box-sizing:border-box;box-sizing:border-box}
+  same: a{-webkit-line-clamp:2;line-clamp:2}
+  same: a{backdrop-filter:blur(1px)}
+  same: a{mask-size:cover}
+  same: a{mask:url(a.png)}
+
+--enforce-spec keeps every prefix, so the same sheets meet their minified form
+from the other side of the target gate too.
+
+  $ for css in \
+  > 'a{-webkit-transform:none;transform:none}' \
+  > 'a{-webkit-transition:all 1s;transition:all 1s}' \
+  > ; do
+  >   printf '%s' "$css" > src.css
+  >   cascade fmt --minify --enforce-spec src.css > min.css
+  >   if cascade diff --diff=canonical src.css min.css > /dev/null; then
+  >     echo "same: $css"
+  >   else
+  >     echo "DIFFERS: $css -> $(cat min.css)"
+  >   fi
+  > done
+  same: a{-webkit-transform:none;transform:none}
+  same: a{-webkit-transition:all 1s;transition:all 1s}
+
+A prefixed declaration with no twin beside it is the only spelling an engine
+that needs the prefix reads, so it is kept and a differing value still differs.
+
+  $ cat > prefixed-none.css <<CSS
+  > a{-webkit-transform:none}
+  > CSS
+  $ cat > standard-rotate.css <<CSS
+  > a{transform:rotate(1deg)}
+  > CSS
+  $ cascade diff --diff=canonical prefixed-none.css standard-rotate.css > /dev/null
+  [1]
+
+  $ cat > prefixed-rotate.css <<CSS
+  > a{-webkit-transform:rotate(1deg)}
+  > CSS
+  $ cat > standard-none.css <<CSS
+  > a{transform:none}
+  > CSS
+  $ cascade diff --diff=canonical prefixed-rotate.css standard-none.css > /dev/null
+  [1]
+
+  $ cat > red.css <<CSS
+  > a{color:red}
+  > CSS
+  $ cat > blue.css <<CSS
+  > a{color:blue}
+  > CSS
+  $ cascade diff --diff=canonical red.css blue.css > /dev/null
+  [1]
+
+  $ cat > mask-none.css <<CSS
+  > a{-webkit-mask:none}
+  > CSS
+  $ cat > mask-url.css <<CSS
+  > a{mask:url(a.png)}
+  > CSS
+  $ cascade diff --diff=canonical mask-none.css mask-url.css > /dev/null
+  [1]
+
+A twin whose value differs from its unprefixed neighbour is a real fallback and
+stays visible on both sides.
+
+  $ cat > fallback.css <<CSS
+  > a{-webkit-transform:none;transform:rotate(1deg)}
+  > CSS
+  $ cat > standard-only.css <<CSS
+  > a{transform:rotate(1deg)}
+  > CSS
+  $ cascade diff --diff=canonical fallback.css standard-only.css > /dev/null
+  [1]


### PR DESCRIPTION
A sheet and its own minified output compare equal under `--diff=canonical` only where the projection folds the prefixed twin, and three shapes did not: the `-webkit-backdrop-filter` and `-webkit-user-select` pairs `--minify` writes for a target that reads only the prefixed spelling, and the authored `-moz-box-sizing` it drops once `box-sizing` has superseded it. The projection now reads the two prefix passes' own tables with their target gates open, rather than the one family it named itself.

Extends #1200, whose entry this consolidates: that PR settled the pairs the WHATWG legacy-name-alias list proves are one property, and left the target-dependent ones distinct.