### PR TITLE
readme: state what minify costs from the measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,11 +346,13 @@ cascade diff --diff=canonical origin/main:src/style.css src/style.css
 The exit code is 0 when the inputs are identical under the chosen mode and 1
 when they differ. It is 2 when the comparison found no difference but cascade
 could not read part of one file. Cascade therefore slots into any tool that
-branches on exit codes (`git` hooks, `make`, GitHub Actions, ...). The
-`--minify` pipeline is fast enough that a 200 KB stylesheet costs well under
-100 ms on the SatCSS corpus; `--objective=raw` trades roughly an order of
-magnitude of wall clock for the last few percent of uncompressed bytes and fits
-a release build rather than a watcher loop.
+branches on exit codes (`git` hooks, `make`, GitHub Actions, ...). On
+the SatCSS corpus `--minify` costs about 2.2 ms per KB of input, so a 200 KB
+stylesheet takes a few hundred milliseconds and the corpus's slowest 300 KB
+sheet takes about a second. Bytes are only a proxy: the cost is driven by how
+many rules can be factored together, so two sheets of a size can differ several
+fold. `--objective=raw` drives the factoring fixpoint to convergence and costs
+a further multiple, which fits a release build rather than a watcher loop.
 
 ## `--minify` policy
 


### PR DESCRIPTION
The "well under 100 ms for 200 KB" claim came from an `8s versus 0.10s` comparison that TODO.md records as never having been like-for-like. Two derivations from the corpus agree on a few hundred milliseconds instead: 79.69s of CPU over 37 MB is 2.2 ms per KB (200 KB ≈ 0.44s), and the slowest fixture is 311 KB at 1.06s (≈ 0.68s scaled).