### PR TITLE
props: type the colour fallback that ends a shadow's length run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -696,9 +696,12 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Canonical diff
 
-- A `var()` fallback the slot could not type compares and minifies as the typed
-  value it substitutes into, so `text-shadow:1px 1px var(--c, rgb(0 0 0 / .1))`
-  and its `rgb(0 0 0/.1)` twin are equal under `--diff=canonical` (#1231)
+- A `var()` colour fallback ending a shadow's length run is read as the colour
+  it is, so `text-shadow:1px 1px var(--c, oklab(from red l a b / 25%))` and
+  its `l a b/.25` twin are equal under `--diff=canonical` (#1232)
+- A `var()` fallback no slot can type compares and minifies as the typed value
+  it substitutes into, so `width:var(--w, rgb(0 0 0 / .1))` and its
+  `rgb(0 0 0/.1)` twin are equal under `--diff=canonical` (#1231)
 - `--diff=canonical` reads an `@container` `style()` or `scroll-state()`
   query as one query whatever case its function name is written in, which CSS
   Values 4 section 9 makes ASCII case-insensitive. `@container STYLE(--x:1)`

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -90,10 +90,12 @@ module Shadow = struct
     let _ : bool = try_inset () in
     let _ : bool = try_color () in
     let _ : bool = try_inset () in
-    let lengths = List.rev !lengths_rev in
+    let lengths, color =
+      take_trailing_color_var (List.rev !lengths_rev) !color
+    in
     match read_lengths lengths with
     | Some (h_offset, v_offset, blur, spread) ->
-        let body = { h_offset; v_offset; blur; spread; color = !color } in
+        let body = { h_offset; v_offset; blur; spread; color } in
         (if !inset then Inset (Body body) else Shadow body : shadow)
     | None -> err_invalid_value t "shadow" "at least two lengths are required"
 end

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -232,6 +232,52 @@ let map_var_preserve f (v : 'a var) : 'a var =
   if fallback == v.fallback && default == v.default then v
   else { v with fallback; default }
 
+(* The colour a [var()] fallback holds when the whole fallback reads as one. *)
+let color_of_syntax_fallback (v : length var) : color option =
+  match v.fallback with
+  | Syntax_fallback components -> (
+      match
+        let t = Cursor.of_components components in
+        let color = read_color t in
+        Cursor.ws t;
+        Cursor.expect_eof t;
+        color
+      with
+      | color -> Some color
+      | exception Cursor.Parse_error _ -> Option.None)
+  | Empty | Empty2 | None | Fallback _ | Var_fallback _ -> Option.None
+
+(* A shadow grammar puts its colour on either side of the length run and never
+   inside it: CSS Backgrounds 3 sec. 6.2 writes [inset? && <length>{2,4} &&
+   <color>?] and CSS Text Decoration 4 sec. 6.2 [<color>? && <length>{2,3}]. A
+   [var()] read positionally into that run is a length until its fallback says
+   otherwise, and a fallback the length reader refused but the colour reader
+   takes whole says so: wherever the custom property is unset the browser
+   substitutes that colour, so the reference is the colour slot's, and typing
+   the fallback is what lets [25%] and [.25] read as one alpha. Only the
+   reference that ends the run moves, once both offsets are read, since a colour
+   cannot stand inside the run. A length's [default] does not apply in colour
+   position. *)
+let take_trailing_color_var (lengths : length list) (color : color option) :
+    length list * color option =
+  match (color, List.rev lengths) with
+  | Option.None, Var v :: (_ :: _ :: _ as before) -> (
+      match color_of_syntax_fallback v with
+      | Some fallback ->
+          let var : color var =
+            {
+              name = v.name;
+              fallback = Fallback fallback;
+              default = Option.None;
+              layer = v.layer;
+              meta = v.meta;
+              runtime = v.runtime;
+            }
+          in
+          (List.rev before, Some (Var var : color))
+      | Option.None -> (lengths, color))
+  | _ -> (lengths, color)
+
 (* Drop a shorthand component that equals its longhand initial: a shorthand
    resets every component it leaves out to that initial, so the two spellings
    name one value. *)

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -2336,12 +2336,13 @@ let rec read_text_shadow t : text_shadow =
       try_color ();
       let lengths = read_shadow_lengths t in
       try_color ();
+      let lengths, color = take_trailing_color_var lengths !color in
       match lengths with
       | h :: v :: rest ->
           let blur =
             match rest with b :: _ -> Option.Some b | _ -> Option.None
           in
-          (Text_shadow { h_offset = h; v_offset = v; blur; color = !color }
+          (Text_shadow { h_offset = h; v_offset = v; blur; color }
             : text_shadow)
       | _ -> err_invalid_value t "text-shadow" "expected at least two lengths")
     t

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -1164,6 +1164,33 @@ let canonical_typed_slot_fallback_slash_whitespace_equal () =
        ".a{color:var(--c, calc(1px - 2px))}"
        ".a{color:var(--c, calc(1px -2px))}")
 
+(* A [var()] that ends a shadow's length run with a colour for its fallback is
+   the colour slot's reference: the browser substitutes that colour wherever the
+   custom property is unset. Typed, its fallback compares as a colour, so [25%]
+   and [.25] are one alpha there as they are at a bare colour slot. *)
+let canonical_shadow_color_var_fallback_alpha_equal () =
+  let check name expected actual =
+    Alcotest.(check bool)
+      name true
+      (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
+  in
+  check "text-shadow relative oklab fallback alpha spelling"
+    ".a{text-shadow:1px 1px var(--c, oklab(from red l a b / 25%))}"
+    ".a{text-shadow:1px 1px var(--c, oklab(from red l a b/.25))}";
+  check "box-shadow rgb fallback alpha spelling"
+    ".a{box-shadow:1px 1px var(--c, rgb(1 2 3 / 25%))}"
+    ".a{box-shadow:1px 1px var(--c, rgb(1 2 3/.25))}";
+  check "box-shadow blur then fallback alpha spelling"
+    ".a{box-shadow:1px 1px 2px var(--c, rgb(1 2 3 / 25%)) inset}"
+    ".a{box-shadow:inset 1px 1px 2px var(--c, rgb(1 2 3/.25))}";
+  check "drop-shadow fallback alpha spelling"
+    ".a{filter:drop-shadow(1px 1px var(--c, rgb(1 2 3 / 25%)))}"
+    ".a{filter:drop-shadow(1px 1px var(--c, rgb(1 2 3/.25)))}";
+  check "shadow list fallback alpha spelling"
+    ".a{box-shadow:1px 1px var(--c, rgb(1 2 3 / 25%)),2px 2px var(--d, #0004)}"
+    ".a{box-shadow:1px 1px var(--c, rgb(1 2 3/.25)),2px 2px var(--d, \
+     #00000044)}"
+
 let canonical_calc_paren_whitespace_equal () =
   let expected = ".x{--v:calc( ( 1 / 2 ) * 100% )}" in
   let actual = ".x{--v:calc((1/2)*100%)}" in
@@ -1940,6 +1967,8 @@ let suite =
         canonical_calc_mul_div_whitespace_equal;
       Alcotest.test_case "canonical typed slot fallback slash whitespace" `Quick
         canonical_typed_slot_fallback_slash_whitespace_equal;
+      Alcotest.test_case "canonical shadow colour var fallback alpha" `Quick
+        canonical_shadow_color_var_fallback_alpha_equal;
       Alcotest.test_case "canonical calc paren whitespace" `Quick
         canonical_calc_paren_whitespace_equal;
       Alcotest.test_case "canonical min comma whitespace" `Quick

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3582,17 +3582,17 @@ let math_sign_whitespace () =
 (* A [var()] fallback the slot's reader could not type is still read by that
    slot's grammar once substituted, so the whitespace beside its [/] is
    spelling, and the printer drops it the way it does in any typed value. A
-   custom property's own value keeps it (above), as its consumer is unknown. The
-   shadow readers take the third slot as a length, so a colour fallback there is
-   the common case; a bare typed slot holds the same stream. *)
+   custom property's own value keeps it (above), as its consumer is unknown. A
+   shadow's length run holds such a stream where a colour fallback cannot move
+   to the colour slot, as when another length follows the reference. *)
 let typed_slot_fallback_whitespace () =
   check_declaration
-    ~expected:"text-shadow:12px 12px var(--c,oklab(59.982%-.067-.124/.25))"
-    ~optimized:"text-shadow:12px 12px var(--c,oklab(59.982%-.067-.124/.25))"
-    "text-shadow: 12px 12px var(--c, oklab(59.982% -.067 -.124 / .25))";
-  check_declaration ~expected:"box-shadow:12px 12px var(--c,rgb(1 2 3/.25))"
-    ~optimized:"box-shadow:12px 12px var(--c,rgb(1 2 3/.25))"
-    "box-shadow: 12px 12px var(--c, rgb(1 2 3 / .25))";
+    ~expected:"text-shadow:12px 12px var(--c,oklab(59.982%-.067-.124/.25)) 1px"
+    ~optimized:"text-shadow:12px 12px var(--c,oklab(59.982%-.067-.124/.25)) 1px"
+    "text-shadow: 12px 12px var(--c, oklab(59.982% -.067 -.124 / .25)) 1px";
+  check_declaration ~expected:"box-shadow:12px 12px var(--c,rgb(1 2 3/.25)) 1px"
+    ~optimized:"box-shadow:12px 12px var(--c,rgb(1 2 3/.25)) 1px"
+    "box-shadow: 12px 12px var(--c, rgb(1 2 3 / .25)) 1px";
   check_declaration ~expected:"width:var(--w,rgb(1 2 3/.5))"
     ~optimized:"width:var(--w,rgb(1 2 3/.5))" "width: var(--w, rgb(1 2 3 / .5))";
   (* Sec. 10.8 still requires the space around a math [+] or [-]. *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3965,7 +3965,23 @@ let test_text_shadow () =
   check_text_shadow "red 2px 2px 4px" ~expected:"2px 2px 4px red";
   check_text_shadow "-2px -2px";
   check_text_shadow "0 0 10px";
-  neg_cursor read_text_shadow "invalid-shadow"
+  neg_cursor read_text_shadow "invalid-shadow";
+  (* CSS Text Decoration 4 sec. 6.2 puts the colour on either side of the length
+     run, so a [var()] ending the run with a colour for its fallback is the
+     colour slot's reference, typed. *)
+  (match
+     (read_text_shadow (Cursor.of_string "2px 2px var(--c, rgb(1 2 3 / 25%))")
+       : text_shadow)
+   with
+  | Text_shadow
+      {
+        blur = None;
+        color = Some (Values.Var { fallback = Values.Fallback _; _ });
+        _;
+      } ->
+      ()
+  | _ -> Alcotest.fail "a colour fallback ends the run as the colour");
+  check_text_shadow "2px 2px var(--c, #0004)" ~expected:"2px 2px var(--c,#0004)"
 
 let test_filter_function () =
   List.iter
@@ -4103,7 +4119,54 @@ let test_shadow () =
   in
   Alcotest.(check string)
     "an authored zero blur before a var colour survives optimization"
-    ".k{box-shadow:0 3px 0 var(--c)}" optimized
+    ".k{box-shadow:0 3px 0 var(--c)}" optimized;
+  (* CSS Backgrounds 3 sec. 6.2 puts the colour on either side of the length
+     run, so a [var()] read into that run is a length until its fallback says
+     otherwise. A fallback the colour reader takes whole says so: the reference
+     ends the run and takes the colour slot, typed, where a length fallback, a
+     bare reference or a reference another length follows all stay lengths. *)
+  let typed_color_var name value =
+    match (read_shadow (Cursor.of_string value) : shadow) with
+    | Shadow
+        {
+          blur = None;
+          spread = None;
+          color =
+            Some (Values.Var { name = "c"; fallback = Values.Fallback _; _ });
+          _;
+        } ->
+        ()
+    | _ -> Alcotest.failf "%s: %s does not end in a typed colour var" name value
+  in
+  typed_color_var "hex fallback" "2px 2px var(--c, #0004)";
+  typed_color_var "alpha fallback" "2px 2px var(--c, rgb(1 2 3 / 25%))";
+  typed_color_var "relative fallback"
+    "2px 2px var(--c, oklab(from red l a b / 25%))";
+  (match
+     (read_shadow (Cursor.of_string "inset 2px 2px 4px var(--c, red)") : shadow)
+   with
+  | Inset
+      (Body
+         {
+           blur = Some _;
+           spread = None;
+           color = Some (Values.Var { fallback = Values.Fallback _; _ });
+           _;
+         }) ->
+      ()
+  | _ -> Alcotest.fail "blur then a colour fallback under inset");
+  let length_var name value =
+    match (read_shadow (Cursor.of_string value) : shadow) with
+    | Shadow { color = None; _ } -> ()
+    | _ -> Alcotest.failf "%s: %s took a colour" name value
+  in
+  length_var "length fallback" "2px 2px var(--c, 3px)";
+  length_var "bare reference" "2px 2px var(--c)";
+  length_var "a length follows" "2px 2px var(--c, red) 1px";
+  length_var "one offset before" "2px var(--c, red)";
+  (* The reference prints where it was read, so the value round-trips. *)
+  check_shadow "2px 2px var(--c, #0004)" ~expected:"2px 2px var(--c,#0004)";
+  check_shadow "2px 2px var(--c, red) 1px" ~expected:"2px 2px var(--c,red) 1px"
 
 let test_align_items () =
   check_align_items "stretch";


### PR DESCRIPTION
`--diff=canonical` still called `text-shadow:1px 1px var(--c, oklab(from red l a b / 25%))` and its `l a b/.25` twin different after #1231: the shadow readers take that slot as a length, so the colour fallback stayed a token stream and `25%` and `.25` compared as two alphas where a bare colour slot reads them as one. A `var()` that ends the length run with a fallback the colour reader takes whole is now the colour slot's reference, typed, in `box-shadow`, `text-shadow` and `drop-shadow()` alike; a reference another length follows stays a length.