### PR TITLE
test: pin the fraction a resolution query keeps

### DIFF
--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -508,6 +508,24 @@ let spec_media_unitless_zero_length () =
   check_recovers "non-zero number is not a length" "(min-width: 1)";
   check_recovers "non-zero number in a range" "(width >= 1)"
 
+(* Media Queries 5 sec. 4.5 gives [resolution] a [<resolution>] value, which
+   css-values-4 sec. 6.3 spells [<number> <resolution-unit>]. So the number is
+   not an integer, and the printer has to answer both ways round: an integral
+   value drops the fraction it was written with, a fractional one keeps it. The
+   whole file's other numbers are integers, which left the fractional half of
+   that decision to no case. *)
+let resolution_keeps_its_fraction () =
+  let printed input = to_string (of_string input) in
+  Alcotest.(check string)
+    "a fractional resolution keeps its digits" "(min-resolution: 1.5dppx)"
+    (printed "(min-resolution: 1.5dppx)");
+  Alcotest.(check string)
+    "an integral one written with a fraction drops it" "(min-resolution: 2dppx)"
+    (printed "(min-resolution: 2.0dppx)");
+  Alcotest.(check string)
+    "and one written without keeps its shape" "(min-resolution: 96dpi)"
+    (printed "(min-resolution: 96dpi)")
+
 (* Media Queries 4 sec. 2.4.4 "Using 'min-' and 'max-' Prefixes On Range
    Features": "Using a 'min-' prefix on a feature name is equivalent to using
    the '>=' operator", and 'max-' is the '<=' operator. Two spellings of one
@@ -643,6 +661,8 @@ let suite =
         spec_media_error_recovery_vectors;
       test_case "spec media unitless zero length" `Quick
         spec_media_unitless_zero_length;
+      test_case "resolution keeps its fraction" `Quick
+        resolution_keeps_its_fraction;
       test_case "kind" `Quick test_kind;
       test_case "kind follows meaning not spelling" `Quick
         kind_follows_meaning_not_spelling;


### PR DESCRIPTION
A mutation sample on `lib/media.ml` found the integer test in `format_float` unguarded: forcing it true leaves the suite green while `(min-resolution: 1.5dppx)` prints back as `(min-resolution: 1dppx)`. Every other number in the media tests is an integer, so the fractional half of that decision had no case.