### PR TITLE
values: minify a var() fallback as the typed slot that reads it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -696,6 +696,9 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Canonical diff
 
+- A `var()` fallback the slot could not type compares and minifies as the typed
+  value it substitutes into, so `text-shadow:1px 1px var(--c, rgb(0 0 0 / .1))`
+  and its `rgb(0 0 0/.1)` twin are equal under `--diff=canonical` (#1231)
 - `--diff=canonical` reads an `@container` `style()` or `scroll-state()`
   query as one query whatever case its function name is written in, which CSS
   Values 4 section 9 makes ASCII case-insensitive. `@container STYLE(--x:1)`

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -871,8 +871,12 @@ let custom_min_word_boundary ~minify p next =
 (* Whitespace in a custom-property value is part of the stream a var()
    substitution receives, so a separator around [*] and [/] is collapsed to one
    space, never deleted: [16 / 9] and [16/9] are distinct streams. Around a
-   math-function [+] or [-] the space is required outright. *)
-let custom_min_needs_separator ~in_math prev next rest =
+   math-function [+] or [-] the space is required outright. The stream is
+   [opaque] when its consumer is unknown, which is what makes that separator
+   content; the fallback of a [var()] in a typed slot is read by the slot's
+   grammar once substituted, where CSS Values 4 (ED) sec. 10.8 makes it
+   optional, so there it goes the way {!to_string_minified} drops it. *)
+let custom_min_needs_separator ~in_math ~opaque prev next rest =
   match prev with
   | None -> false
   | Some p ->
@@ -881,15 +885,15 @@ let custom_min_needs_separator ~in_math prev next rest =
         || Option.is_none (numeric_leading_sign ~minify:false next)
       in
       pair_forms_multichar_token p next
-      || custom_min_is_math_delim p
-      || custom_min_is_math_delim next
+      || opaque
+         && (custom_min_is_math_delim p || custom_min_is_math_delim next)
       || math_sign_boundary ~in_math p next
       || custom_min_bang_boundary prev next rest
       || custom_min_word_boundary ~minify:minify_numeric p next
 
-let custom_min_ws_separator ~in_math buf prev separated rest =
+let custom_min_ws_separator ~in_math ~opaque buf prev separated rest =
   match rest with
-  | next :: _ when custom_min_needs_separator ~in_math prev next rest ->
+  | next :: _ when custom_min_needs_separator ~in_math ~opaque prev next rest ->
       Buffer.add_char buf ' ';
       true
   | _ -> separated
@@ -933,15 +937,15 @@ let add_custom_value_token ~fold_ident ~preserve_numeric_sign buf :
   | Token.Ident s -> Buffer.add_string buf (escape_ident (fold_ident s))
   | other -> add_minified_token_kind ~preserve_numeric_sign buf other
 
-let rec cv_to_buffer_custom_min ~fold_ident ~in_math ~preserve_numeric_sign buf
-    : Component.t -> unit = function
+let rec cv_to_buffer_custom_min ~fold_ident ~in_math ~opaque
+    ~preserve_numeric_sign buf : Component.t -> unit = function
   | Preserved t ->
       add_custom_value_token ~fold_ident ~preserve_numeric_sign buf t.kind
   | Block { node = { opening; value; _ }; _ } ->
       Buffer.add_char buf (opening_char opening);
       cvs_to_buffer_min_custom ~fold_ident
         ~in_math:(block_in_math ~in_math opening)
-        buf value;
+        ~opaque buf value;
       Buffer.add_char buf (closing_char opening)
   | Func { node = { name; arguments; _ }; _ }
     when String.lowercase_ascii name = "url" -> (
@@ -953,25 +957,26 @@ let rec cv_to_buffer_custom_min ~fold_ident ~in_math ~preserve_numeric_sign buf
       | None ->
           Buffer.add_string buf (escape_ident name);
           Buffer.add_char buf '(';
-          cvs_to_buffer_min_custom ~fold_ident ~in_math:false buf arguments;
+          cvs_to_buffer_min_custom ~fold_ident ~in_math:false ~opaque buf
+            arguments;
           Buffer.add_char buf ')')
   | Func { node = { name; arguments; _ }; _ } ->
       Buffer.add_string buf (escape_ident name);
       Buffer.add_char buf '(';
-      cvs_to_buffer_min_custom ~fold_ident ~in_math:(is_math_function name) buf
-        arguments;
+      cvs_to_buffer_min_custom ~fold_ident ~in_math:(is_math_function name)
+        ~opaque buf arguments;
       Buffer.add_char buf ')'
 
 (* Drops optional whitespace between sibling tokens (like [cvs_to_buffer_min])
    but routes children through [cv_to_buffer_custom_min] so nested function and
    block contents use the custom-property minifier recursively. *)
