### PR TITLE
diff: read a container query's function name case-insensitively

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -696,6 +696,11 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Canonical diff
 
+- `--diff=canonical` reads an `@container` `style()` or `scroll-state()`
+  query as one query whatever case its function name is written in, which CSS
+  Values 4 section 9 makes ASCII case-insensitive. `@container STYLE(--x:1)`
+  and `@container style(--x:1)` compared as a difference where cascade's own
+  container-condition equality already read them as one (#1226)
 - `--diff=canonical` reads a prefixed declaration the WHATWG Compatibility
   Standard section 3.4.1 names a legacy name alias as the same property as its
   unprefixed twin, so an identical pair normalizes to the twin alone:

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -955,9 +955,14 @@ let fold_layer_pins (stmts : statement list) : statement list =
 let canonical_media : Media.t -> Media.t = Media.lower_for_minify
 
 (* An [@container] prelude carries a media condition of its own, and the same
-   respellings hold inside it. *)
-let canonical_container : Container.t -> Container.t =
-  Container.lower_for_minify
+   respellings hold inside it, plus one the emitter cannot take: CSS Values 4
+   sec. 9 makes a function name ASCII case-insensitive, so [style(] and [STYLE(]
+   open one query. The AST keeps the case the author wrote and
+   {!Container.lower_for_minify} leaves it alone for that reason, since emission
+   round-trips it. A comparison has the opposite job, and {!Container.normalize}
+   is the spelling its own equivalence class is compared by -- what
+   {!Container.equal} already reads these two as. *)
+let canonical_container : Container.t -> Container.t = Container.normalize
 
 (* [@media] and [@container] are the only statements whose prelude this
    rewrites, so they are the only ones named; the descent below them is

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -182,6 +182,27 @@ let canonical_drops_redundant_decoration_color_alias () =
    meaning, and cascade's own minified output writes the range form, so the fold
    has to hold on the comparison side once the projection stops taking the
    optimizer's target facts. Deleting nothing, it is a respelling and stays. *)
+(* CSS Values 4 sec. 9: a function name is ASCII case-insensitive, so
+   [style(...)] and [STYLE(...)] name one query and so do the two spellings of
+   [scroll-state(...)]. The AST keeps the case the author wrote so emission can
+   round-trip it, which leaves the projection to bring the two together, and
+   cascade's own [Container.equal] already reads them as one. *)
+let canonical_folds_container_function_case () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "a style() query agrees with its uppercase spelling" true
+    (equal "@container STYLE(--x:1){.a{color:red}}"
+       "@container style(--x:1){.a{color:red}}");
+  Alcotest.(check bool)
+    "and a scroll-state() query with its own" true
+    (equal "@container SCROLL-STATE(stuck:top){.a{color:red}}"
+       "@container scroll-state(stuck:top){.a{color:red}}");
+  (* The case is all that folds: a different query is still a different one. *)
+  Alcotest.(check bool)
+    "a different style() property still differs" false
+    (equal "@container STYLE(--x:1){.a{color:red}}"
+       "@container style(--y:1){.a{color:red}}")
+
 let canonical_folds_media_range_spellings () =
   let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
   Alcotest.(check bool)
@@ -2000,6 +2021,8 @@ let suite =
         canonical_keeps_target_gated_content;
       Alcotest.test_case "canonical drops redundant decoration-color alias"
         `Quick canonical_drops_redundant_decoration_color_alias;
+      Alcotest.test_case "canonical folds container function case" `Quick
+        canonical_folds_container_function_case;
       Alcotest.test_case "canonical folds media range spellings" `Quick
         canonical_folds_media_range_spellings;
       Alcotest.test_case "canonical lossless equates exact srgb spellings"


### PR DESCRIPTION
`--diff=canonical` reported `@container STYLE(--x:1)` and `@container style(--x:1)` as a difference, where cascade's own `Container.equal` already reads them as one query and CSS Values 4 section 9 makes a function name ASCII case-insensitive. The projection lowered the prelude through `lower_for_minify`, whose contract deliberately leaves those forms untouched so emission round-trips the authored case; a comparison wants `Container.normalize` instead.

Found while sampling `lib/container.ml` for the mutation campaign.