### PR TITLE
test: pin the parens a not condition takes beside and

### DIFF
--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -25,6 +25,18 @@ let test_string_output () =
             property "contain-intrinsic-size" "1px" ),
         "(not (-webkit-appearance: -apple-pay-button)) or \
          (contain-intrinsic-size: 1px)" );
+      (* CSS Conditional 3 sec. 6 makes every operand of [and] and [or] a
+         [<supports-in-parens>], and a [not] condition is not one, so it takes
+         parentheses of its own on either side of either operator. The [or] row
+         above and this [and] row are printed by two different arms. *)
+      ( And
+          ( Not (property "display" "grid"),
+            property "contain-intrinsic-size" "1px" ),
+        "(not (display: grid)) and (contain-intrinsic-size: 1px)" );
+      ( And
+          ( property "contain-intrinsic-size" "1px",
+            Not (property "display" "grid") ),
+        "(contain-intrinsic-size: 1px) and (not (display: grid))" );
     ]
   in
   List.iter


### PR DESCRIPTION
The printed-form vectors covered a `not` operand of `or` but not of `and`, and the printer reaches the two through different arms. Dropping the parenthesising flag on the `and` arm leaves the suite green while the printer emits a condition no parser accepts back.