-and cvs_to_buffer_min_custom ~fold_ident ~in_math buf cvs =
+and cvs_to_buffer_min_custom ~fold_ident ~in_math ~opaque buf cvs =
   let rec loop prev separated after_whitespace = function
     | [] -> ()
     | cv :: rest when is_whitespace cv ->
         let rest' = drop_whitespace_components rest in
         let separated' =
-          custom_min_ws_separator ~in_math buf prev separated rest'
+          custom_min_ws_separator ~in_math ~opaque buf prev separated rest'
         in
         loop prev separated' true rest'
     | cv :: rest ->
@@ -980,8 +985,8 @@ and cvs_to_buffer_min_custom ~fold_ident ~in_math buf cvs =
             ~after_whitespace prev cv
         in
         custom_min_item_separator ~preserve_numeric_sign buf prev separated cv;
-        cv_to_buffer_custom_min ~fold_ident ~in_math ~preserve_numeric_sign buf
-          cv;
+        cv_to_buffer_custom_min ~fold_ident ~in_math ~opaque
+          ~preserve_numeric_sign buf cv;
         loop (Some cv) false false rest
   in
   loop None false false cvs
@@ -990,11 +995,12 @@ and cvs_to_buffer_min_custom ~fold_ident ~in_math buf cvs =
    [string_of_components] keeps every optional whitespace token. This minified
    rendering is for canonical output only: collapse optional whitespace in
    blocks and function args while preserving token boundaries. *)
-let to_string_custom_minified ?(fold_ident = fold_value_ident) cvs =
+let to_string_custom_minified ?(fold_ident = fold_value_ident) ?(opaque = true)
+    cvs =
   if cvs <> [] && List.for_all is_whitespace cvs then " "
   else
     let buf = Buffer.create 64 in
-    cvs_to_buffer_min_custom ~fold_ident ~in_math:false buf cvs;
+    cvs_to_buffer_min_custom ~fold_ident ~in_math:false ~opaque buf cvs;
     Buffer.contents buf
 
 (** {1 Rule / declaration consumers (section 5.3)} *)

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -86,13 +86,20 @@ val fold_value_ident : string -> string
     {!to_string_custom_minified}. *)
 
 val to_string_custom_minified :
