### PR TITLE
optimize: drop the number-percentage printer argument nothing reads

### DIFF
--- a/lib/prop_filter.ml
+++ b/lib/prop_filter.ml
@@ -149,17 +149,16 @@ let rec pp_filter : filter Pp.t =
   | None -> Pp.string ctx "none"
   | Omitted fn -> Pp.call (filter_function_name fn) Pp.nop ctx ()
   | Blur l -> Pp.call "blur" pp_blur_length ctx l
-  | Brightness n ->
-      Pp.call "brightness" (pp_number_percentage ~always:true) ctx n
-  | Contrast n -> Pp.call "contrast" (pp_number_percentage ~always:true) ctx n
+  | Brightness n -> Pp.call "brightness" pp_number_percentage ctx n
+  | Contrast n -> Pp.call "contrast" pp_number_percentage ctx n
   | Drop_shadow s -> Pp.call "drop-shadow" pp_shadow ctx s
-  | Grayscale n -> Pp.call "grayscale" (pp_number_percentage ~always:true) ctx n
+  | Grayscale n -> Pp.call "grayscale" pp_number_percentage ctx n
   | Hue_rotate (Deg 0.) when Pp.minified ctx -> Pp.string ctx "hue-rotate()"
   | Hue_rotate a -> Pp.call "hue-rotate" pp_angle ctx a
-  | Invert n -> Pp.call "invert" (pp_number_percentage ~always:true) ctx n
-  | Opacity n -> Pp.call "opacity" (pp_number_percentage ~always:true) ctx n
-  | Saturate n -> Pp.call "saturate" (pp_number_percentage ~always:true) ctx n
-  | Sepia n -> Pp.call "sepia" (pp_number_percentage ~always:true) ctx n
+  | Invert n -> Pp.call "invert" pp_number_percentage ctx n
+  | Opacity n -> Pp.call "opacity" pp_number_percentage ctx n
+  | Saturate n -> Pp.call "saturate" pp_number_percentage ctx n
+  | Sepia n -> Pp.call "sepia" pp_number_percentage ctx n
   | Url url -> Pp.url ctx url
   | List filters ->
       let sep = if Pp.minified ctx then Pp.nop else Pp.space in

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4413,15 +4413,14 @@ let rec pp_length_percentage ?(always = false) : length_percentage Pp.t =
          else Parser.string_of_components tokens)
 
 (* Pure serialiser: the [Pct] <-> [Num] shortest-spelling choice ([Pct 0. -> 0]
-   included) is a node-changing fold in [normalize_number_percentage], not here.
-   [~always] is kept for caller signature parity but has no effect on top-level
-   emission. *)
-let rec pp_number_percentage ?(always = false) : number_percentage Pp.t =
+   included) is a node-changing fold in [normalize_number_percentage], not
+   here. *)
+let rec pp_number_percentage : number_percentage Pp.t =
  fun ctx -> function
   | Num f -> Pp.float ctx f
   | Pct f -> Pp.pct ctx f
-  | Var v -> pp_var (pp_number_percentage ~always) ctx v
-  | Calc c -> pp_calc (pp_number_percentage ~always) ctx c
+  | Var v -> pp_var pp_number_percentage ctx v
+  | Calc c -> pp_calc pp_number_percentage ctx c
 
 (* AST-level [<number-percentage>] canonicalisation: CSS Transforms 2 secs. 5 and
    12.1-12.2 and Filter Effects 1 sec. 6.1 define typed positions where [%] and

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -361,9 +361,10 @@ val normalize_color :
     relative-colour origin keep their [none]. Like [exact_srgb] it is for the
     canonical diff projection, and emission never sets it. *)
 
-val pp_number_percentage : ?always:bool -> number_percentage Pp.t
-(** [pp_number_percentage ?always] pretty-prints {!number_percentage} values.
-    When [always] is true, always includes units even for 0. *)
+val pp_number_percentage : number_percentage Pp.t
+(** [pp_number_percentage] pretty-prints {!number_percentage} values. A number
+    carries no unit and a percentage always carries its sign, so unlike
+    {!pp_length} there is nothing here for a zero to elide. *)
 
 val pp_calc :
   ?unwrap_num:bool ->


### PR DESCRIPTION
`pp_number_percentage`'s `~always` flag is documented as "always includes units even for 0" and no arm consults it: the leaf arms print outright and the recursive arms only pass it down to themselves. The doc was copied from `pp_length`, where a zero length really can elide its unit. `prop_filter.ml` was the only caller passing it, at all seven filter functions, and a row of surviving mutants there is what pointed at it.