### PR TITLE
optimize: drop the custom-value scanner the serialiser already ran

### DIFF
--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -630,51 +630,24 @@ and canonicalize_block ~parent changed (stmts : statement list) : statement list
 (* A custom property is an opaque token stream, so a minifier that treats it as
    text keeps the spacing the author wrote while one that re-serialises a typed
    value drops it: [var(--a, var(--b), var(--c))] against
-   [var(--a,var(--b),var(--c))]. The two are the same value, so the projection
-   normalises the space after a top-level comma. Text inside quotes is left
-   alone. *)
-let normalize_custom_value v =
-  let len = String.length v in
-  let buf = Buffer.create len in
-  let rec go i quote =
-    if i >= len then ()
-    else
-      let c = v.[i] in
-      match quote with
-      | Some q ->
-          Buffer.add_char buf c;
-          go (i + 1) (if c = q then None else quote)
-      | None ->
-          if c = '"' || c = '\'' then begin
-            Buffer.add_char buf c;
-            go (i + 1) (Some c)
-          end
-          else if c = ',' then begin
-            Buffer.add_char buf ',';
-            let rec skip j =
-              if j < len && v.[j] = ' ' then skip (j + 1) else j
-            in
-            go (skip (i + 1)) None
-          end
-          else begin
-            Buffer.add_char buf c;
-            go (i + 1) None
-          end
-  in
-  go 0 None;
-  Buffer.contents buf
+   [var(--a,var(--b),var(--c))]. The two are the same value, and
+   {!Declaration.map_custom_value} settles it by construction: it rebuilds the
+   declaration from the MINIFIED serialisation of its value, so the identity
+   below is a re-serialisation and not a no-op. Rewriting that text is what a
+   caller would reach for and there is nothing left to rewrite.
 
-(* A font name spells the same family quoted or as the bare ident sequence it
-   unquotes to, one word or several (CSS Fonts 4 sec. 2.1.1). A bare generic
-   family in the stream is what proves the custom property holds a font stack;
-   with that proof either form substitutes identically into [font-family], and
-   without it the stream is arbitrary tokens and neither form may move. Emission
-   keeps whichever the author wrote, so the projection folds the quoted form
-   onto the ident sequence - the same normalisation the structural comparator
-   applies through {!Css.declaration_value_for_equivalence}. *)
+   A font name is the other half, and does need a rewrite: it spells the same
+   family quoted or as the bare ident sequence it unquotes to, one word or
+   several (CSS Fonts 4 sec. 2.1.1). A bare generic family in the stream is what
+   proves the custom property holds a font stack; with that proof either form
+   substitutes identically into [font-family], and without it the stream is
+   arbitrary tokens and neither form may move. Emission keeps whichever the
+   author wrote, so the projection folds the quoted form onto the ident sequence
+   - the same normalisation the structural comparator applies through
+   {!Css.declaration_value_for_equivalence}. *)
 let normalize_custom_declaration d =
   Declaration.unquote_custom_font_strings
-    (Declaration.map_custom_value normalize_custom_value d)
+    (Declaration.map_custom_value Fun.id d)
 
 (* The fold reads one declaration, so it holds wherever the declaration sits: a
    [@keyframes] frame and a [@page] box spell a custom property exactly as a

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -93,6 +93,30 @@ let custom_property_font_name_quoting_converges () =
     "a single-word string stays opaque" true
     (canonical {|.a{--x:"foo"}|} <> canonical ".a{--x:foo}")
 
+(* A custom property is an opaque token stream and the AST keeps the spelling
+   the author wrote, so a run of spaces after a comma survives pretty-printing
+   and a comparison meets two spellings of one value wherever two minifiers
+   wrote the inputs. The projection settles that by re-serialising every custom
+   value through its minified form, which is what
+   {!Declaration.map_custom_value} does on the way in. A comma inside a string
+   is text rather than a token separator, so the space beside it is content. *)
+let custom_property_comma_spacing_normalizes () =
+  let projected css =
+    Pp.to_string ~minify:false Stylesheet.pp_stylesheet
+      (Rule_order.canonicalize (statements css))
+  in
+  Alcotest.(check string)
+    "the space after a top-level comma goes"
+    (projected ":root{--a:var(--b),var(--c)}")
+    (projected ":root{--a:var(--b), var(--c)}");
+  Alcotest.(check string)
+    "and so does a run of them"
+    (projected ":root{--a:foo,bar}")
+    (projected ":root{--a:foo,   bar}");
+  Alcotest.(check bool)
+    "a comma inside a string is text, not a separator" true
+    (projected {|:root{--a:"x, y"}|} <> projected {|:root{--a:"x,y"}|})
+
 (* Every block at-rule that holds a statement list, each as the CSS text that
    opens and closes it. [@else] has no standalone form (css-conditional-5 sec. 3
    binds it to the [@when] before it), so its opener carries the antecedent.
@@ -514,6 +538,8 @@ let suite =
         custom_property_layer_and_meta_survive;
       Alcotest.test_case "custom-property font-name quoting converges" `Quick
         custom_property_font_name_quoting_converges;
+      Alcotest.test_case "custom-property comma spacing normalizes" `Quick
+        custom_property_comma_spacing_normalizes;
       Alcotest.test_case
         "custom-property font-name quoting converges under every wrapper" `Quick
         custom_font_quoting_converges_under_every_wrapper;


### PR DESCRIPTION
The canonical projection scanned every custom-property value for a space after a top-level comma. `Declaration.map_custom_value` hands its callback the minified serialisation, which never has one, so the scanner could not fire and its comment pointed a reader at the wrong mechanism: what settles the spacing is the re-serialisation `map_custom_value` performs on the way in.

The test commit pins that re-serialisation first, since the identity that replaces the scanner looks like a no-op and is not one.