-  ?fold_ident:(string -> string) -> Component.t list -> string
+  ?fold_ident:(string -> string) -> ?opaque:bool -> Component.t list -> string
 (** Variant of {!string_of_components} for CSS Custom Properties Level 1 token
     streams. Optional whitespace is collapsed using the rules of
     {!to_string_minified} while preserving token boundaries. [fold_ident]
     (default {!fold_value_ident}) maps each ident token to its serialized
     spelling; callers that can recognise a wider set of case-insensitive value
-    keywords pass a stronger fold. *)
+    keywords pass a stronger fold.
+
+    [opaque] (default [true]) says the stream's consumer is unknown, as a custom
+    property's own value is: a whitespace token beside a [*] or [/] is then part
+    of the stream a [var()] substitutes and is kept as one space. The fallback
+    of a [var()] in a typed slot passes [~opaque:false]: the slot's grammar
+    reads the substituted stream, CSS Values 4 (ED) section 10.8 makes that
+    separator optional, and it is dropped as {!to_string_minified} drops it. *)
 
 val escape_ident : string -> string
 (** [escape_ident s] returns [s] with non-ident-continue code points backslash-

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -409,12 +409,20 @@ let pp_var_fallback ctx fallback_name =
   pp_var_open ctx fallback_name;
   Pp.string ctx "))"
 
+(* A [Syntax_fallback] is the [<declaration-value>] a [var()] in a typed slot
+   falls back to, so the slot's grammar reads it once substituted and the
+   whitespace beside a [*] or [/] is spelling, not content: two shadows whose
+   colour fallbacks differ only around the alpha slash paint the same. Only a
+   custom property's own value keeps that separator, and that stream never
+   prints through here. *)
+let string_of_syntax_fallback ctx value =
+  if Pp.minified ctx then
+    Parser.to_string_custom_minified ~fold_ident:fold_custom_value_ident
+      ~opaque:false value
+  else Parser.string_of_components value
+
 let pp_syntax_fallback ctx value =
-  Pp.string ctx
-    (if Pp.minified ctx then
-       Parser.to_string_custom_minified ~fold_ident:fold_custom_value_ident
-         value
-     else Parser.string_of_components value)
+  Pp.string ctx (string_of_syntax_fallback ctx value)
 
 let pp_var_ref ctx name =
   pp_var_open ctx name;
@@ -5002,12 +5010,7 @@ and pp_color_var (ctx : Pp.ctx) (v : color var) =
   match v with
   | { fallback = Syntax_fallback value; default = Option.None; _ }
     when ctx.inline ->
-      let rendered =
-        if Pp.minified ctx then
-          Parser.to_string_custom_minified ~fold_ident:fold_custom_value_ident
-            value
-        else Parser.string_of_components value
-      in
+      let rendered = string_of_syntax_fallback ctx value in
       Pp.string ctx (first_top_level_comma_segment rendered)
   | _ when Pp.minified ctx -> (
       match color_of_var_resolution ctx v with

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -1132,6 +1132,38 @@ let canonical_calc_mul_div_whitespace_equal () =
     "calc(...) whitespace around * and / canonicalizes equal" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
+(* A [var()] fallback the slot's reader could not type is a
+   [<declaration-value>] that slot's grammar reads once substituted, so the
+   whitespace beside the alpha slash of a colour written there is spelling, as
+   it is at a bare colour slot where the reader types it. The shadow readers
+   take the third slot as a length, which is where a colour fallback lands
+   untyped; a bare typed slot holds the same stream. Both compare the way the
+   browser paints them. *)
+let canonical_typed_slot_fallback_slash_whitespace_equal () =
+  let check name expected actual =
+    Alcotest.(check bool)
+      name true
+      (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
+  in
+  check "text-shadow oklab fallback alpha slash whitespace"
+    ".a{text-shadow:12px 12px var(--c, oklab(59.982% -.067 -.124 / .25))}"
+    ".a{text-shadow:12px 12px var(--c, oklab(59.982% -.067 -.124/.25))}";
+  check "box-shadow rgb fallback alpha slash whitespace"
+    ".a{box-shadow:12px 12px var(--c, rgb(1 2 3 / .25))}"
+    ".a{box-shadow:12px 12px var(--c, rgb(1 2 3/.25))}";
+  check "typed colour slot fallback alpha slash whitespace"
+    ".a{color:var(--c, oklab(59.982% -.067 -.124 / .25))}"
+    ".a{color:var(--c, oklab(59.982% -.067 -.124/.25))}";
+  check "bare typed slot untyped fallback slash whitespace"
+    ".a{width:var(--w, rgb(1 2 3 / .5))}" ".a{width:var(--w, rgb(1 2 3/.5))}";
+  (* The separator sec. 10.8 requires around a math [+] or [-] stays a
+     difference: without it the fallback is a different token stream. *)
+  Alcotest.(check bool)
+    "untyped fallback math sign whitespace stays distinct" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a{color:var(--c, calc(1px - 2px))}"
+       ".a{color:var(--c, calc(1px -2px))}")
+
 let canonical_calc_paren_whitespace_equal () =
   let expected = ".x{--v:calc( ( 1 / 2 ) * 100% )}" in
   let actual = ".x{--v:calc((1/2)*100%)}" in
@@ -1906,6 +1938,8 @@ let suite =
         canonical_bare_ratio_whitespace_equal;
       Alcotest.test_case "canonical calc *,/ whitespace" `Quick
         canonical_calc_mul_div_whitespace_equal;
+      Alcotest.test_case "canonical typed slot fallback slash whitespace" `Quick
+        canonical_typed_slot_fallback_slash_whitespace_equal;
       Alcotest.test_case "canonical calc paren whitespace" `Quick
         canonical_calc_paren_whitespace_equal;
       Alcotest.test_case "canonical min comma whitespace" `Quick

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3579,6 +3579,27 @@ let math_sign_whitespace () =
     "--a: cubic-bezier(.4,0,.6,1) infinite";
   check_declaration ~expected:"--t:100%x" ~optimized:"--t:100%x" "--t: 100% x"
 
+(* A [var()] fallback the slot's reader could not type is still read by that
+   slot's grammar once substituted, so the whitespace beside its [/] is
+   spelling, and the printer drops it the way it does in any typed value. A
+   custom property's own value keeps it (above), as its consumer is unknown. The
+   shadow readers take the third slot as a length, so a colour fallback there is
+   the common case; a bare typed slot holds the same stream. *)
+let typed_slot_fallback_whitespace () =
+  check_declaration
+    ~expected:"text-shadow:12px 12px var(--c,oklab(59.982%-.067-.124/.25))"
+    ~optimized:"text-shadow:12px 12px var(--c,oklab(59.982%-.067-.124/.25))"
+    "text-shadow: 12px 12px var(--c, oklab(59.982% -.067 -.124 / .25))";
+  check_declaration ~expected:"box-shadow:12px 12px var(--c,rgb(1 2 3/.25))"
+    ~optimized:"box-shadow:12px 12px var(--c,rgb(1 2 3/.25))"
+    "box-shadow: 12px 12px var(--c, rgb(1 2 3 / .25))";
+  check_declaration ~expected:"width:var(--w,rgb(1 2 3/.5))"
+    ~optimized:"width:var(--w,rgb(1 2 3/.5))" "width: var(--w, rgb(1 2 3 / .5))";
+  (* Sec. 10.8 still requires the space around a math [+] or [-]. *)
+  check_declaration ~expected:"color:var(--c,calc(1px - 2px))"
+    ~optimized:"color:var(--c,calc(1px - 2px))"
+    "color: var(--c, calc(1px - 2px))"
+
 (* CSS Syntax 3 (ED) sec. 4.3.9 "Would start an identifier" and sec. 4.3.10
    "Would start a number" fix what a token absorbs on re-lexing. A [+] is
    neither a name code point nor a continuation of the number in front of it, so
@@ -7679,6 +7700,8 @@ let declaration_tests =
     test_case "custom properties" `Quick custom_properties;
     test_case "opaque numeric tokens" `Quick opaque_numeric_tokens;
     test_case "math sign whitespace" `Quick math_sign_whitespace;
+    test_case "typed slot fallback whitespace" `Quick
+      typed_slot_fallback_whitespace;
     test_case "inserted token boundary" `Quick inserted_token_boundary;
     test_case "custom property values" `Quick custom_property_values;
     test_case "typed custom font family layers print alike" `Quick

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -1520,7 +1520,7 @@ let token_printers =
     ("string_of_components", Parser.string_of_components);
     ("to_string_minified", Parser.to_string_minified);
     ( "to_string_custom_minified",
-      Parser.to_string_custom_minified ~fold_ident:Fun.id );
+      Parser.to_string_custom_minified ~fold_ident:Fun.id ~opaque:true );
   ]
 
 (* [hot] and [cold] serialise to the same byte count, so the output buffer, its
@@ -1641,6 +1641,33 @@ let spec_escaped_ident_survives_minify () =
   check_keeps_dash_digit "custom-property value" {|.x{--a:-\34 }|};
   check_keeps_dash_digit "media feature name"
     {|@media (-\34 :1){.x{color:red}}|}
+
+(* An opaque stream keeps the separator beside a [*] or [/] as one space, since
+   the consumer that will read it is unknown; a stream a typed slot's grammar
+   reads once substituted drops it, as CSS Values 4 (ED) sec. 10.8 makes it
+   optional. The separator sec. 10.8 requires around a math [+] or [-] and the
+   one two word-like tokens need stay whichever way the stream is read. *)
+let custom_minified_opaque_separators () =
+  let minify ~opaque source =
+    Parser.to_string_custom_minified ~opaque (parse_cvs source)
+  in
+  let check source ~opaque ~typed =
+    Alcotest.(check string)
+      (String.concat "" [ source; " opaque" ])
+      opaque
+      (minify ~opaque:true source);
+    Alcotest.(check string)
+      (String.concat "" [ source; " typed" ])
+      typed
+      (minify ~opaque:false source)
+  in
+  check "rgb(1 2 3 / .25)" ~opaque:"rgb(1 2 3 / .25)" ~typed:"rgb(1 2 3/.25)";
+  check "16 / 9" ~opaque:"16 / 9" ~typed:"16/9";
+  check "calc(1 * 2)" ~opaque:"calc(1 * 2)" ~typed:"calc(1*2)";
+  check "calc(1px - 2px)" ~opaque:"calc(1px - 2px)" ~typed:"calc(1px - 2px)";
+  check "a b" ~opaque:"a b" ~typed:"a b";
+  check "var(--a) var(--b)" ~opaque:"var(--a) var(--b)"
+    ~typed:"var(--a) var(--b)"
 
 let suite =
   ( "parser",
@@ -1793,6 +1820,8 @@ let suite =
         spec_escape_ident_leading_digit;
       Alcotest.test_case "spec section 4.2 escaped ident survives minify" `Quick
         spec_escaped_ident_survives_minify;
+      Alcotest.test_case "custom minified opaque separators" `Quick
+        custom_minified_opaque_separators;
     ] )
 
 (* Keep helper constructors referenced. *)


### PR DESCRIPTION
`--diff=canonical` called `text-shadow:12px 12px var(--c, rgb(1 2 3 / .25))` and its `rgb(1 2 3/.25)` twin different: the shadow readers take that slot as a length, so the colour fallback stays an untyped stream, and its minified print kept the space beside the `/` the way a custom property's own value must. A typed slot's fallback is read by that slot's grammar once substituted, so the space is spelling and `--minify` now drops it there, for every property with the shape rather than the shadows alone.